### PR TITLE
[dfg] Fix for STM32 devices without CMSIS header

### DIFF
--- a/devices/stm32/stm32f2-05.xml
+++ b/devices/stm32/stm32f2-05.xml
@@ -108,7 +108,7 @@
       <vector position="75" name="OTG_HS_EP1_IN"/>
       <vector position="76" name="OTG_HS_WKUP"/>
       <vector position="77" name="OTG_HS"/>
-      <vector position="80" name="HASH_RNG"/>
+      <vector position="80" name="RNG"/>
     </driver>
     <driver name="adc" type="stm32">
       <instance value="1"/>

--- a/devices/stm32/stm32f2-07_15_17.xml
+++ b/devices/stm32/stm32f2-07_15_17.xml
@@ -120,7 +120,8 @@
       <vector position="77" name="OTG_HS"/>
       <vector device-name="07|17" position="78" name="DCMI"/>
       <vector device-name="15|17" position="79" name="CRYP"/>
-      <vector position="80" name="HASH_RNG"/>
+      <vector device-name="15|17" position="80" name="HASH_RNG"/>
+      <vector device-name="07" position="80" name="RNG"/>
     </driver>
     <driver name="adc" type="stm32">
       <instance value="1"/>

--- a/devices/stm32/stm32g0-70.xml
+++ b/devices/stm32/stm32g0-70.xml
@@ -483,9 +483,6 @@
         <signal af="0" driver="rcc" name="osc_en"/>
         <signal af="2" driver="tim" instance="15" name="ch1n"/>
       </gpio>
-      <gpio port="f" pin="2">
-        <signal af="0" driver="rcc" name="mco"/>
-      </gpio>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g4-31_41.xml
+++ b/devices/stm32/stm32g4-31_41.xml
@@ -33,6 +33,7 @@
     <valid-device>stm32g441cby</valid-device>
     <valid-device>stm32g441kbt</valid-device>
     <valid-device>stm32g441kbu</valid-device>
+    <valid-device>stm32g441mbt</valid-device>
     <valid-device>stm32g441rbi</valid-device>
     <valid-device>stm32g441rbt</valid-device>
     <valid-device>stm32g441vbt</valid-device>

--- a/devices/stm32/stm32g4-71.xml
+++ b/devices/stm32/stm32g4-71.xml
@@ -111,6 +111,7 @@
     <driver name="adc" type="stm32-f3">
       <instance value="1"/>
       <instance value="2"/>
+      <instance value="3"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_g4_rockfish_cube">
       <instance value="1"/>
@@ -452,6 +453,7 @@
       </gpio>
       <gpio port="b" pin="0">
         <signal driver="adc" instance="1" name="in15"/>
+        <signal driver="adc" instance="3" name="in12"/>
         <signal driver="comp" instance="4" name="inp"/>
         <signal driver="opamp" instance="2" name="vinp"/>
         <signal driver="opamp" instance="2" name="vinp_sec"/>
@@ -465,6 +467,7 @@
       </gpio>
       <gpio port="b" pin="1">
         <signal driver="adc" instance="1" name="in12"/>
+        <signal driver="adc" instance="3" name="in1"/>
         <signal driver="comp" instance="1" name="inp"/>
         <signal driver="opamp" instance="3" name="vout"/>
         <signal af="2" driver="tim" instance="3" name="ch4"/>
@@ -612,6 +615,7 @@
         <signal af="9" driver="fdcan" instance="2" name="rx"/>
       </gpio>
       <gpio port="b" pin="13">
+        <signal driver="adc" instance="3" name="in5"/>
         <signal driver="opamp" instance="3" name="vinp"/>
         <signal driver="opamp" instance="3" name="vinp_sec"/>
         <signal af="5" driver="i2s" instance="2" name="ck"/>
@@ -884,35 +888,42 @@
         <signal af="7" driver="usart" instance="3" name="rx"/>
       </gpio>
       <gpio device-pin="m|q|v" port="d" pin="10">
+        <signal driver="adc" instance="3" name="in7"/>
         <signal af="7" driver="usart" instance="3" name="ck"/>
       </gpio>
       <gpio device-pin="m" device-package="y" port="d" pin="11">
+        <signal driver="adc" instance="3" name="in8"/>
         <signal af="1" driver="tim" instance="5" name="etr"/>
         <signal af="4" driver="i2c" instance="4" name="smba"/>
         <signal af="7" driver="usart" instance="3" name="cts"/>
         <signal af="7" driver="usart" instance="3" name="nss"/>
       </gpio>
       <gpio device-pin="q" device-package="t" port="d" pin="11">
+        <signal driver="adc" instance="3" name="in8"/>
         <signal af="1" driver="tim" instance="5" name="etr"/>
         <signal af="4" driver="i2c" instance="4" name="smba"/>
         <signal af="7" driver="usart" instance="3" name="cts"/>
         <signal af="7" driver="usart" instance="3" name="nss"/>
       </gpio>
       <gpio device-pin="v" device-package="h|i|t" port="d" pin="11">
+        <signal driver="adc" instance="3" name="in8"/>
         <signal af="1" driver="tim" instance="5" name="etr"/>
         <signal af="4" driver="i2c" instance="4" name="smba"/>
         <signal af="7" driver="usart" instance="3" name="cts"/>
         <signal af="7" driver="usart" instance="3" name="nss"/>
       </gpio>
       <gpio device-pin="q|v" port="d" pin="12">
+        <signal driver="adc" instance="3" name="in9"/>
         <signal af="2" driver="tim" instance="4" name="ch1"/>
         <signal af="7" driver="usart" instance="3" name="de"/>
         <signal af="7" driver="usart" instance="3" name="rts"/>
       </gpio>
       <gpio device-pin="q|v" port="d" pin="13">
