### PR TITLE
STM32G4

### DIFF
--- a/devices/stm32/stm32g4-31_41.xml
+++ b/devices/stm32/stm32g4-31_41.xml
@@ -226,14 +226,12 @@
     </driver>
     <driver name="tracer_emb" type="stm32-v1.0"/>
     <driver device-pin="m|r|v" name="uart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="4"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
       <instance value="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance device-pin="c|m|r|v" value="3"/>

--- a/devices/stm32/stm32g4-71.xml
+++ b/devices/stm32/stm32g4-71.xml
@@ -223,7 +223,6 @@
     </driver>
     <driver name="tracer_emb" type="stm32-v1.0"/>
     <driver device-pin="m|q|r|v" name="uart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="4"/>
       <instance value="5"/>
     </driver>
@@ -231,7 +230,6 @@
       <instance value="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32g4-73_83.xml
+++ b/devices/stm32/stm32g4-73_83.xml
@@ -270,7 +270,6 @@
     </driver>
     <driver name="tracer_emb" type="stm32-v1.0"/>
     <driver device-pin="m|q|r|v" name="uart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="4"/>
       <instance value="5"/>
     </driver>
@@ -278,7 +277,6 @@
       <instance value="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/devices/stm32/stm32g4-74_84.xml
+++ b/devices/stm32/stm32g4-74_84.xml
@@ -281,7 +281,6 @@
     </driver>
     <driver name="tracer_emb" type="stm32-v1.0"/>
     <driver device-pin="m|q|r|v" name="uart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="4"/>
       <instance value="5"/>
     </driver>
@@ -289,7 +288,6 @@
       <instance value="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="tcbgt"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="3"/>

--- a/tools/generator/dfg/stm32/stm_peripherals.py
+++ b/tools/generator/dfg/stm32/stm_peripherals.py
@@ -388,12 +388,12 @@ stm_peripherals = \
                 'hardware': 'stm32-extended',
                 'features': ['tcbgt'],
                 'protocols': ['uart'],
-                'devices': [{'family': ['l4'], 'name': ['r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'g4', 'wb']}]
+                'devices': [{'family': ['l4'], 'name': ['r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'wb']}]
             },{
                 'hardware': 'stm32-extended',
                 'features': [],
                 'protocols': ['uart'],
-                'devices': [{'family': ['f7', 'l4']}]
+                'devices': [{'family': ['f7', 'l4', 'g4']}]
             },{
                 'hardware': 'stm32',
                 'features': ['over8'],
@@ -419,12 +419,12 @@ stm_peripherals = \
                 'hardware': 'stm32-extended',
                 'features': ['tcbgt'],
                 'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['l4'], 'name': ['r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'g4', 'wb']}]
+                'devices': [{'family': ['l4'], 'name': ['r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'wb']}]
             },{
                 'hardware': 'stm32-extended',
                 'features': [],
                 'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['f7', 'l4']}]
+                'devices': [{'family': ['f7', 'l4', 'g4']}]
             },{
                 'hardware': 'stm32',
                 'features': ['over8'],


### PR DESCRIPTION
~STM32G4 u(s)art has no tcbgt~

For the STM32G4 series only USART1/2/3 support `TCBGT`, UART4/5 and LPUART do not support it.
