### PR TITLE
Add I2C peripheral data for all devices

### DIFF
--- a/devices/stm32/stm32f0-30-8.xml
+++ b/devices/stm32/stm32f0-30-8.xml
@@ -41,6 +41,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-30_70-4_6.xml
+++ b/devices/stm32/stm32f0-30_70-4_6.xml
@@ -45,6 +45,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>

--- a/devices/stm32/stm32f0-30_70-b_c.xml
+++ b/devices/stm32/stm32f0-30_70-b_c.xml
@@ -52,6 +52,9 @@
       <instance device-name="30" value="2"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature device-name="30|70" device-pin="c" value="fmp"/>
+      <feature device-name="70" device-pin="r" value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-31_51-4_6.xml
+++ b/devices/stm32/stm32f0-31_51-4_6.xml
@@ -77,6 +77,8 @@
     </driver>
     <driver device-name="51" name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">

--- a/devices/stm32/stm32f0-38_48-6.xml
+++ b/devices/stm32/stm32f0-38_48-6.xml
@@ -54,6 +54,8 @@
     </driver>
     <driver device-name="48" name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">

--- a/devices/stm32/stm32f0-42-4_6.xml
+++ b/devices/stm32/stm32f0-42-4_6.xml
@@ -61,6 +61,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">

--- a/devices/stm32/stm32f0-51_71-8.xml
+++ b/devices/stm32/stm32f0-51_71-8.xml
@@ -71,6 +71,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r|v" value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-58-8.xml
+++ b/devices/stm32/stm32f0-58-8.xml
@@ -57,6 +57,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature device-package="t|y" value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r" value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-71_91-b_c.xml
+++ b/devices/stm32/stm32f0-71_91-b_c.xml
@@ -86,6 +86,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-72-8_b.xml
+++ b/devices/stm32/stm32f0-72-8_b.xml
@@ -73,6 +73,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f0-78_98-b_c.xml
+++ b/devices/stm32/stm32f0-78_98-b_c.xml
@@ -84,6 +84,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f3-01.xml
+++ b/devices/stm32/stm32f3-01.xml
@@ -78,6 +78,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32f3-02-6_8.xml
+++ b/devices/stm32/stm32f3-02-6_8.xml
@@ -87,6 +87,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32f3-02-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-02-b_c_d_e.xml
@@ -122,6 +122,8 @@
     </driver>
     <driver device-pin="v|z" device-size="d|e" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance device-size="d|e" value="3"/>

--- a/devices/stm32/stm32f3-03-6_8.xml
+++ b/devices/stm32/stm32f3-03-6_8.xml
@@ -86,6 +86,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>

--- a/devices/stm32/stm32f3-03-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-03-b_c_d_e.xml
@@ -146,6 +146,8 @@
     <driver device-pin="v" device-size="d|e" device-package="h|t" name="fmc" type="stm32-v1.0"/>
     <driver device-pin="z" device-size="d|e" device-package="t" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance device-size="d|e" value="3"/>

--- a/devices/stm32/stm32f3-18_28.xml
+++ b/devices/stm32/stm32f3-18_28.xml
@@ -93,6 +93,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-name="18" value="2"/>
       <instance device-name="18" value="3"/>

--- a/devices/stm32/stm32f3-34.xml
+++ b/devices/stm32/stm32f3-34.xml
@@ -100,6 +100,8 @@
       <instance value="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>

--- a/devices/stm32/stm32f3-58_98.xml
+++ b/devices/stm32/stm32f3-58_98.xml
@@ -125,6 +125,8 @@
     </driver>
     <driver device-name="98" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance device-name="98" value="3"/>

--- a/devices/stm32/stm32f3-73_78.xml
+++ b/devices/stm32/stm32f3-73_78.xml
@@ -117,6 +117,8 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32f7-22_23_32_33.xml
+++ b/devices/stm32/stm32f7-22_23_32_33.xml
@@ -151,6 +151,8 @@
     </driver>
     <driver device-pin="i|v|z" name="fmc" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32f7-30_50.xml
+++ b/devices/stm32/stm32f7-30_50.xml
@@ -151,6 +151,8 @@
     <driver device-name="50" name="hash" type="stm32-v2.0"/>
     <driver device-name="50" name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32f7-45_46_56.xml
