### PR TITLE
[dfg] Remove remapped pins from data sets

### DIFF
--- a/devices/stm32/stm32f0-30_70-4_6.xml
+++ b/devices/stm32/stm32f0-30_70-4_6.xml
@@ -152,14 +152,13 @@
         <signal af="2" driver="tim" instance="1" name="ch3"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-size="6" port="a" pin="11">
-        <signal device-name="70" driver="usb" name="dm"/>
+      <gpio device-pin="c|k" port="a" pin="11">
+        <signal device-name="70" device-pin="c" driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
-        <signal device-name="70" device-pin="f" af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-size="6" port="a" pin="12">
-        <signal device-name="70" driver="usb" name="dp"/>
+      <gpio device-pin="c|k" port="a" pin="12">
+        <signal device-name="70" device-pin="c" driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>

--- a/devices/stm32/stm32f0-38_48-6.xml
+++ b/devices/stm32/stm32f0-38_48-6.xml
@@ -196,34 +196,19 @@
         <signal device-name="48" af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-name="38" device-pin="c|k" port="a" pin="11">
-        <signal device-name="48" driver="usb" name="dm"/>
+      <gpio device-pin="c|k|t" port="a" pin="11">
+        <signal device-name="48" device-pin="c|t" driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
-        <signal device-name="48" af="3" driver="tsc" name="g4_io3"/>
-        <signal device-name="48" af="5" driver="i2c" instance="1" name="scl"/>
+        <signal device-name="48" device-pin="c|t" af="3" driver="tsc" name="g4_io3"/>
+        <signal device-name="48" device-pin="c|t" af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-name="48" device-pin="c|g|t" port="a" pin="11">
-        <signal device-name="48" driver="usb" name="dm"/>
-        <signal af="1" driver="usart" instance="1" name="cts"/>
-        <signal af="2" driver="tim" instance="1" name="ch4"/>
-        <signal device-name="48" af="3" driver="tsc" name="g4_io3"/>
-        <signal device-name="48" af="5" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio device-name="38" device-pin="c|k" port="a" pin="12">
-        <signal device-name="48" driver="usb" name="dp"/>
+      <gpio device-pin="c|k|t" port="a" pin="12">
+        <signal device-name="48" device-pin="c|t" driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
-        <signal device-name="48" af="3" driver="tsc" name="g4_io4"/>
-        <signal device-name="48" device-pin="c|t" af="5" driver="i2c" instance="1" name="sda"/>
-      </gpio>
-      <gpio device-name="48" device-pin="c|g|t" port="a" pin="12">
-        <signal device-name="48" driver="usb" name="dp"/>
-        <signal af="1" driver="usart" instance="1" name="de"/>
-        <signal af="1" driver="usart" instance="1" name="rts"/>
-        <signal af="2" driver="tim" instance="1" name="etr"/>
-        <signal device-name="48" af="3" driver="tsc" name="g4_io4"/>
+        <signal device-name="48" device-pin="c|t" af="3" driver="tsc" name="g4_io4"/>
         <signal device-name="48" device-pin="c|t" af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">

--- a/devices/stm32/stm32f0-42-4_6.xml
+++ b/devices/stm32/stm32f0-42-4_6.xml
@@ -189,22 +189,22 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio port="a" pin="11">
+      <gpio device-pin="c|k|t" port="a" pin="11">
         <signal driver="usb" name="dm"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="cts"/>
+        <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="4" driver="can" name="rx"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="12">
+      <gpio device-pin="c|k|t" port="a" pin="12">
         <signal driver="usb" name="dp"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="de"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="rts"/>
+        <signal af="1" driver="usart" instance="1" name="de"/>
+        <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
         <signal af="4" driver="can" name="tx"/>
-        <signal device-pin="c|k|t" af="5" driver="i2c" instance="1" name="sda"/>
+        <signal af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>

--- a/devices/stm32/stm32g0-70.xml
+++ b/devices/stm32/stm32g0-70.xml
@@ -180,21 +180,6 @@
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="5" driver="tim" instance="15" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
-      </gpio>
       <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>

--- a/devices/stm32/stm32g0-71_81.xml
+++ b/devices/stm32/stm32g0-71_81.xml
@@ -268,36 +268,17 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc1"/>
-        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc1"/>
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="5" driver="tim" instance="15" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
       <gpio device-pin="c|k|r" port="a" pin="9">
-        <signal device-package="i" driver="ucpd" instance="1" name="dbcc1"/>
+        <signal driver="ucpd" instance="1" name="dbcc1"/>
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc2"/>
-        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc2"/>
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k|r" port="a" pin="10">
-        <signal device-package="i" driver="ucpd" instance="1" name="dbcc2"/>
+        <signal driver="ucpd" instance="1" name="dbcc2"/>
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -207,6 +207,8 @@ class STMDeviceTree:
                 pin = pin[:3]
             return (port, int(pin[2:]))
         pins = sorted(pins, key=raw_pin_sort)
+        # STM32G0 has pin remaps?!?
+        pins = filter(lambda p: "PINREMAP" not in p.get("Variant", ""), pins)
 
         gpios = []
 


### PR DESCRIPTION
The STM32G0/F0 devices have a pin remap functionality (set via individual bits in SysCfg), which isn't modelled yet in the device files.