+        <signal driver="adc" instance="3" name="in10"/>
         <signal af="2" driver="tim" instance="4" name="ch2"/>
       </gpio>
       <gpio device-pin="q|v" port="d" pin="14">
+        <signal driver="adc" instance="3" name="in11"/>
         <signal driver="opamp" instance="2" name="vinp"/>
         <signal driver="opamp" instance="2" name="vinp_sec"/>
         <signal af="2" driver="tim" instance="4" name="ch3"/>
@@ -966,34 +977,41 @@
         <signal af="13" driver="sai" instance="1" name="sd_a"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="7">
+        <signal driver="adc" instance="3" name="in4"/>
         <signal driver="comp" instance="4" name="inp"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="13" driver="sai" instance="1" name="sd_b"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="8">
+        <signal driver="adc" instance="3" name="in6"/>
         <signal driver="comp" instance="4" name="inm"/>
         <signal af="1" driver="tim" instance="5" name="ch3"/>
         <signal af="2" driver="tim" instance="1" name="ch1n"/>
         <signal af="13" driver="sai" instance="1" name="sck_b"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="9">
+        <signal driver="adc" instance="3" name="in2"/>
         <signal af="1" driver="tim" instance="5" name="ch4"/>
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="13" driver="sai" instance="1" name="fs_b"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="10">
+        <signal driver="adc" instance="3" name="in14"/>
         <signal af="2" driver="tim" instance="1" name="ch2n"/>
         <signal af="13" driver="sai" instance="1" name="mclk_b"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="11">
+        <signal driver="adc" instance="3" name="in15"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="5" driver="spi" instance="4" name="nss"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="12">
+        <signal driver="adc" instance="3" name="in16"/>
         <signal af="2" driver="tim" instance="1" name="ch3n"/>
         <signal af="5" driver="spi" instance="4" name="sck"/>
       </gpio>
       <gpio device-pin="m|q|v" port="e" pin="13">
+        <signal driver="adc" instance="3" name="in3"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>
         <signal af="5" driver="spi" instance="4" name="miso"/>
       </gpio>

--- a/devices/stm32/stm32l4-12_22.xml
+++ b/devices/stm32/stm32l4-12_22.xml
@@ -306,7 +306,7 @@
         <signal af="5" driver="spi" instance="1" name="nss"/>
         <signal device-pin="c|r" af="7" driver="usart" instance="3" name="de"/>
         <signal device-pin="c|r" af="7" driver="usart" instance="3" name="rts"/>
-        <signal af="9" driver="tsc" name="g3_io1"/>
+        <signal device-pin="r|t" af="9" driver="tsc" name="g3_io1"/>
       </gpio>
       <gpio port="b" pin="0">
         <signal driver="adc" instance="1" name="in15"/>

--- a/devices/stm32/stm32wb-55.xml
+++ b/devices/stm32/stm32wb-55.xml
@@ -141,6 +141,7 @@
     <driver name="sai" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
+    <driver name="sequencer" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
@@ -148,7 +149,7 @@
       <instance value="1"/>
       <instance device-pin="r|v" value="2"/>
     </driver>
-    <driver name="stm32_wpan" type="stm32-v1.0"/>
+    <driver name="stm32_wpan" type="stm32-v1.2"/>
     <driver name="sys" type="stm32">
       <feature value="cfgr2"/>
       <feature value="exti"/>
@@ -163,6 +164,7 @@
       <instance value="16"/>
       <instance value="17"/>
     </driver>
+    <driver name="tiny_lpm" type="stm32-v1.0"/>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
       <feature value="tcbgt"/>

--- a/tools/generator/dfg/stm32/stm.py
+++ b/tools/generator/dfg/stm32/stm.py
@@ -231,7 +231,7 @@ stm32_memory = \
                 'memories': {'flash': 0, 'sram1': 0, 'sram2': 16*1024, 'ccm': 16*1024}
             },
             {
-                'name': ['73', '74', '84'],
+                'name': ['73', '74', '83', '84'],
                 'memories': {'flash': 0, 'sram1': 0, 'sram2': 16*1024, 'ccm': 32*1024}
             }
         ]

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -193,6 +193,9 @@ class STMDeviceTree:
 
         # Information from the CMSIS headers
         stm_header = STMHeader(did)
+        if not stm_header.is_valid:
+            LOGGER.error("CMSIS Header invalid for %s", did.string)
+            return None
         p["stm_header"] = stm_header
         p["interrupts"] = stm_header.get_interrupt_table()
         # Flash latency table

--- a/tools/generator/dfg/stm32/stm_header.py
+++ b/tools/generator/dfg/stm32/stm_header.py
@@ -57,13 +57,15 @@ class STMHeader:
 
     def __init__(self, did):
         self.did = did
-        family = did.family
-        self.family_folder = "stm32{}xx".format(family)
+        self.family_folder = "stm32{}xx".format(self.did.family)
         self.cmsis_folder = STMHeader.HEADER_PATH / self.family_folder / "Include"
         self.family_header_file = "{}.h".format(self.family_folder)
 
         self.family_defines = self._get_family_defines()
         self.define = stm.getDefineForDevice(self.did, self.family_defines)
+        self.is_valid = self.define is not None
+        if not self.is_valid: return;
+
         self.header_file = "{}.h".format(self.define.lower())
         self.device_map = None
 


### PR DESCRIPTION
CubeMX has the STM32G483 in its listing, but the CubeG4 does not have a header file for it yet…