+++ b/devices/stm32/stm32f7-45_46_56.xml
@@ -174,6 +174,8 @@
     <driver device-name="56" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
+++ b/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
@@ -206,6 +206,8 @@
     <driver device-name="77|78|79" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32h7-43_53.xml
+++ b/devices/stm32/stm32h7-43_53.xml
@@ -212,7 +212,9 @@
     <driver device-name="53" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32h7-50.xml
+++ b/devices/stm32/stm32h7-50.xml
@@ -193,7 +193,9 @@
     <driver name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l0-11_21.xml
+++ b/devices/stm32/stm32l0-11_21.xml
@@ -63,7 +63,9 @@
     <driver name="dma" type="stm32-extended">
       <instance value="1"/>
     </driver>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>

--- a/devices/stm32/stm32l0-31_41.xml
+++ b/devices/stm32/stm32l0-31_41.xml
@@ -64,7 +64,9 @@
     <driver name="dma" type="stm32-extended">
       <instance value="1"/>
     </driver>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>

--- a/devices/stm32/stm32l0-51_52_53_62_63.xml
+++ b/devices/stm32/stm32l0-51_52_53_62_63.xml
@@ -92,7 +92,9 @@
     <driver name="dma" type="stm32-extended">
       <instance value="1"/>
     </driver>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r|t" value="2"/>
     </driver>

--- a/devices/stm32/stm32l0-71_72_73_81_82_83.xml
+++ b/devices/stm32/stm32l0-71_72_73_81_82_83.xml
@@ -138,7 +138,9 @@
     <driver name="dma" type="stm32-extended">
       <instance value="1"/>
     </driver>
-    <driver name="i2c" type="stm32">
+    <driver name="i2c" type="stm32-extended">
+      <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r|v" value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-12_22.xml
+++ b/devices/stm32/stm32l4-12_22.xml
@@ -100,8 +100,9 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r" value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-31_33_43.xml
+++ b/devices/stm32/stm32l4-31_33_43.xml
@@ -135,8 +135,9 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance device-pin="c|r|v" value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-32_42.xml
+++ b/devices/stm32/stm32l4-32_42.xml
@@ -92,8 +92,9 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="3"/>
     </driver>

--- a/devices/stm32/stm32l4-51_71.xml
+++ b/devices/stm32/stm32l4-51_71.xml
@@ -146,8 +146,9 @@
       <instance value="2"/>
     </driver>
     <driver device-name="71" device-pin="q|v|z" name="fmc" type="stm32-v1.1"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-52_62.xml
+++ b/devices/stm32/stm32l4-52_62.xml
@@ -121,8 +121,9 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-75_85.xml
+++ b/devices/stm32/stm32l4-75_85.xml
@@ -126,8 +126,9 @@
       <instance value="2"/>
     </driver>
     <driver device-pin="v" name="fmc" type="stm32-v1.1"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-76_86.xml
+++ b/devices/stm32/stm32l4-76_86.xml
@@ -138,8 +138,9 @@
       <instance value="2"/>
     </driver>
     <driver device-pin="q|v|z" name="fmc" type="stm32-v1.1"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-96_a6.xml
+++ b/devices/stm32/stm32l4-96_a6.xml
@@ -150,8 +150,9 @@
     <driver name="dma2d" type="stm32"/>
     <driver device-pin="a|q|v|z" name="fmc" type="stm32-v2.0"/>
     <driver device-name="a6" name="hash" type="stm32-v2.2"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-r5_r7_r9.xml
+++ b/devices/stm32/stm32l4-r5_r7_r9.xml
@@ -150,8 +150,9 @@
     <driver device-name="r9" name="dsihost" type="stm32-v1.0"/>
     <driver name="fmc" type="stm32-v2.1"/>
     <driver device-name="r7|r9" name="gfxmmu" type="stm32-v1.0"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32l4-s5_s7_s9.xml
+++ b/devices/stm32/stm32l4-s5_s7_s9.xml
@@ -142,8 +142,9 @@
     <driver name="fmc" type="stm32-v2.1"/>
     <driver device-name="s7|s9" name="gfxmmu" type="stm32-v1.0"/>
     <driver name="hash" type="stm32-v2.2"/>
-    <driver name="i2c" type="stm32l4">
+    <driver name="i2c" type="stm32-extended">
       <feature value="dnf"/>
+      <feature value="fmp"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/tools/generator/dfg/stm32/stm_peripherals.py
+++ b/tools/generator/dfg/stm32/stm_peripherals.py
@@ -295,34 +295,71 @@ stm_peripherals = \
             }
         ]
     }],
-    'i2c': [{
-        'instances': '*',
-        'groups': [
-            {
-                # This hardware can go up to 1MHz (Fast Mode Plus)
-                'hardware': 'stm32-extended',
-                'features': [],
-                'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
-                'devices': [{'family': ['f0', 'f3', 'f7']}]
-            },{
-                # Some F4 have a digital noise filter
-                'hardware': 'stm32',
-                'features': ['dnf'],
-                'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
-                'devices': [{'family': ['f4'], 'name': ['27', '29', '37', '39', '46', '69', '79']}]
-            },{
-                'hardware': 'stm32l4',
-                'features': ['dnf'],
-                'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
-                'devices': [{'family': ['l4']}]
-            },{
-                'hardware': 'stm32',
-                'features': [],
-                'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
-                'devices': '*'
-            }
-        ]
-    }],
+    'i2c': [
+        {
+            # F1/F2/F4/L1 standard I2C with SMBus support
+            'instances': '*',
+            'groups': [
+                {
+                    # Some F4 have a digital noise filter
+                    'hardware': 'stm32',
+                    'features': ['dnf'],
+                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
+                    'devices': [{'family': ['f4'], 'name': ['27', '29', '37', '39', '46', '69', '79']}]
+                },{
+                    'hardware': 'stm32',
+                    'features': [],
+                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
+                    'devices': [{'family': ['f1', 'f2', 'f4', 'l1']}]
+                }
+            ]
+        },{
+            # F0/F3/F7/L0/L4/L4+/H7 extended I2C instance 2 with optional FM+ and SMBus support
+            'instances': ['2'],
+            'groups': [
+                {
+                    # This hardware supports neither FM+ (1 Mhz) nor SMBus
+                    'hardware': 'stm32-extended',
+                    'features': ['dnf'],
+                    'protocols': ['i2c-v3.0'],
+                    'devices': [
+                        {
+                            'family': ['f0'],
+                            'name': ['30', '31', '38', '51', '58']
+                        },{
+                            'family': ['f0'],
+                            'name': ['70'],
+                            'size': ['b']
+                        }
+                    ]
+                },{
+                    # This hardware supports FM+ (1 Mhz) but not SMBus
+                    'hardware': 'stm32-extended',
+                    'features': ['dnf', 'fmp'],
+                    'protocols': ['i2c-v3.0'],
+                    'devices': [{'family': ['f0', 'l0']}]
+                },{
+                    # This hardware supports FM+ (1 Mhz) and SMBus
+                    'hardware': 'stm32-extended',
+                    'features': ['dnf', 'fmp'],
+                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
+                    'devices': [{'family': ['f3', 'f7', 'l4', 'h7']}]
+                }
+            ]
+        },{
+            # F0/F3/F7/L0/L4/L4+/H7 extended I2C with FM+ and SMBus support
+            'instances': ['1', '3', '4'],
+            'groups': [
+                {
+                    # This hardware supports FM+ (1 Mhz) and SMBus
+                    'hardware': 'stm32-extended',
+                    'features': ['dnf', 'fmp'],
+                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
+                    'devices': [{'family': ['f0', 'f3', 'f7', 'l0', 'l4', 'h7']}]
+                }
+            ]
+        }
+    ],
     'uart': [{
         'instances': '*',
         'groups': [


### PR DESCRIPTION
Adds the necessary data for solving [modm issue #101](https://github.com/modm-io/modm/issues/101).

What should we do about the F4 FMPI2C? The hardware is identical to the `stm32-extended` I2C but it is named FMPI2Cx. The peripheral is not listed at all in stm_peripherals.py.

The raw data contains instance specific feature tags which can't be modeled in the device files right now (see #7).