### PR TITLE
[api] Create a common API for accessing device file data

### DIFF
--- a/devices/avr/at90-32_64_128-can.xml
+++ b/devices/avr/at90-32_64_128-can.xml
@@ -24,19 +24,19 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-1281_2561.xml
+++ b/devices/avr/atmega-1281_2561.xml
@@ -27,21 +27,21 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-1284-n_p.xml
+++ b/devices/avr/atmega-1284-n_p.xml
@@ -20,19 +20,19 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-164_324_644-a_n_p_pa_pv_v.xml
+++ b/devices/avr/atmega-164_324_644-a_n_p_pa_pv_v.xml
@@ -101,18 +101,18 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance device-type="a|p|pa|pv" value="1"/>
+      <instance name="0"/>
+      <instance device-type="a|p|pa|pv" name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-169_329_649.xml
+++ b/devices/avr/atmega-169_329_649.xml
@@ -73,16 +73,16 @@
     <driver name="lcd" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="usart" type="avr">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="usi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/atmega-16_32-u4_u4rc.xml
+++ b/devices/avr/atmega-16_32-u4_u4rc.xml
@@ -21,18 +21,18 @@
     <driver name="pll" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc10">
-      <instance value="4"/>
+      <instance name="4"/>
     </driver>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usb_device" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/atmega-16_32_64-c1_m1.xml
+++ b/devices/avr/atmega-16_32_64-c1_m1.xml
@@ -31,10 +31,10 @@
     <driver device-type="m1" name="psc" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-324-pb.xml
+++ b/devices/avr/atmega-324-pb.xml
@@ -17,28 +17,28 @@
     <driver name="eeprom" type="avr"/>
     <driver name="ptc" type="avr"/>
     <driver name="spi" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-48_88_168_328-a_n_p_pa_pv_v.xml
+++ b/devices/avr/atmega-48_88_168_328-a_n_p_pa_pv_v.xml
@@ -125,17 +125,17 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-48_88_168_328-pb.xml
+++ b/devices/avr/atmega-48_88_168_328-pb.xml
@@ -28,27 +28,27 @@
     <driver name="eeprom" type="avr"/>
     <driver device-name="328" name="ptc" type="avr"/>
     <driver name="spi" type="avr">
-      <instance device-name="328" value="0"/>
-      <instance device-name="328" value="1"/>
+      <instance device-name="328" name="0"/>
+      <instance device-name="328" name="1"/>
     </driver>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance device-name="328" value="3"/>
-      <instance device-name="328" value="4"/>
+      <instance name="1"/>
+      <instance device-name="328" name="3"/>
+      <instance device-name="328" name="4"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr">
-      <instance device-name="328" value="0"/>
-      <instance device-name="328" value="1"/>
+      <instance device-name="328" name="0"/>
+      <instance device-name="328" name="1"/>
     </driver>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance device-name="328" value="1"/>
+      <instance name="0"/>
+      <instance device-name="328" name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-640_1280_2560.xml
+++ b/devices/avr/atmega-640_1280_2560.xml
@@ -33,23 +33,23 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-64_128-a_l_n.xml
+++ b/devices/avr/atmega-64_128-a_l_n.xml
@@ -43,19 +43,19 @@
     <driver name="misc" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/atmega-8_16_32-a_l_n.xml
+++ b/devices/avr/atmega-8_16_32-a_l_n.xml
@@ -61,13 +61,13 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tc" type="tc8_async">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr"/>

--- a/devices/avr/atmega-8_16_32-u2.xml
+++ b/devices/avr/atmega-8_16_32-u2.xml
@@ -22,13 +22,13 @@
     <driver name="pll" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="usart" type="avr">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usb_device" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-102_104.xml
+++ b/devices/avr/attiny-102_104.xml
@@ -17,7 +17,7 @@
     <driver name="adc" type="avr"/>
     <driver name="clock" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="usart" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-13.xml
+++ b/devices/avr/attiny-13.xml
@@ -37,7 +37,7 @@
     <driver name="clock" type="avr"/>
     <driver name="eeprom" type="avr"/>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/attiny-20.xml
+++ b/devices/avr/attiny-20.xml
@@ -14,10 +14,10 @@
     <driver name="clock" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-24_44_84.xml
+++ b/devices/avr/attiny-24_44_84.xml
@@ -27,10 +27,10 @@
     <driver name="clock" type="avr"/>
     <driver name="eeprom" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="usi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-25_45_85.xml
+++ b/devices/avr/attiny-25_45_85.xml
@@ -48,11 +48,11 @@
     <driver name="clock" type="avr"/>
     <driver name="eeprom" type="avr"/>
     <driver device-name="85" name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
-      <instance device-name="25|45" value="1"/>
+      <instance name="0"/>
+      <instance device-name="25|45" name="1"/>
     </driver>
     <driver name="usi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-261_461_861.xml
+++ b/devices/avr/attiny-261_461_861.xml
@@ -42,11 +42,11 @@
     <driver name="clock" type="avr"/>
     <driver name="eeprom" type="avr"/>
     <driver device-name="861" name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
-      <instance device-name="261|461" value="1"/>
+      <instance name="0"/>
+      <instance device-name="261|461" name="1"/>
     </driver>
     <driver name="usi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-40.xml
+++ b/devices/avr/attiny-40.xml
@@ -14,7 +14,7 @@
     <driver name="clock" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-441_841.xml
+++ b/devices/avr/attiny-441_841.xml
@@ -19,17 +19,17 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="tocpm" type="avr"/>
     <driver name="twi" type="avr"/>
     <driver name="usart" type="avr">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/avr/attiny-48_88.xml
+++ b/devices/avr/attiny-48_88.xml
@@ -19,10 +19,10 @@
     <driver name="eeprom" type="avr"/>
     <driver name="spi" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tc" type="tc8">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twi" type="avr"/>
     <driver name="wdt" type="avr"/>

--- a/devices/avr/attiny-4_5_9_10.xml
+++ b/devices/avr/attiny-4_5_9_10.xml
@@ -18,7 +18,7 @@
     <driver device-name="5|10" name="adc" type="avr"/>
     <driver name="clock" type="avr"/>
     <driver name="tc" type="tc16">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="wdt" type="avr"/>
     <driver name="gpio" type="avr">

--- a/devices/nrf/nrf52810.xml
+++ b/devices/nrf/nrf52810.xml
@@ -42,8 +42,8 @@
     <driver name="comp" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="gpiote" type="nrf52"/>
@@ -52,53 +52,53 @@
     <driver name="power" type="nrf52"/>
     <driver name="ppi" type="nrf52"/>
     <driver name="pwm" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="qdec" type="nrf52"/>
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="saadc" type="nrf52"/>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="wdt" type="nrf52"/>

--- a/devices/nrf/nrf52811.xml
+++ b/devices/nrf/nrf52811.xml
@@ -42,8 +42,8 @@
     <driver name="comp" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="gpiote" type="nrf52"/>
@@ -52,56 +52,56 @@
     <driver name="power" type="nrf52"/>
     <driver name="ppi" type="nrf52"/>
     <driver name="pwm" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="qdec" type="nrf52"/>
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="saadc" type="nrf52"/>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="wdt" type="nrf52"/>

--- a/devices/nrf/nrf52820.xml
+++ b/devices/nrf/nrf52820.xml
@@ -41,12 +41,12 @@
     <driver name="comp" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="gpiote" type="nrf52"/>
@@ -57,53 +57,53 @@
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="usbd" type="nrf52"/>

--- a/devices/nrf/nrf52832.xml
+++ b/devices/nrf/nrf52832.xml
@@ -55,12 +55,12 @@
     <driver name="comp" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="fpu" type="nrf52"/>
@@ -74,67 +74,67 @@
     <driver name="power" type="nrf52"/>
     <driver name="ppi" type="nrf52"/>
     <driver name="pwm" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="qdec" type="nrf52"/>
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="saadc" type="nrf52"/>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="wdt" type="nrf52"/>

--- a/devices/nrf/nrf52833.xml
+++ b/devices/nrf/nrf52833.xml
@@ -56,12 +56,12 @@
     <driver name="comp" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="fpu" type="nrf52"/>
@@ -75,70 +75,70 @@
     <driver name="power" type="nrf52"/>
     <driver name="ppi" type="nrf52"/>
     <driver name="pwm" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="qdec" type="nrf52"/>
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="saadc" type="nrf52"/>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="usbd" type="nrf52"/>

--- a/devices/nrf/nrf52840.xml
+++ b/devices/nrf/nrf52840.xml
@@ -61,12 +61,12 @@
     <driver name="cryptocell" type="nrf52"/>
     <driver name="ecb" type="nrf52"/>
     <driver name="egu" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ficr" type="nrf52"/>
     <driver name="fpu" type="nrf52"/>
@@ -80,71 +80,71 @@
     <driver name="power" type="nrf52"/>
     <driver name="ppi" type="nrf52"/>
     <driver name="pwm" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="qdec" type="nrf52"/>
     <driver name="qspi" type="nrf52"/>
     <driver name="radio" type="nrf52"/>
     <driver name="rng" type="nrf52"/>
     <driver name="rtc" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="saadc" type="nrf52"/>
     <driver name="spi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="spis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="swi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="temp" type="nrf52"/>
     <driver name="timer" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="twi" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twim" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="twis" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uart" type="nrf52">
-      <instance value="0"/>
+      <instance name="0"/>
     </driver>
     <driver name="uarte" type="nrf52">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="uicr" type="nrf52"/>
     <driver name="usbd" type="nrf52"/>

--- a/devices/sam/samd21.xml
+++ b/devices/sam/samd21.xml
@@ -218,8 +218,8 @@
       <memory device-flash="18" name="ram" access="rwx" start="0x20000000" size="32768"/>
     </driver>
     <driver name="ac" type="sam">
-      <instance device-variant="l" value=""/>
-      <instance device-variant="l" value="1"/>
+      <instance device-variant="l" name=""/>
+      <instance device-variant="l" name="1"/>
     </driver>
     <driver name="adc" type="sam"/>
     <driver name="dac" type="sam"/>
@@ -232,38 +232,38 @@
     <driver name="nvic" type="sam"/>
     <driver name="nvmctrl" type="sam"/>
     <driver name="pac" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pm" type="sam"/>
     <driver device-variant="a|b|c|d" name="ptc" type="sam"/>
     <driver name="rtc" type="sam"/>
     <driver name="sercom" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="g|j" value="4"/>
-      <instance device-pin="g|j" value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="g|j" name="4"/>
+      <instance device-pin="g|j" name="5"/>
     </driver>
     <driver name="sysctrl" type="sam"/>
     <driver name="tc" type="sam">
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance device-pin="g" device-variant="a" device-package="u" value="6"/>
-      <instance device-pin="g" device-variant="l" device-package="m" value="6"/>
-      <instance device-pin="j" device-variant="a|b|d" device-package="a|c|m" value="6"/>
-      <instance device-pin="g" device-variant="a" device-package="u" value="7"/>
-      <instance device-pin="g" device-variant="l" device-package="m" value="7"/>
-      <instance device-pin="j" device-variant="a|b|d" device-package="a|c|m" value="7"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance device-pin="g" device-variant="a" device-package="u" name="6"/>
+      <instance device-pin="g" device-variant="l" device-package="m" name="6"/>
+      <instance device-pin="j" device-variant="a|b|d" device-package="a|c|m" name="6"/>
+      <instance device-pin="g" device-variant="a" device-package="u" name="7"/>
+      <instance device-pin="g" device-variant="l" device-package="m" name="7"/>
+      <instance device-pin="j" device-variant="a|b|d" device-package="a|c|m" name="7"/>
     </driver>
     <driver name="tcc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-flash="17" device-variant="d|l" value="3"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-flash="17" device-variant="d|l" name="3"/>
     </driver>
     <driver device-variant="a|b|c|d" name="usb" type="sam"/>
     <driver name="wdt" type="sam"/>

--- a/devices/sam/samd51.xml
+++ b/devices/sam/samd51.xml
@@ -189,8 +189,8 @@
     </driver>
     <driver name="ac" type="sam"/>
     <driver name="adc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
+      <instance name="0"/>
+      <instance name="1"/>
     </driver>
     <driver name="aes" type="sam"/>
     <driver name="ccl" type="sam"/>
@@ -225,36 +225,36 @@
     <driver name="rstc" type="sam"/>
     <driver name="rtc" type="sam"/>
     <driver name="sdhc" type="sam">
-      <instance value="0"/>
-      <instance device-pin="n|p" value="1"/>
+      <instance name="0"/>
+      <instance device-pin="n|p" name="1"/>
     </driver>
     <driver name="sercom" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance device-pin="n|p" value="6"/>
-      <instance device-pin="n|p" value="7"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance device-pin="n|p" name="6"/>
+      <instance device-pin="n|p" name="7"/>
     </driver>
     <driver name="supc" type="sam"/>
     <driver name="tc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="j|n|p" value="4"/>
-      <instance device-pin="j|n|p" value="5"/>
-      <instance device-pin="n|p" value="6"/>
-      <instance device-pin="n|p" value="7"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="j|n|p" name="4"/>
+      <instance device-pin="j|n|p" name="5"/>
+      <instance device-pin="n|p" name="6"/>
+      <instance device-pin="n|p" name="7"/>
     </driver>
     <driver name="tcc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="j|n|p" value="3"/>
-      <instance device-pin="j|n|p" value="4"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="j|n|p" name="3"/>
+      <instance device-pin="j|n|p" name="4"/>
     </driver>
     <driver name="tpi" type="sam"/>
     <driver name="trng" type="sam"/>

--- a/devices/sam/saml21.xml
+++ b/devices/sam/saml21.xml
@@ -119,27 +119,27 @@
     <driver name="rstc" type="sam"/>
     <driver name="rtc" type="sam"/>
     <driver name="sercom" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="e|g|j" device-variant="b" value="4"/>
-      <instance device-pin="g|j" device-variant="a" value="4"/>
-      <instance device-pin="e|g|j" device-variant="b" value="5"/>
-      <instance device-pin="g|j" device-variant="a" value="5"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="e|g|j" device-variant="b" name="4"/>
+      <instance device-pin="g|j" device-variant="a" name="4"/>
+      <instance device-pin="e|g|j" device-variant="b" name="5"/>
+      <instance device-pin="g|j" device-variant="a" name="5"/>
     </driver>
     <driver name="supc" type="sam"/>
     <driver name="tc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance device-pin="j" value="2"/>
-      <instance device-pin="j" value="3"/>
-      <instance value="4"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance device-pin="j" name="2"/>
+      <instance device-pin="j" name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="tcc" type="sam">
-      <instance value="0"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="0"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="trng" type="sam"/>
     <driver name="usb" type="sam"/>

--- a/devices/stm32/stm32f0-30.xml
+++ b/devices/stm32/stm32f0-30.xml
@@ -47,10 +47,7 @@
       <vector device-size="c" position="29" name="USART3_6"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -58,54 +55,49 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-size="8|c" value="2"/>
+      <instance name="1"/>
+      <instance device-size="8|c" name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-size="8|c" value="2"/>
+      <instance name="1"/>
+      <instance device-size="8|c" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-size="8|c" name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance device-size="c" value="7"/>
+      <instance name="6"/>
+      <instance device-size="c" name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance device-size="8|c" value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance device-size="8|c" name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance device-size="8|c" value="2"/>
-      <instance device-size="c" value="3"/>
-      <instance device-size="c" value="4"/>
-      <instance device-size="c" value="5"/>
-      <instance device-size="c" value="6"/>
+      <feature device-size="c" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance device-size="8|c" name="2"/>
+      <instance device-size="c" name="3"/>
+      <instance device-size="c" name="4"/>
+      <instance device-size="c" name="5"/>
+      <instance device-size="c" name="6"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver device-size="4|6|8" name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>
@@ -213,8 +205,8 @@
       </channels>
     </driver>
     <driver device-size="c" name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="1">

--- a/devices/stm32/stm32f0-31.xml
+++ b/devices/stm32/stm32f0-31.xml
@@ -48,10 +48,7 @@
       <vector position="27" name="USART1"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -59,46 +56,40 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-38.xml
+++ b/devices/stm32/stm32f0-38.xml
@@ -35,10 +35,7 @@
       <vector position="27" name="USART1"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -46,46 +43,40 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-42.xml
+++ b/devices/stm32/stm32f0-42.xml
@@ -55,13 +55,8 @@
       <vector position="31" name="USB"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="can" type="stm32"/>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -70,50 +65,45 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-48.xml
+++ b/devices/stm32/stm32f0-48.xml
@@ -38,10 +38,7 @@
       <vector position="31" name="USB"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -50,50 +47,45 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-51.xml
+++ b/devices/stm32/stm32f0-51.xml
@@ -70,16 +70,12 @@
     </driver>
     <driver name="adc" type="stm32-f0"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -89,55 +85,49 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" device-size="8" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" device-size="8" name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" device-size="8" value="2"/>
-      <instance device-pin="r" device-size="4|6" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" device-size="8" name="2"/>
+      <instance device-pin="r" device-size="4|6" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance device-size="6|8" value="2"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance device-size="6|8" name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-58.xml
+++ b/devices/stm32/stm32f0-58.xml
@@ -43,16 +43,12 @@
     </driver>
     <driver name="adc" type="stm32-f0"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -62,54 +58,48 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-70.xml
+++ b/devices/stm32/stm32f0-70.xml
@@ -42,10 +42,7 @@
       <vector position="31" name="USB"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -53,53 +50,48 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-size="b" value="2"/>
+      <instance name="1"/>
+      <instance device-size="b" name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-size="b" value="2"/>
+      <instance name="1"/>
+      <instance device-size="b" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-size="b" name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance device-size="b" value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance device-size="b" name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-size="b" value="3"/>
-      <instance device-size="b" value="4"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-size="b" name="3"/>
+      <instance device-size="b" name="4"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-71.xml
+++ b/devices/stm32/stm32f0-71.xml
@@ -57,16 +57,11 @@
     </driver>
     <driver name="adc" type="stm32-f0"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -75,58 +70,53 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-72.xml
+++ b/devices/stm32/stm32f0-72.xml
@@ -63,20 +63,13 @@
       <vector position="31" name="USB"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -85,59 +78,54 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-78.xml
+++ b/devices/stm32/stm32f0-78.xml
@@ -50,16 +50,11 @@
     </driver>
     <driver name="adc" type="stm32-f0"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -68,59 +63,54 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32f0-91.xml
+++ b/devices/stm32/stm32f0-91.xml
@@ -61,20 +61,13 @@
       <vector position="30" name="CEC_CAN"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -83,64 +76,58 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance device-pin="r|v" value="7"/>
-      <instance device-pin="r|v" value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance device-pin="r|v" name="7"/>
+      <instance device-pin="r|v" name="8"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32f0-98.xml
+++ b/devices/stm32/stm32f0-98.xml
@@ -48,20 +48,13 @@
       <vector position="30" name="CEC_CAN"/>
     </driver>
     <driver name="adc" type="stm32-f0"/>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -70,64 +63,58 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance device-pin="r|v" value="7"/>
-      <instance device-pin="r|v" value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance device-pin="r|v" name="7"/>
+      <instance device-pin="r|v" name="8"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32f1-00-4_6.xml
+++ b/devices/stm32/stm32f1-00-4_6.xml
@@ -58,7 +58,7 @@
       <vector position="55" name="TIM7"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -69,40 +69,39 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-00-8_b.xml
+++ b/devices/stm32/stm32f1-00-8_b.xml
@@ -60,7 +60,7 @@
       <vector position="55" name="TIM7"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -71,44 +71,43 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-00-c_d_e.xml
+++ b/devices/stm32/stm32f1-00-c_d_e.xml
@@ -70,7 +70,7 @@
       <vector position="60" name="DMA2_Channel5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -82,53 +82,54 @@
     <driver device-pin="v|z" name="fsmc" type="stm32-v4.0"/>
     <driver name="hdmi_cec" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-01-c_d_e.xml
+++ b/devices/stm32/stm32f1-01-c_d_e.xml
@@ -56,7 +56,7 @@
       <vector position="59" name="DMA2_Channel4_5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -69,44 +69,43 @@
     </driver>
     <driver device-pin="v|z" name="fsmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-01-f_g.xml
+++ b/devices/stm32/stm32f1-01-f_g.xml
@@ -60,7 +60,7 @@
       <vector position="59" name="DMA2_Channel4_5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -73,50 +73,49 @@
     </driver>
     <driver device-pin="v|z" name="fsmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-01_02-4_6.xml
+++ b/devices/stm32/stm32f1-01_02-4_6.xml
@@ -52,7 +52,7 @@
       <vector device-name="02" position="42" name="USBWakeUp"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -63,31 +63,29 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="02" name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-01_02-8_b.xml
+++ b/devices/stm32/stm32f1-01_02-8_b.xml
@@ -62,7 +62,7 @@
       <vector device-name="02" position="42" name="USBWakeUp"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -73,35 +73,33 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r|v" value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r|v" name="3"/>
     </driver>
     <driver device-name="02" name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-03-4_6.xml
+++ b/devices/stm32/stm32f1-03-4_6.xml
@@ -66,12 +66,10 @@
       <vector position="42" name="USBWakeUp"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -81,34 +79,32 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-03-8_b.xml
+++ b/devices/stm32/stm32f1-03-8_b.xml
@@ -77,12 +77,10 @@
       <vector position="42" name="USBWakeUp"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -92,38 +90,36 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r|v" value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r|v" name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-03-c_d_e.xml
+++ b/devices/stm32/stm32f1-03-c_d_e.xml
@@ -91,13 +91,11 @@
       <vector position="59" name="DMA2_Channel4_5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -109,54 +107,53 @@
     </driver>
     <driver device-pin="v|z" name="fsmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-03-f_g.xml
+++ b/devices/stm32/stm32f1-03-f_g.xml
@@ -77,13 +77,11 @@
       <vector position="59" name="DMA2_Channel4_5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -95,60 +93,59 @@
     </driver>
     <driver device-pin="v|z" name="fsmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f1-05_07.xml
+++ b/devices/stm32/stm32f1-05_07.xml
@@ -93,13 +93,12 @@
       <vector position="67" name="OTG_FS"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-14"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32"/>
@@ -112,52 +111,51 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance device-name="05" value="2"/>
+      <instance name="1"/>
+      <instance device-name="05" name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32-f1">
-      <feature value="exti"/>
-      <feature value="remap"/>
-    </driver>
+    <driver name="sys" type="stm32-f1"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f2-05.xml
+++ b/devices/stm32/stm32f2-05.xml
@@ -124,19 +124,16 @@
       <vector position="80" name="RNG"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="16000000"/>
@@ -173,13 +170,13 @@
     </driver>
     <driver device-pin="v|z" name="fsmc" type="stm32-v4.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.1">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -187,51 +184,51 @@
     <driver name="rtc" type="stm32-v1.0"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f2-07_15_17.xml
+++ b/devices/stm32/stm32f2-07_15_17.xml
@@ -135,20 +135,17 @@
       <vector device-name="07" position="80" name="RNG"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver device-name="15|17" name="cryp" type="stm32-v1.0"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver device-name="07|17" name="dcmi" type="stm32"/>
     <driver device-name="07|17" name="eth" type="stm32-v2.0"/>
     <driver name="flash" type="stm32-v1.0">
@@ -188,13 +185,13 @@
     <driver device-pin="i|v|z" name="fsmc" type="stm32-v4.0"/>
     <driver device-name="15|17" name="hash" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.1">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -202,51 +199,51 @@
     <driver name="rtc" type="stm32-v1.0"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f3-01.xml
+++ b/devices/stm32/stm32f3-01.xml
@@ -67,20 +67,15 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-v1.2">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c|r" value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c|r" name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -89,60 +84,53 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-02-6_8.xml
+++ b/devices/stm32/stm32f3-02-6_8.xml
@@ -70,23 +70,16 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.2">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c|r" value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c|r" name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="24000000"/>
@@ -95,61 +88,54 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-02-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-02-b_c_d_e.xml
@@ -99,31 +99,25 @@
       <vector device-size="d|e" position="84" name="SPI4"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver device-size="d|e" name="comp" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance name="6"/>
     </driver>
     <driver device-size="b|c" name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance device-size="d|e" value="1"/>
+      <instance device-size="d|e" name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -134,72 +128,68 @@
     </driver>
     <driver device-pin="v|z" device-size="d|e" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-size="d|e" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-size="d|e" name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="v|z" device-size="d|e" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="v|z" device-size="d|e" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver device-pin="r|v|z" name="uart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature device-size="d|e" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature device-size="d|e" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-03-6_8.xml
+++ b/devices/stm32/stm32f3-03-6_8.xml
@@ -63,25 +63,19 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c|r" value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c|r" name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -91,55 +85,48 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-03-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-03-b_c_d_e.xml
@@ -119,39 +119,33 @@
       <vector device-size="d|e" position="84" name="SPI4"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver device-size="d|e" name="comp" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver device-size="b|c" name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance device-size="d|e" value="1"/>
+      <instance device-size="d|e" name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -163,77 +157,73 @@
     <driver device-pin="v" device-size="d|e" device-package="h|t" name="fmc" type="stm32-v1.0"/>
     <driver device-pin="z" device-size="d|e" device-package="t" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-size="d|e" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-size="d|e" name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="v|z" device-size="d|e" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="v|z" device-size="d|e" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
-      <instance device-pin="v|z" device-size="d|e" value="20"/>
+      <instance name="1"/>
+      <instance name="8"/>
+      <instance device-pin="v|z" device-size="d|e" name="20"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver device-pin="r|v|z" name="uart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature device-size="d|e" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature device-size="d|e" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-18_28.xml
+++ b/devices/stm32/stm32f3-18_28.xml
@@ -65,30 +65,24 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance device-name="28" value="2"/>
+      <instance name="1"/>
+      <instance device-name="28" name="2"/>
     </driver>
-    <driver device-name="28" name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver device-name="28" name="can" type="stm32"/>
     <driver device-name="28" name="comp" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance name="6"/>
     </driver>
     <driver device-name="18" name="comp" type="stm32-v1.2">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c" device-package="t|y" device-temperature="6" value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c" device-package="t|y" device-temperature="6" name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance device-name="28" value="1"/>
-      <instance device-name="28" value="2"/>
+      <instance device-name="28" name="1"/>
+      <instance device-name="28" name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -98,63 +92,56 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-name="18" value="2"/>
-      <instance device-name="18" value="3"/>
+      <instance name="1"/>
+      <instance device-name="18" name="2"/>
+      <instance device-name="18" name="3"/>
     </driver>
     <driver device-name="18" name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance device-name="28" value="1"/>
-      <instance device-name="18" value="2"/>
-      <instance device-name="18" value="3"/>
+      <instance device-name="28" name="1"/>
+      <instance device-name="18" name="2"/>
+      <instance device-name="18" name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance device-name="28" value="7"/>
+      <instance name="6"/>
+      <instance device-name="28" name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance device-name="28" value="3"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance device-name="28" name="3"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c" name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-34.xml
+++ b/devices/stm32/stm32f3-34.xml
@@ -82,25 +82,19 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c|r" value="6"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c|r" name="6"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -110,58 +104,51 @@
       </latency>
     </driver>
     <driver name="hrtim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-58_98.xml
+++ b/devices/stm32/stm32f3-58_98.xml
@@ -85,39 +85,33 @@
       <vector device-name="98" position="84" name="SPI4"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver device-name="98" name="comp" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver device-name="58" name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance device-name="98" value="1"/>
+      <instance device-name="98" name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -128,76 +122,72 @@
     </driver>
     <driver device-name="98" name="fmc" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-name="98" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-name="98" name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="98" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="98" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
-      <instance device-name="98" value="20"/>
+      <instance name="1"/>
+      <instance name="8"/>
+      <instance device-name="98" name="20"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver device-pin="r|v" name="uart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature device-name="98" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature device-name="98" value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f3-73_78.xml
+++ b/devices/stm32/stm32f3-73_78.xml
@@ -100,23 +100,17 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-    </driver>
+    <driver name="can" type="stm32"/>
     <driver name="comp" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -127,73 +121,65 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sdadc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="18"/>
-      <instance value="19"/>
+      <instance name="18"/>
+      <instance name="19"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <feature value="wakeup"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="73" name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc" instance="1"/>

--- a/devices/stm32/stm32f4-01_11.xml
+++ b/devices/stm32/stm32f4-01_11.xml
@@ -123,7 +123,7 @@
       <vector device-name="11" position="85" name="SPI5"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -163,16 +163,16 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance device-name="11" value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="11" value="4"/>
-      <instance device-name="11" value="5"/>
+      <instance device-name="11" name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="11" name="4"/>
+      <instance device-name="11" name="5"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -180,39 +180,38 @@
     <driver device-name="11" device-pin="c" name="sdio" type="stm32"/>
     <driver device-name="01|11" device-pin="r|v" name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="11" device-pin="c|r" value="4"/>
-      <instance device-name="01|11" device-pin="v" value="4"/>
-      <instance device-name="11" value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="11" device-pin="c|r" name="4"/>
+      <instance device-name="01|11" device-pin="v" name="4"/>
+      <instance device-name="11" name="5"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-05_07_15_17.xml
+++ b/devices/stm32/stm32f4-05_07_15_17.xml
@@ -133,20 +133,17 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver device-name="15|17" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver device-name="07|17" name="dcmi" type="stm32"/>
     <driver device-name="07|17" name="eth" type="stm32-v2.0"/>
     <driver name="flash" type="stm32-v1.0">
@@ -191,13 +188,13 @@
     <driver device-pin="i|o|v|z" name="fsmc" type="stm32-v4.0"/>
     <driver device-name="15|17" name="hash" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -205,51 +202,51 @@
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-10.xml
+++ b/devices/stm32/stm32f4-10.xml
@@ -85,12 +85,10 @@
       <vector position="97" name="LPTIM1"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="16000000"/>
@@ -124,53 +122,52 @@
       </latency>
     </driver>
     <driver name="fmpi2c" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v2.4">
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
-      <instance device-pin="c|r" value="5"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
+      <instance device-pin="c|r" name="5"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
-      <instance device-pin="c|r" value="5"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
+      <instance device-pin="c|r" name="5"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="11"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="11"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="6"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="1">

--- a/devices/stm32/stm32f4-12.xml
+++ b/devices/stm32/stm32f4-12.xml
@@ -114,16 +114,15 @@
       <vector position="96" name="FMPI2C1_ER"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -158,20 +157,20 @@
       </latency>
     </driver>
     <driver name="fmpi2c" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="r|v|z" name="fsmc" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-pin="r|v|z" name="quadspi" type="stm32-v1.0"/>
@@ -180,47 +179,46 @@
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-13_23.xml
+++ b/devices/stm32/stm32f4-13_23.xml
@@ -169,22 +169,19 @@
       <vector position="101" name="DFSDM2_FLT3"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="23" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -219,84 +216,84 @@
       </latency>
     </driver>
     <driver name="fmpi2c" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="m|r|v|z" name="fsmc" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="m|r|v|z" name="quadspi" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sai" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="v|z" value="8"/>
-      <instance device-pin="v|z" value="9"/>
-      <instance device-pin="v|z" value="10"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="v|z" name="8"/>
+      <instance device-pin="v|z" name="9"/>
+      <instance device-pin="v|z" name="10"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="m|r|v|z" value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="m|r|v|z" name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-27_29_37_39.xml
+++ b/devices/stm32/stm32f4-27_29_37_39.xml
@@ -179,20 +179,17 @@
       <vector position="90" name="DMA2D"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver device-name="37|39" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dcmi" type="stm32"/>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v2.0"/>
@@ -241,14 +238,13 @@
     <driver name="fmc" type="stm32-v1.0"/>
     <driver device-name="37|39" name="hash" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32">
-      <feature value="dnf"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="29|39" name="ltdc" type="stm32-v1.0"/>
@@ -256,60 +252,60 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sai" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="a|b|i|n|z" value="5"/>
-      <instance device-pin="b|i|n|z" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="a|b|i|n|z" name="5"/>
+      <instance device-pin="b|i|n|z" name="6"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-46.xml
+++ b/devices/stm32/stm32f4-46.xml
@@ -117,19 +117,16 @@
       <vector position="96" name="FMPI2C1_ER"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dcmi" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
@@ -175,77 +172,76 @@
     </driver>
     <driver device-pin="v|z" name="fmc" type="stm32-v2.0"/>
     <driver name="fmpi2c" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32">
-      <feature value="dnf"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="quadspi" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance device-pin="m|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="m|v|z" name="2"/>
     </driver>
     <driver name="sdio" type="stm32"/>
     <driver name="spdifrx" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="m|v|z" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="m|v|z" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f4-69_79.xml
+++ b/devices/stm32/stm32f4-69_79.xml
@@ -153,20 +153,17 @@
       <vector position="92" name="DSI"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver device-name="79" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dcmi" type="stm32"/>
     <driver name="dma2d" type="stm32"/>
     <driver name="dsihost" type="stm32-v1.0"/>
@@ -216,14 +213,13 @@
     <driver name="fmc" type="stm32-v2.0"/>
     <driver device-name="79" name="hash" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32">
-      <feature value="dnf"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v2.3">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="ltdc" type="stm32-v1.1"/>
@@ -232,60 +228,60 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.3"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="b|i|n" value="5"/>
-      <instance device-pin="a|b|i|n" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="b|i|n" name="5"/>
+      <instance device-pin="a|b|i|n" name="6"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="a|b|i|n|z" value="8"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="a|b|i|n|z" name="8"/>
     </driver>
     <driver name="usart" type="stm32">
+      <feature value="half-duplex"/>
       <feature value="over8"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.1"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f7-22_23_32_33.xml
+++ b/devices/stm32/stm32f7-22_23_32_33.xml
@@ -150,22 +150,16 @@
       <vector position="103" name="SDMMC2"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="32|33" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1800">
         <wait-state ws="0" hclk-max="20000000"/>
@@ -213,88 +207,89 @@
     </driver>
     <driver device-pin="i|v|z" name="fmc" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver device-pin="i|v|z" name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="quadspi" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.6"/>
     <driver name="sai" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance device-name="22|32" device-pin="i|v|z" value="2"/>
-      <instance device-name="23|33" device-pin="i|z" value="2"/>
+      <instance name="1"/>
+      <instance device-name="22|32" device-pin="i|v|z" name="2"/>
+      <instance device-name="23|33" device-pin="i|z" name="2"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="i|v|z" value="4"/>
-      <instance device-pin="i|z" value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="i|v|z" name="4"/>
+      <instance device-pin="i|z" name="5"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance device-name="22|32" device-pin="i|r|v|z" value="12"/>
-      <instance device-name="23|33" device-pin="i" value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance device-name="22|32" device-pin="i|r|v|z" name="12"/>
+      <instance device-name="23|33" device-pin="i" name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance device-pin="i|v|z" value="7"/>
-      <instance device-pin="i|v|z" value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance device-pin="i|v|z" name="7"/>
+      <instance device-pin="i|v|z" name="8"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v3.0"/>
     <driver name="usb_otg_hs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f7-30_50.xml
+++ b/devices/stm32/stm32f7-30_50.xml
@@ -129,24 +129,18 @@
       <vector device-name="30" position="103" name="SDMMC2"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="30" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance device-name="50" value="2"/>
+      <instance name="1"/>
+      <instance device-name="50" name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="50" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver device-name="50" name="dcmi" type="stm32"/>
     <driver device-name="50" name="dma2d" type="stm32"/>
     <driver device-name="50" name="eth" type="stm32-v2.0"/>
@@ -199,23 +193,19 @@
     <driver device-name="50" name="hash" type="stm32-v2.2"/>
     <driver device-name="50" name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="50" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="50" name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver device-pin="i|n|v|z" name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="50" name="ltdc" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -223,64 +213,69 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.6"/>
     <driver device-name="50" name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="30" name="sai" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance device-name="30" device-pin="i|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-name="30" device-pin="i|v|z" name="2"/>
     </driver>
     <driver device-name="50" name="spdifrx" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="i|n|v|z" value="4"/>
-      <instance device-pin="i|n|z" value="5"/>
-      <instance device-name="50" device-pin="n|z" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="i|n|v|z" name="4"/>
+      <instance device-pin="i|n|z" name="5"/>
+      <instance device-name="50" device-pin="n|z" name="6"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance device-name="30" device-pin="i|r|v" value="12"/>
-      <instance device-name="50" device-pin="n|v|z" value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance device-name="30" device-pin="i|r|v" name="12"/>
+      <instance device-name="50" device-pin="n|v|z" name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance device-pin="i|n|v|z" value="7"/>
-      <instance device-pin="i|n|v|z" value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance device-pin="i|n|v|z" name="7"/>
+      <instance device-pin="i|n|v|z" name="8"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver device-name="50" name="usb_otg_fs" type="stm32-v2.1"/>
     <driver device-name="30" name="usb_otg_fs" type="stm32-v3.0"/>
@@ -288,8 +283,8 @@
     <driver device-name="30" name="usb_otg_hs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f7-45_46_56.xml
+++ b/devices/stm32/stm32f7-45_46_56.xml
@@ -161,23 +161,17 @@
       <vector position="97" name="SPDIF_RX"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="56" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dcmi" type="stm32"/>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v2.0"/>
@@ -230,23 +224,19 @@
     <driver device-name="56" name="hash" type="stm32-v2.2"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="46|56" name="ltdc" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -254,65 +244,70 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.6"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spdifrx" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="b|i|n|z" value="5"/>
-      <instance device-pin="b|i|n|z" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="b|i|n|z" name="5"/>
+      <instance device-pin="b|i|n|z" name="6"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.1"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
+++ b/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
@@ -191,27 +191,21 @@
       <vector position="109" name="MDIOS"/>
     </driver>
     <driver name="adc" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="77|78|79" name="cryp" type="stm32-v2.2"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver device-name="68|69|78|79" name="dsihost" type="stm32-v1.0"/>
@@ -265,24 +259,20 @@
     <driver device-name="77|78|79" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver device-name="67|68|69|77|78|79" name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="67|68|69|77|78|79" name="ltdc" type="stm32-v1.1"/>
     <driver name="mdios" type="stm32-v1.0"/>
@@ -291,66 +281,71 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.6"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="b|i|n|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="b|i|n|z" name="5"/>
+      <instance name="6"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
     </driver>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v1.2"/>
     <driver name="usb_otg_hs" type="stm32-v1.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-stream-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <streams instance="1">
         <stream position="0">
           <channel position="0">

--- a/devices/stm32/stm32g0-30.xml
+++ b/devices/stm32/stm32g0-30.xml
@@ -38,14 +38,9 @@
       <vector position="28" name="USART2"/>
     </driver>
     <driver name="adc" type="stm32-g0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
         <wait-state ws="0" hclk-max="8000000"/>
@@ -58,49 +53,44 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance device-pin="c|f|k" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|f|k" name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
+      <instance name="1"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g0-31_41.xml
+++ b/devices/stm32/stm32g0-31_41.xml
@@ -88,15 +88,10 @@
       <vector device-name="41" position="31" name="AES_RNG"/>
     </driver>
     <driver name="adc" type="stm32-g0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="41" name="aes" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
         <wait-state ws="0" hclk-max="8000000"/>
@@ -109,24 +104,20 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver device-name="41" name="rng" type="stm32"/>
@@ -134,33 +125,32 @@
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance device-pin="c|f|g|k|y" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|f|g|k|y" name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
+      <instance name="1"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g0-70_b0.xml
+++ b/devices/stm32/stm32g0-70_b0.xml
@@ -50,14 +50,9 @@
       <vector device-name="b0" position="29" name="USART3_4_5_6"/>
     </driver>
     <driver name="adc" type="stm32-g0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
         <wait-state ws="0" hclk-max="8000000"/>
@@ -70,67 +65,62 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-name="b0" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-name="b0" name="3"/>
     </driver>
     <driver device-name="70" name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="b0" name="i2s" type="stm32-v3.5">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-name="b0" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-name="b0" name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="3"/>
-      <instance device-name="b0" value="4"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="3"/>
+      <instance device-name="b0" name="4"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-name="b0" value="5"/>
-      <instance device-name="b0" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-name="b0" name="5"/>
+      <instance device-name="b0" name="6"/>
     </driver>
     <driver device-name="b0" name="usb_drd_fs" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance device-name="b0" value="2"/>
+      <instance name="1"/>
+      <instance device-name="b0" name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g0-71_81.xml
+++ b/devices/stm32/stm32g0-71_81.xml
@@ -117,22 +117,16 @@
       <vector device-name="81" position="31" name="AES_RNG"/>
     </driver>
     <driver name="adc" type="stm32-g0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="81" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_orcazero_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -147,24 +141,20 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v3.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver device-name="81" name="rng" type="stm32"/>
@@ -172,52 +162,51 @@
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver device-pin="c|k|r" device-variant="" name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="c|r" device-variant="" value="2"/>
-      <instance device-pin="g|k" device-variant="n" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" device-variant="" name="2"/>
+      <instance device-pin="g|k" device-variant="n" name="2"/>
     </driver>
     <driver device-pin="g|k" device-variant="n" name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="c|r" device-variant="" value="2"/>
-      <instance device-pin="g|k" device-variant="n" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" device-variant="" name="2"/>
+      <instance device-pin="g|k" device-variant="n" name="2"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver device-pin="c|k|r" device-variant="" name="usbpd" type="stm32-v1.4"/>
     <driver device-pin="g|k" device-variant="n" name="usbpd" type="stm32-v1.4"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
+      <instance name="1"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g0-b1_c1.xml
+++ b/devices/stm32/stm32g0-b1_c1.xml
@@ -85,27 +85,21 @@
       <vector device-name="c1" position="31" name="AES_RNG"/>
     </driver>
     <driver name="adc" type="stm32-g0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="c1" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_orcazero_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -120,27 +114,23 @@
     </driver>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver device-name="c1" name="rng" type="stm32"/>
@@ -148,52 +138,51 @@
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-variant="" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-variant="" name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="itline"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="c|m|r|v" device-variant="" value="2"/>
-      <instance device-pin="k" device-variant="n" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|m|r|v" device-variant="" name="2"/>
+      <instance device-pin="k" device-variant="n" name="2"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_drd_fs" type="stm32-v1.0"/>
     <driver name="usbpd" type="stm32-v1.4"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g4-31_41.xml
+++ b/devices/stm32/stm32g4-31_41.xml
@@ -159,27 +159,24 @@
       <vector position="101" name="FMAC"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="41" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_g4_rockfish_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -201,86 +198,84 @@
     </driver>
     <driver name="fmac" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-g4_tsmc90_fastopamp_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver device-pin="m|r|v" name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
+      <instance name="4"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|m|r|v" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|m|r|v" name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.2"/>
     <driver name="usbpd" type="stm32-v1.3"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g4-71_91_a1.xml
+++ b/devices/stm32/stm32g4-71_91_a1.xml
@@ -156,29 +156,26 @@
       <vector position="101" name="FMAC"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="a1" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_g4_rockfish_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -200,95 +197,93 @@
     </driver>
     <driver name="fmac" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="71" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="71" name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-g4_tsmc90_fastopamp_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="91|a1" value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="91|a1" name="6"/>
     </driver>
     <driver device-name="91|a1" name="quadspi" type="stm32-v4.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="71" device-pin="m|q|v" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="71" device-pin="m|q|v" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
-      <instance device-name="91|a1" value="20"/>
+      <instance name="1"/>
+      <instance name="8"/>
+      <instance device-name="91|a1" name="20"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-name="71" value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-name="71" name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver device-pin="m|q|r|v" name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|m|q|r|v" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|m|q|r|v" name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.2"/>
     <driver name="usbpd" type="stm32-v1.3"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g4-73_83.xml
+++ b/devices/stm32/stm32g4-73_83.xml
@@ -186,37 +186,34 @@
       <vector position="101" name="FMAC"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver device-name="83" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_g4_rockfish_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -239,97 +236,95 @@
     <driver name="fmac" type="stm32-v1.0"/>
     <driver device-pin="p|q|v" name="fmc" type="stm32-v2.2"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-g4_tsmc90_fastopamp_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="quadspi" type="stm32-v4.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="m|p|q|v" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="m|p|q|v" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
-      <instance value="20"/>
+      <instance name="1"/>
+      <instance name="8"/>
+      <instance name="20"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver device-pin="m|p|q|r|v" name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.2"/>
     <driver name="usbpd" type="stm32-v1.3"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32g4-74_84.xml
+++ b/devices/stm32/stm32g4-74_84.xml
@@ -200,37 +200,34 @@
       <vector position="101" name="FMAC"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver device-name="84" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_g4_rockfish_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -253,100 +250,98 @@
     <driver name="fmac" type="stm32-v1.0"/>
     <driver device-pin="p|q|v" name="fmc" type="stm32-v2.2"/>
     <driver name="hrtim" type="stm32-hrtim_g4">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v3.5">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.4">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-g4_tsmc90_fastopamp_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="quadspi" type="stm32-v4.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v1.1"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="m|p|q|v" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="m|p|q|v" name="4"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="ccm-wp"/>
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="fpu"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
-      <instance value="20"/>
+      <instance name="1"/>
+      <instance name="8"/>
+      <instance name="20"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver device-pin="m|p|q|r|v" name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="ucpd" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.2"/>
     <driver name="usbpd" type="stm32-v1.3"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-23_33.xml
+++ b/devices/stm32/stm32h7-23_33.xml
@@ -169,37 +169,33 @@
       <vector position="162" name="TIM24"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="33" name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -227,50 +223,48 @@
     <driver device-name="33" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2c" type="stm32-v1.1">
-      <instance value="5"/>
+      <instance name="5"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="33" name="otfdec" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -278,76 +272,84 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tim" type="stm32-v3.x">
-      <instance value="23"/>
-      <instance value="24"/>
+      <instance name="23"/>
+      <instance name="24"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
-      <instance value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
+      <instance name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
-      <instance value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
+      <instance name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-25_35.xml
+++ b/devices/stm32/stm32h7-25_35.xml
@@ -196,37 +196,33 @@
       <vector position="162" name="TIM24"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="35" name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="a|i|v|z" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="a|i|v|z" name="3"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -254,50 +250,48 @@
     <driver device-name="35" name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver device-pin="a|i|v|z" name="i2c" type="stm32-v1.1">
-      <instance value="5"/>
+      <instance name="5"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|v|z" name="2"/>
     </driver>
     <driver device-name="35" name="otfdec" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -305,79 +299,87 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver device-pin="a|i|v|z" name="sai" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-package="h|i|k|t" value="4"/>
-      <instance device-pin="a|i|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-package="h|i|k|t" name="4"/>
+      <instance device-pin="a|i|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tim" type="stm32-v3.x">
-      <instance value="23"/>
-      <instance value="24"/>
+      <instance name="23"/>
+      <instance name="24"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="a|i|v|z" value="8"/>
-      <instance device-pin="a" device-package="i" value="9"/>
-      <instance device-pin="i" device-package="k|t" value="9"/>
-      <instance device-pin="v" device-package="y" value="9"/>
-      <instance device-pin="z" device-package="t" value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="a|i|v|z" name="8"/>
+      <instance device-pin="a" device-package="i" name="9"/>
+      <instance device-pin="i" device-package="k|t" name="9"/>
+      <instance device-pin="v" device-package="y" name="9"/>
+      <instance device-pin="z" device-package="t" name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="a|i|v|z" value="6"/>
-      <instance device-pin="i|z" value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="a|i|v|z" name="6"/>
+      <instance device-pin="i|z" name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-30.xml
+++ b/devices/stm32/stm32h7-30.xml
@@ -162,37 +162,33 @@
       <vector position="162" name="TIM24"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="cordic" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -220,50 +216,48 @@
     <driver name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2c" type="stm32-v1.1">
-      <instance value="5"/>
+      <instance name="5"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="otfdec" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -271,76 +265,84 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="a|i|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="a|i|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tim" type="stm32-v3.x">
-      <instance value="23"/>
-      <instance value="24"/>
+      <instance name="23"/>
+      <instance name="24"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
-      <instance value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
+      <instance name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
-      <instance device-pin="i|v|z" value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
+      <instance device-pin="i|v|z" name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-42.xml
+++ b/devices/stm32/stm32h7-42.xml
@@ -167,33 +167,29 @@
       <vector position="149" name="WAKEUP_PIN"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -220,36 +216,34 @@
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -257,73 +251,81 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="a|b|i|x|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="a|b|i|x|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-43_53.xml
+++ b/devices/stm32/stm32h7-43_53.xml
@@ -181,34 +181,30 @@
       <vector position="149" name="WAKEUP_PIN"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="53" name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -236,38 +232,36 @@
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -275,73 +269,81 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="a|b|i|x|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="a|b|i|x|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -197,35 +197,31 @@
       <vector position="149" name="WAKEUP_PIN"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="cortex_m4" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="55" name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -253,43 +249,41 @@
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="openamp" type="stm32-v1.0">
-      <instance value="cortex-m4"/>
-      <instance value="cortex-m7"/>
+      <instance name="cortex-m4"/>
+      <instance name="cortex-m7"/>
     </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -298,75 +292,83 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="sys_m4" type="stm32-v1.0"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -177,36 +177,32 @@
       <vector position="149" name="WAKEUP_PIN"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="cortex_m4" type="stm32-v1.0"/>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver device-name="57" name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dsihost" type="stm32-v1.0"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -234,43 +230,41 @@
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="openamp" type="stm32-v1.0">
-      <instance value="cortex-m4"/>
-      <instance value="cortex-m7"/>
+      <instance name="cortex-m4"/>
+      <instance name="cortex-m7"/>
     </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -279,75 +273,83 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="a|b|i|x" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="a|b|i|x" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="sys_m4" type="stm32-v1.0"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-50.xml
+++ b/devices/stm32/stm32h7-50.xml
@@ -160,34 +160,30 @@
       <vector position="149" name="WAKEUP_PIN"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="bdma" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="eth" type="stm32-v3.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -215,38 +211,36 @@
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="hrtim" type="stm32-hrtim_h7"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
@@ -254,73 +248,81 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance device-pin="i|x|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance device-pin="i|x|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance value="8"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance name="8"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-a3.xml
+++ b/devices/stm32/stm32h7-a3.xml
@@ -180,35 +180,31 @@
       <vector position="154" name="BDMA1"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="bdma1" type="stm32-v1.1"/>
     <driver name="bdma2" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="a|i|l|n|q|v|z" name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -235,42 +231,40 @@
     <driver name="gfxmmu" type="stm32-v1.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
     </driver>
     <driver device-pin="a|i|l|n|q|v|z" name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -278,12 +272,12 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance device-pin="a|i|l|n|q|v|z" value="1"/>
-      <instance value="2"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="l|v" device-package="h" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver device-pin="n|v" device-package="h" device-variant="" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
@@ -293,67 +287,75 @@
     <driver device-pin="q" device-package="y" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver device-pin="z" device-package="t" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="4"/>
-      <instance device-pin="a|i|l|n|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="4"/>
+      <instance device-pin="a|i|l|n|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="8"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="8"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
-      <instance device-pin="l|v" device-package="h" device-variant="q" value="10"/>
-      <instance device-pin="n|v" device-package="h" device-variant="" value="10"/>
-      <instance device-pin="v|z" device-package="t" device-variant="" value="10"/>
-      <instance device-pin="a" device-package="i" device-variant="q" value="10"/>
-      <instance device-pin="i" device-package="k|t" device-variant="|q" value="10"/>
-      <instance device-pin="q" device-package="y" device-variant="q" value="10"/>
-      <instance device-pin="z" device-package="t" device-variant="q" value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
+      <instance device-pin="l|v" device-package="h" device-variant="q" name="10"/>
+      <instance device-pin="n|v" device-package="h" device-variant="" name="10"/>
+      <instance device-pin="v|z" device-package="t" device-variant="" name="10"/>
+      <instance device-pin="a" device-package="i" device-variant="q" name="10"/>
+      <instance device-pin="i" device-package="k|t" device-variant="|q" name="10"/>
+      <instance device-pin="q" device-package="y" device-variant="q" name="10"/>
+      <instance device-pin="z" device-package="t" device-variant="q" name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-b0.xml
+++ b/devices/stm32/stm32h7-b0.xml
@@ -159,36 +159,32 @@
       <vector position="154" name="BDMA1"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="bdma1" type="stm32-v1.1"/>
     <driver name="bdma2" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance device-pin="a|i|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|v|z" name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="a|i|v|z" name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -216,46 +212,44 @@
     <driver name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="a|i|v|z" value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|v|z" name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|v|z" name="2"/>
     </driver>
     <driver name="otfdec" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|z" name="2"/>
     </driver>
     <driver device-pin="a|i|v|z" name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -263,70 +257,78 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance device-pin="a|i|v|z" value="1"/>
-      <instance value="2"/>
+      <instance device-pin="a|i|v|z" name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="a|i|v|z" value="4"/>
-      <instance device-pin="a|i|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="a|i|v|z" name="4"/>
+      <instance device-pin="a|i|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="a|i|v|z" value="8"/>
-      <instance device-pin="a|i|v|z" value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="a|i|v|z" name="8"/>
+      <instance device-pin="a|i|v|z" name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
-      <instance device-pin="a|i|v|z" value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
+      <instance device-pin="a|i|v|z" name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32h7-b3.xml
+++ b/devices/stm32/stm32h7-b3.xml
@@ -170,36 +170,32 @@
       <vector position="154" name="BDMA1"/>
     </driver>
     <driver name="adc" type="stm32-h7">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="bdma1" type="stm32-v1.1"/>
     <driver name="bdma2" type="stm32-v1.2"/>
     <driver name="comp" type="stm32-tsmc90_h7_cube">
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
     </driver>
-    <driver name="crc" type="stm32">
-      <feature value="polynomial"/>
-      <feature value="reverse"/>
-    </driver>
+    <driver name="crc" type="stm32"/>
     <driver name="cryp" type="stm32-v2.0"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="a|i|l|n|q|v|z" name="dcmi" type="stm32"/>
     <driver name="debug" type="stm32-v1.0"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="dts" type="stm32-v1.0"/>
     <driver name="fdcan" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="950">
@@ -227,47 +223,45 @@
     <driver name="hash" type="stm32-v2.0"/>
     <driver name="hdmi_cec" type="stm32-v2.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="i2s" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
     </driver>
     <driver name="iwdg" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="jpeg" type="stm32-v1.0"/>
     <driver name="lptim" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.0"/>
     <driver name="mdios" type="stm32-v1.0"/>
     <driver name="mdma" type="stm32-v1.0"/>
     <driver name="octospi" type="stm32-v2.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v2.1"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="2"/>
     </driver>
     <driver name="otfdec" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-pin="a|i|l" device-variant="q" value="2"/>
-      <instance device-pin="i|n|z" device-variant="" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="a|i|l" device-variant="q" name="2"/>
+      <instance device-pin="i|n|z" device-variant="" name="2"/>
     </driver>
     <driver device-pin="a|i|l|n|q|v|z" name="pssi" type="stm32-v3.0"/>
     <driver name="pwr" type="stm32-v1.0"/>
@@ -275,12 +269,12 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-v2.1">
-      <instance device-pin="a|i|l|n|q|v|z" value="1"/>
-      <instance value="2"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="l|v" device-package="h" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver device-pin="n|v" device-package="h" device-variant="" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
@@ -290,67 +284,75 @@
     <driver device-pin="q" device-package="y" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver device-pin="z" device-package="t" device-variant="q" name="spdifrx" type="stm32-spdifrx1_h7_cube"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="4"/>
-      <instance device-pin="a|i|l|n|z" value="5"/>
-      <instance value="6"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="4"/>
+      <instance device-pin="a|i|l|n|z" name="5"/>
+      <instance name="6"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="12"/>
-      <instance value="13"/>
-      <instance value="14"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="12"/>
+      <instance name="13"/>
+      <instance name="14"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="7"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="8"/>
-      <instance device-pin="a|i|l|n|q|v|z" value="9"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="7"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="8"/>
+      <instance device-pin="a|i|l|n|q|v|z" name="9"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="6"/>
-      <instance device-pin="l|v" device-package="h" device-variant="q" value="10"/>
-      <instance device-pin="n|v" device-package="h" device-variant="" value="10"/>
-      <instance device-pin="v|z" device-package="t" device-variant="" value="10"/>
-      <instance device-pin="a" device-package="i" device-variant="q" value="10"/>
-      <instance device-pin="i" device-package="k|t" device-variant="|q" value="10"/>
-      <instance device-pin="q" device-package="y" device-variant="q" value="10"/>
-      <instance device-pin="z" device-package="t" device-variant="q" value="10"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <feature value="tcbgt"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="6"/>
+      <instance device-pin="l|v" device-package="h" device-variant="q" name="10"/>
+      <instance device-pin="n|v" device-package="h" device-variant="" name="10"/>
+      <instance device-pin="v|z" device-package="t" device-variant="" name="10"/>
+      <instance device-pin="a" device-package="i" device-variant="q" name="10"/>
+      <instance device-pin="i" device-package="k|t" device-variant="|q" name="10"/>
+      <instance device-pin="q" device-package="y" device-variant="q" name="10"/>
+      <instance device-pin="z" device-package="t" device-variant="q" name="10"/>
     </driver>
     <driver name="usb_otg_hs" type="stm32-v2.0"/>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32l0-10.xml
+++ b/devices/stm32/stm32l0-10.xml
@@ -41,11 +41,7 @@
       <vector position="28" name="USART2"/>
       <vector position="29" name="LPUART1"/>
     </driver>
-    <driver name="adc" type="stm32-l0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-    </driver>
+    <driver name="adc" type="stm32-l0"/>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1050">
@@ -61,44 +57,44 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="f|k" device-size="4" name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="c" device-size="6" name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="r" device-size="8|b" name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="21"/>
-      <instance device-size="b" value="22"/>
+      <instance name="21"/>
+      <instance device-size="b" name="22"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l0-11_21.xml
+++ b/devices/stm32/stm32l0-11_21.xml
@@ -69,15 +69,11 @@
       <vector device-name="21" position="29" name="AES_LPUART1"/>
       <vector device-name="11" position="29" name="LPUART1"/>
     </driver>
-    <driver name="adc" type="stm32-l0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-    </driver>
+    <driver name="adc" type="stm32-l0"/>
     <driver device-name="21" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -94,37 +90,37 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="21"/>
+      <instance name="21"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l0-31_41.xml
+++ b/devices/stm32/stm32l0-31_41.xml
@@ -79,15 +79,11 @@
       <vector device-name="41" position="29" name="AES_LPUART1"/>
       <vector device-name="31" position="29" name="LPUART1"/>
     </driver>
-    <driver name="adc" type="stm32-l0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-    </driver>
+    <driver name="adc" type="stm32-l0"/>
     <driver device-name="41" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -104,38 +100,38 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="21"/>
-      <instance value="22"/>
+      <instance name="21"/>
+      <instance name="22"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l0-51_52_53_62_63.xml
+++ b/devices/stm32/stm32l0-51_52_53_62_63.xml
@@ -115,20 +115,14 @@
       <vector device-name="53|63" position="30" name="LCD"/>
       <vector device-name="52|53|62|63" position="31" name="USB"/>
     </driver>
-    <driver name="adc" type="stm32-l0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-    </driver>
+    <driver name="adc" type="stm32-l0"/>
     <driver device-name="62|63" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver device-name="52|53|62|63" name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver device-name="52|53|62|63" name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1050">
         <wait-state ws="0" hclk-max="4200000"/>
@@ -143,51 +137,51 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r|t" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|t" name="2"/>
     </driver>
     <driver device-pin="c|r" name="i2s" type="stm32-v3.1">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="53|63" name="lcd" type="stm32-v1.3"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="c|r|t" name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver device-name="52|53|62|63" name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="21"/>
-      <instance value="22"/>
+      <instance name="21"/>
+      <instance name="22"/>
     </driver>
     <driver device-name="52|53|62|63" name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="52|53|62|63" name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l0-71_72_73_81_82_83.xml
+++ b/devices/stm32/stm32l0-71_72_73_81_82_83.xml
@@ -205,20 +205,14 @@
       <vector device-name="73|83" position="30" name="LCD"/>
       <vector device-name="72|73|82|83" position="31" name="USB"/>
     </driver>
-    <driver name="adc" type="stm32-l0">
-      <feature value="calfact"/>
-      <feature value="oversampler"/>
-      <feature value="prescaler"/>
-    </driver>
+    <driver name="adc" type="stm32-l0"/>
     <driver device-name="81|82|83" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver device-name="72|73|82|83" name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver device-name="72|73|82|83" name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1050">
         <wait-state ws="0" hclk-max="4200000"/>
@@ -233,59 +227,59 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-pin="c|r|v" name="i2s" type="stm32-v3.1">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="73|83" name="lcd" type="stm32-v1.3"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver device-name="72|73|82|83" name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="tim" type="stm32-v2.x">
-      <instance value="21"/>
-      <instance value="22"/>
+      <instance name="21"/>
+      <instance name="22"/>
     </driver>
     <driver device-name="72|73|82|83" name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="4"/>
-      <instance device-pin="c|k" device-package="t" value="5"/>
-      <instance device-pin="c" device-package="e|u|y" value="5"/>
-      <instance device-pin="r" device-package="h|i|t" value="5"/>
-      <instance device-pin="v" device-package="i|t" value="5"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="4"/>
+      <instance device-pin="c|k" device-package="t" name="5"/>
+      <instance device-pin="c" device-package="e|u|y" name="5"/>
+      <instance device-pin="r" device-package="h|i|t" name="5"/>
+      <instance device-pin="v" device-package="i|t" name="5"/>
     </driver>
     <driver device-name="72|73|82|83" name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l1-00.xml
+++ b/devices/stm32/stm32l1-00.xml
@@ -77,21 +77,19 @@
     </driver>
     <driver name="adc" type="stm32"/>
     <driver device-size="6|8|b" device-variant="" name="comp" type="stm32-v3.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-size="6|8|b" device-variant="a" name="comp" type="stm32-v3.6">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-size="c" device-variant="" name="comp" type="stm32-v3.6">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1200">
         <wait-state device-size="c" ws="0" hclk-max="2100000"/>
@@ -109,47 +107,47 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-size="c" name="i2s" type="stm32-v2.2">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver name="lcd" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.5"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-size="c" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-size="c" name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance device-size="c" value="2"/>
+      <instance name="1"/>
+      <instance device-size="c" name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32l1-51_52-6_8_b.xml
+++ b/devices/stm32/stm32l1-51_52-6_8_b.xml
@@ -126,17 +126,15 @@
     </driver>
     <driver name="adc" type="stm32"/>
     <driver device-variant="" name="comp" type="stm32-v3.4">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-variant="a" name="comp" type="stm32-v3.6">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1200">
         <wait-state ws="0" hclk-max="4200000"/>
@@ -152,42 +150,42 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="52" name="lcd" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.5"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
     </driver>
     <driver name="ts" type="stm32-v1.0"/>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
+      <instance name="1"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32l1-51_52_62-c_d_e.xml
+++ b/devices/stm32/stm32l1-51_52_62-c_d_e.xml
@@ -144,13 +144,11 @@
     <driver name="adc" type="stm32"/>
     <driver device-name="62" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-v3.6">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
-    <driver name="dac" type="stm32">
-      <feature value="status"/>
-    </driver>
+    <driver name="dac" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1200">
         <wait-state ws="0" hclk-max="2100000"/>
@@ -167,59 +165,61 @@
     </driver>
     <driver device-pin="q|v|z" device-size="d" device-variant="" name="fsmc" type="stm32-v4.0"/>
     <driver name="i2c" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="i2s" type="stm32-v2.2">
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="52|62" name="lcd" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-size="d" device-variant="" value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-size="d" device-variant="" name="3"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rtc" type="stm32-v2.5"/>
     <driver device-size="d" device-variant="" name="sdio" type="stm32"/>
     <driver name="spi" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="9"/>
-      <instance value="10"/>
-      <instance value="11"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="9"/>
+      <instance name="10"/>
+      <instance name="11"/>
     </driver>
     <driver name="ts" type="stm32-v1.0"/>
     <driver device-size="d|e" name="uart" type="stm32">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v1.2"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <signal driver="adc"/>

--- a/devices/stm32/stm32l4-12_22.xml
+++ b/devices/stm32/stm32l4-12_22.xml
@@ -105,12 +105,12 @@
       <vector position="82" name="CRS"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="22" name="aes" type="stm32-v1.0"/>
     <driver name="comp" type="stm32-tsmc90_orca128_cube">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -129,23 +129,21 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.2"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -154,35 +152,36 @@
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c|r" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|r" name="2"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="15"/>
-      <instance value="16"/>
+      <instance name="2"/>
+      <instance name="15"/>
+      <instance name="16"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r" name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-31_33_43.xml
+++ b/devices/stm32/stm32l4-31_33_43.xml
@@ -154,21 +154,19 @@
       <vector position="82" name="CRS"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="43" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -186,72 +184,71 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver device-name="33|43" name="lcd" type="stm32-v1.2"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.2"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="r|v" device-variant="" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="c|r|v" value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance device-pin="c|r|v" name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="15"/>
-      <instance value="16"/>
+      <instance name="2"/>
+      <instance name="15"/>
+      <instance name="16"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance device-pin="c|r|v" value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance device-pin="c|r|v" name="3"/>
     </driver>
     <driver device-name="33|43" name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-32_42.xml
+++ b/devices/stm32/stm32l4-32_42.xml
@@ -72,21 +72,19 @@
       <vector position="82" name="CRS"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="42" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -104,65 +102,64 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.2"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="15"/>
-      <instance value="16"/>
+      <instance name="2"/>
+      <instance name="15"/>
+      <instance name="16"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="usb" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-51_71.xml
+++ b/devices/stm32/stm32l4-51_71.xml
@@ -132,29 +132,27 @@
       <vector device-name="51" position="84" name="I2C4_ER"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance device-name="71" value="2"/>
-      <instance device-name="71" value="3"/>
+      <instance name="1"/>
+      <instance device-name="71" name="2"/>
+      <instance device-name="71" name="3"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="71" name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="51" name="comp" type="stm32-tsmc90_orca512_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -173,25 +171,23 @@
     </driver>
     <driver device-name="71" device-pin="q|v|z" name="fmc" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="51" value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="51" name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance device-name="71" value="2"/>
+      <instance name="1"/>
+      <instance device-name="71" name="2"/>
     </driver>
     <driver device-name="71" name="quadspi" type="stm32-v2.0"/>
     <driver device-name="51" name="quadspi" type="stm32-v2.2"/>
@@ -199,57 +195,62 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance device-name="71" value="2"/>
+      <instance name="1"/>
+      <instance device-name="71" name="2"/>
     </driver>
     <driver device-pin="q|r|v|z" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="71" name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance device-name="71" value="8"/>
+      <instance name="1"/>
+      <instance device-name="71" name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance device-name="71" value="7"/>
+      <instance name="6"/>
+      <instance device-name="71" name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance device-name="71" value="4"/>
-      <instance device-name="71" value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance device-name="71" value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance device-name="71" name="4"/>
+      <instance device-name="71" name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance device-name="71" name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance device-name="71" value="5"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance device-name="71" name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-52_62.xml
+++ b/devices/stm32/stm32l4-52_62.xml
@@ -121,24 +121,22 @@
       <vector position="84" name="I2C4_ER"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="62" name="aes" type="stm32-v1.1"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_orca512_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -156,72 +154,75 @@
       </latency>
     </driver>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.2"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="r|v" device-variant="" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
+      <instance name="6"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="15"/>
-      <instance value="16"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="15"/>
+      <instance name="16"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb" type="stm32-v2.1"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-75_85.xml
+++ b/devices/stm32/stm32l4-75_85.xml
@@ -103,26 +103,24 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="85" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -141,82 +139,85 @@
     </driver>
     <driver device-pin="v" name="fmc" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-76_86.xml
+++ b/devices/stm32/stm32l4-76_86.xml
@@ -136,26 +136,24 @@
       <vector position="81" name="FPU"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="86" name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="flash" type="stm32-v1.0">
       <latency vcore-min="1000">
@@ -174,83 +172,86 @@
     </driver>
     <driver device-pin="q|v|z" name="fmc" type="stm32-v1.1"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lcd" type="stm32-v1.2"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.1">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-96_a6.xml
+++ b/devices/stm32/stm32l4-96_a6.xml
@@ -164,28 +164,26 @@
       <vector position="90" name="DMA2D"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver device-name="a6" name="aes" type="stm32-v1.1"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -206,93 +204,96 @@
     <driver device-pin="a|q|v|w|z" name="fmc" type="stm32-v2.0"/>
     <driver device-name="a6" name="hash" type="stm32-v2.2"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lcd" type="stm32-v1.2"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="quadspi" type="stm32-v2.2"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v1.2">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-name="96" device-pin="w" device-variant="p" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="96|a6" device-pin="a|q|v|z" device-variant="|p" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="96|a6" device-pin="r" device-variant="" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="a6" device-pin="r" device-variant="p" name="sdmmc" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="swpmi" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
-      <instance value="4"/>
-      <instance value="5"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v2.4"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-channel-request">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <channels instance="1">
         <channel position="1">
           <request position="0">

--- a/devices/stm32/stm32l4-p5.xml
+++ b/devices/stm32/stm32l4-p5.xml
@@ -122,25 +122,23 @@
       <vector position="94" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="a|q|r|v|z" name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -160,89 +158,92 @@
     <driver device-pin="a|q|v|z" name="fmc" type="stm32-v2.2"/>
     <driver name="hash" type="stm32-v2.2"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.2"/>
     <driver name="octospi" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver device-pin="a|q|v|z" name="pssi" type="stm32-v3.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.9"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.1">
-      <instance device-pin="a|q|r|v|z" value="1"/>
-      <instance value="2"/>
+      <instance device-pin="a|q|r|v|z" name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance device-pin="a|q|v|z" value="5"/>
+      <instance name="4"/>
+      <instance device-pin="a|q|v|z" name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32l4-q5.xml
+++ b/devices/stm32/stm32l4-q5.xml
@@ -106,26 +106,24 @@
       <vector position="94" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
-      <instance device-pin="c|q|r|v|z" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="c|q|r|v|z" name="2"/>
     </driver>
     <driver name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-pin="a|q|r|v|z" name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -145,31 +143,29 @@
     <driver device-pin="a|q|v|z" name="fmc" type="stm32-v2.2"/>
     <driver name="hash" type="stm32-v2.2"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="ltdc" type="stm32-v1.2"/>
     <driver name="octospi" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pka" type="stm32-v1.0"/>
     <driver device-pin="a|q|v|z" name="pssi" type="stm32-v3.0"/>
@@ -177,58 +173,63 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.9"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.1">
-      <instance device-pin="a|q|r|v|z" value="1"/>
-      <instance value="2"/>
+      <instance device-pin="a|q|r|v|z" name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance device-pin="a|q|v|z" value="5"/>
+      <instance name="4"/>
+      <instance device-pin="a|q|v|z" name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32l4-r5_r7_r9.xml
+++ b/devices/stm32/stm32l4-r5_r7_r9.xml
@@ -125,24 +125,22 @@
       <vector position="94" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver device-name="r9" name="dsihost" type="stm32-v1.0"/>
@@ -163,87 +161,90 @@
     <driver name="fmc" type="stm32-v2.1"/>
     <driver device-name="r7|r9" name="gfxmmu" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="r7|r9" name="ltdc" type="stm32-v1.1"/>
     <driver name="octospi" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32l4-s5_s7_s9.xml
+++ b/devices/stm32/stm32l4-s5_s7_s9.xml
@@ -117,25 +117,23 @@
       <vector position="94" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="aes" type="stm32-v1.0"/>
     <driver name="can" type="stm32">
-      <feature value="filter-28"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="dac" type="stm32">
-      <feature value="status"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dcmi" type="stm32"/>
     <driver name="dfsdm" type="stm32-v1.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="dma2d" type="stm32"/>
     <driver device-name="s9" name="dsihost" type="stm32-v1.0"/>
@@ -157,87 +155,90 @@
     <driver device-name="s7|s9" name="gfxmmu" type="stm32-v1.0"/>
     <driver name="hash" type="stm32-v2.2"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
     <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.2">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver device-name="s7|s9" name="ltdc" type="stm32-v1.1"/>
     <driver name="octospi" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="octospim" type="stm32-v1.0"/>
     <driver name="opamp" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="rcc" type="stm32-v1.0"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.4"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="sdmmc" type="stm32-v1.1">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
-    <driver name="sys" type="stm32">
-      <feature value="exti"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
-      <instance value="8"/>
+      <instance name="1"/>
+      <instance name="8"/>
     </driver>
     <driver name="tim" type="stm32-basic">
-      <instance value="6"/>
-      <instance value="7"/>
+      <instance name="6"/>
+      <instance name="7"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="3"/>
-      <instance value="4"/>
-      <instance value="5"/>
-      <instance value="15"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="3"/>
+      <instance name="4"/>
+      <instance name="5"/>
+      <instance name="15"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="uart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="4"/>
-      <instance value="5"/>
+      <instance name="4"/>
+      <instance name="5"/>
     </driver>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
-      <instance value="2"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="2"/>
+      <instance name="3"/>
     </driver>
     <driver name="usb_otg_fs" type="stm32-v3.0"/>
     <driver name="wwdg" type="stm32-v1.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32wb-30_50.xml
+++ b/devices/stm32/stm32wb-30_50.xml
@@ -58,10 +58,10 @@
       <vector position="62" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="aes" type="stm32-v1.0">
-      <instance value="2"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -79,17 +79,13 @@
     </driver>
     <driver name="hsem" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="pka" type="stm32-v1.0"/>
     <driver name="rcc" type="stm32-v1.0"/>
@@ -100,33 +96,31 @@
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="stm32_wpan" type="stm32-v1.2"/>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="imr"/>
-      <feature value="sram2-wp"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tiny_lpm" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32wb-35_55.xml
+++ b/devices/stm32/stm32wb-35_55.xml
@@ -110,15 +110,15 @@
       <vector position="62" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="aes" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_dory_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -136,22 +136,18 @@
     </driver>
     <driver name="hsem" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver device-name="55" name="lcd" type="stm32-v1.2"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="pka" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v2.2"/>
@@ -160,42 +156,40 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-rtc2_v2_wb_cube"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="sequencer" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance device-pin="r|v" value="2"/>
+      <instance name="1"/>
+      <instance device-pin="r|v" name="2"/>
     </driver>
     <driver name="stm32_wpan" type="stm32-v1.2"/>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="imr"/>
-      <feature value="sram2-wp"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tiny_lpm" type="stm32-v1.0"/>
     <driver device-pin="r|v" name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usb" type="stm32-v2.1"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/devices/stm32/stm32wb-5m.xml
+++ b/devices/stm32/stm32wb-5m.xml
@@ -72,15 +72,15 @@
       <vector position="62" name="DMAMUX1_OVR"/>
     </driver>
     <driver name="adc" type="stm32-f3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="aes" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="comp" type="stm32-tsmc90_dory_cube">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="crc" type="stm32"/>
     <driver name="flash" type="stm32-v1.0">
@@ -98,22 +98,18 @@
     </driver>
     <driver name="hsem" type="stm32-v1.0"/>
     <driver name="i2c" type="stm32-extended">
-      <feature value="dnf"/>
-      <feature value="fmp"/>
-      <instance value="1"/>
-      <instance value="3"/>
+      <instance name="1"/>
+      <instance name="3"/>
     </driver>
     <driver name="irtim" type="stm32-v1.0"/>
-    <driver name="iwdg" type="stm32">
-      <feature value="window"/>
-    </driver>
+    <driver name="iwdg" type="stm32"/>
     <driver name="lcd" type="stm32-v1.2"/>
     <driver name="lptim" type="stm32-v1.0">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="lpuart" type="stm32-v1.3">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="pka" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v2.2"/>
@@ -122,42 +118,40 @@
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-rtc2_v2_wb_cube"/>
     <driver name="sai" type="stm32-v2.0">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="sequencer" type="stm32-v1.0"/>
     <driver name="spi" type="stm32">
       <feature value="data-size"/>
       <feature value="fifo"/>
-      <feature value="nss-pulse"/>
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
     </driver>
     <driver name="stm32_wpan" type="stm32-v1.2"/>
-    <driver name="sys" type="stm32">
-      <feature value="cfgr2"/>
-      <feature value="exti"/>
-      <feature value="imr"/>
-      <feature value="sram2-wp"/>
-    </driver>
+    <driver name="sys" type="stm32"/>
     <driver name="tim" type="stm32-advanced">
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="tim" type="stm32-general-purpose">
-      <instance value="2"/>
-      <instance value="16"/>
-      <instance value="17"/>
+      <instance name="2"/>
+      <instance name="16"/>
+      <instance name="17"/>
     </driver>
     <driver name="tiny_lpm" type="stm32-v1.0"/>
     <driver name="tsc" type="stm32-v1.0"/>
     <driver name="usart" type="stm32-extended">
+      <feature value="7-bit"/>
+      <feature value="half-duplex"/>
+      <feature value="over8"/>
+      <feature value="swap"/>
       <feature value="tcbgt"/>
-      <instance value="1"/>
+      <instance name="1"/>
     </driver>
     <driver name="usb" type="stm32-v2.1"/>
     <driver name="wwdg" type="stm32-v2.0"/>
     <driver name="dma" type="stm32-mux">
-      <instance value="1"/>
-      <instance value="2"/>
+      <instance name="1"/>
+      <instance name="2"/>
       <requests>
         <request position="1">
           <signal driver="dma" name="generator0"/>

--- a/modm_devices/__init__.py
+++ b/modm_devices/__init__.py
@@ -10,10 +10,18 @@ from . import device_file
 from . import device_identifier
 from . import device
 from . import parser
+from . import stm32
 
 from .pkg import naturalkey
 from .exception import ParserException
 
-__all__ = ['exception', 'device_file', 'device_identifier', 'device', 'parser', 'pkg']
+__all__ = [
+	'exception',
+	'device_file',
+	'device_identifier',
+	'device',
+	'parser',
+	'pkg'
+]
 
 __version__ = "0.2.8"

--- a/modm_devices/access.py
+++ b/modm_devices/access.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import copy
+
+def copy_keys(src, *keys):
+    dest = {};
+    for key in keys:
+        conv = lambda o: o
+        if isinstance(key, tuple):
+            key, conv = key
+        if key in src:
+            dest[key] = conv(src[key])
+    return dest
+
+def copy_deep(obj):
+    return copy.deepcopy(obj)
+
+
+class ReadOnlyList(list):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("You are trying to modify read-only DeviceFile data!")
+    pop = __readonly__
+    remove = __readonly__
+    append = __readonly__
+    clear = __readonly__
+    extend = __readonly__
+    insert = __readonly__
+    reverse = __readonly__
+    __copy__ = list.copy
+    __deepcopy__ = copy._deepcopy_dispatch.get(list)
+    del __readonly__
+
+
+class ReadOnlyDict(dict):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("You are trying to modify read-only DeviceFile data!")
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop = __readonly__
+    popitem = __readonly__
+    clear = __readonly__
+    update = __readonly__
+    setdefault = __readonly__
+    __copy__ = dict.copy
+    __deepcopy__ = copy._deepcopy_dispatch.get(dict)
+    del __readonly__
+
+
+def read_only(obj):
+    if isinstance(obj, dict):
+        return ReadOnlyDict(obj)
+    if isinstance(obj, list):
+        return ReadOnlyList(obj)
+    return obj

--- a/modm_devices/cache.py
+++ b/modm_devices/cache.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import functools
+
+class cached_property(object):
+    def __init__(self, func):
+        self.__doc__ = getattr(func, "__doc__")
+        self.func = func
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
+        return value
+
+cached_function = functools.lru_cache(None)

--- a/modm_devices/device.py
+++ b/modm_devices/device.py
@@ -21,26 +21,19 @@ class Device:
         self.partname = identifier.string
         self.device_file = device_file
 
-        self._properties = None
-
-    def __parse_properties(self):
-        """
-        Perform a lazy initialization of the driver property tree.
-        """
-        if self._properties is None:
-            self._properties = self.device_file.get_properties(self._identifier)
+        self.__properties = None
 
     @property
-    def properties(self):
-        self.__parse_properties()
-        return copy.deepcopy(self._properties)
+    def _properties(self):
+        if self.__properties is None:
+            self.__properties = self.device_file.get_properties(self._identifier)
+        return self.__properties
 
     @property
     def identifier(self):
-        return self._identifier.copy()
+        return self._identifier
 
     def get_all_drivers(self, name):
-        self.__parse_properties()
         parts = name.split(":")
         results = []
 
@@ -58,7 +51,7 @@ class Device:
                                   "The name must contain no or one ':' to "
                                   "separate type and name.".format(name))
 
-        return copy.deepcopy(results)
+        return results
 
     def get_driver(self, name):
         results = self.get_all_drivers(name)

--- a/modm_devices/device_file.py
+++ b/modm_devices/device_file.py
@@ -6,12 +6,14 @@
 # All rights reserved.
 
 import lxml.etree
+import copy
 
 from collections import defaultdict
 
 from .device import Device
 from .device_identifier import DeviceIdentifier
 from .device_identifier import MultiDeviceIdentifier
+from .access import read_only
 
 from .exception import ParserException
 
@@ -59,14 +61,13 @@ class DeviceFile:
         Returns:
             True if the selectors match, False otherwise.
         """
-        device_keys = filter(lambda k: k.startswith(DeviceFile._PREFIX_ATTRIBUTE_DEVICE), node.attrib.keys())
-        properties = {k.replace(DeviceFile._PREFIX_ATTRIBUTE_DEVICE, ''):node.attrib[k].split("|") for k in device_keys}
-        return not any(identifier[key] not in value for key, value in properties.items())
+        device_keys = (k for k in node.attrib.keys() if k.startswith(DeviceFile._PREFIX_ATTRIBUTE_DEVICE))
+        properties = ((k.replace(DeviceFile._PREFIX_ATTRIBUTE_DEVICE, ''), node.attrib[k].split("|"))
+                      for k in device_keys)
+        return all(identifier[key] in value for key, value in properties)
 
     def get_properties(self, identifier: DeviceIdentifier):
         class Converter:
-            """
-            """
             def __init__(self, identifier: DeviceIdentifier):
                 self.identifier = identifier
 
@@ -79,9 +80,9 @@ class DeviceFile:
                 return DeviceFile.is_valid(node, self.identifier)
 
             def strip_attrib(self, node):
-                stripped_keys = filter(lambda k: not k.startswith(DeviceFile._PREFIX_ATTRIBUTE_DEVICE), node.attrib.keys())
+                stripped_keys = (k for k in node.attrib.keys() if not k.startswith(DeviceFile._PREFIX_ATTRIBUTE_DEVICE))
                 if node.getparent().getparent() is None and node.tag == 'device':
-                    stripped_keys = filter(lambda k: k not in self.identifier.keys(), stripped_keys)
+                    stripped_keys = (k for k in stripped_keys if k not in self.identifier.keys())
                 return {k:node.attrib[k] for k in stripped_keys}
 
             def to_dict(self, t):
@@ -90,10 +91,7 @@ class DeviceFile:
                     return {}
                 attrib = self.strip_attrib(t)
                 d = {t.tag: {} if len(attrib) else None}
-                children = []
-                for c in t:
-                    if self.is_valid(c):
-                        children.append(c)
+                children = filter(self.is_valid, t)
                 if children:
                     dd = defaultdict(list)
                     for dc in map(self.to_dict, children):
@@ -106,7 +104,7 @@ class DeviceFile:
                                 raise ParserException("Attribute '{}' cannot be a list!".format(k))
                             k = k.replace(DeviceFile._PREFIX_ATTRIBUTE, '')
                             v = v[0]
-                        dk[k] = v
+                        dk[k] = read_only(v)
                     d = {t.tag: dk}
                 if list(attrib.keys()) == ['value']:
                     d[t.tag] = attrib['value']
@@ -114,7 +112,7 @@ class DeviceFile:
                     if any(k in d[t.tag] for k in attrib.keys()):
                         raise ParserException("Node children are overwriting attribute '{}'!".format(k))
                     d[t.tag].update(attrib.items())
-                return d
+                return read_only({k:read_only(v) for k,v in d.items()})
 
         properties = Converter(identifier).to_dict(self.rootnode.find("device"))
         return properties["device"]

--- a/modm_devices/device_file.py
+++ b/modm_devices/device_file.py
@@ -95,7 +95,9 @@ class DeviceFile:
                 if children:
                     dd = defaultdict(list)
                     for dc in map(self.to_dict, children):
+                        # print(dc)
                         for k, v in dc.items():
+                            # if k == "signal" and v.get("name") == "seg40": print(v)
                             dd[k].append(v)
                     dk = {}
                     for k, v in dd.items():
@@ -111,8 +113,11 @@ class DeviceFile:
                 elif len(attrib):
                     if any(k in d[t.tag] for k in attrib.keys()):
                         raise ParserException("Node children are overwriting attribute '{}'!".format(k))
+                    # print(attrib.items())
                     d[t.tag].update(attrib.items())
                 return read_only({k:read_only(v) for k,v in d.items()})
 
         properties = Converter(identifier).to_dict(self.rootnode.find("device"))
+        # print(properties)
+        # exit(1)
         return properties["device"]

--- a/modm_devices/device_file.py
+++ b/modm_devices/device_file.py
@@ -11,6 +11,7 @@ import copy
 from collections import defaultdict
 
 from .device import Device
+from .stm32.device import Stm32Device
 from .device_identifier import DeviceIdentifier
 from .device_identifier import MultiDeviceIdentifier
 from .access import read_only
@@ -47,10 +48,14 @@ class DeviceFile:
         valid_devices = [node.text for node in device_node.iterfind(self._VALID_DEVICE)]
         devices = identifiers
         if len(invalid_devices):
-            devices = [did for did in devices if did.string not in invalid_devices]
+            devices = (did for did in devices if did.string not in invalid_devices)
         if len(valid_devices):
-            devices = [did for did in devices if did.string in valid_devices]
-        return [Device(did, self) for did in devices]
+            devices = (did for did in devices if did.string in valid_devices)
+        def build_device(did, device_file):
+            if did.platform == "stm32":
+                return Stm32Device(did, device_file)
+            return Device(did, device_file)
+        return [build_device(did, self) for did in devices]
 
     @staticmethod
     def is_valid(node, identifier: DeviceIdentifier):

--- a/modm_devices/device_identifier.py
+++ b/modm_devices/device_identifier.py
@@ -99,12 +99,14 @@ class MultiDeviceIdentifier:
 
         if isinstance(objs, DeviceIdentifier):
             self._ids = [objs.copy()]
-        if isinstance(objs, (list, set, tuple)):
+        elif isinstance(objs, (list, set, tuple)):
             for obj in objs:
-                if isinstance(objs, DeviceIdentifier):
-                    self._ids.append(objs)
-        if isinstance(objs, MultiDeviceIdentifier):
+                if isinstance(obj, DeviceIdentifier):
+                    self._ids.append(obj)
+        elif isinstance(objs, MultiDeviceIdentifier):
             self._ids = [dev for dev in objs.ids]
+        elif objs is not None:
+            print("No known conversion of '{}' to MultiDeviceIdentifier!".format(objs))
 
     @property
     def ids(self):
@@ -126,13 +128,14 @@ class MultiDeviceIdentifier:
         mid._ids = [dev for dev in device_ids]
         return mid
 
-    def append(self, did):
-        assert isinstance(did, DeviceIdentifier)
+    def append(self, *dids):
+        for did in dids:
+            assert isinstance(did, DeviceIdentifier)
 
-        self._ids.append(did)
-        self.__dirty = True
-        self.__string = None
-        self.__naming_schema = None
+            self._ids.append(did)
+            self.__dirty = True
+            self.__string = None
+            self.__naming_schema = None
 
     def extend(self, dids):
         assert isinstance(dids, (MultiDeviceIdentifier, list))

--- a/modm_devices/driver.py
+++ b/modm_devices/driver.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Niklas Hauser
+# All rights reserved.
+
+from collections import defaultdict
+from .cache import *
+
+class Instance:
+    def __init__(self, driver, instance):
+        self._instance = instance
+        self.driver = driver
+        self.name = self._instance["name"]
+        self.number = int(self.name) if self.name.isdigit() else self.name
+
+    def features(self, default=[]):
+        feats = self.driver.features()
+        feats.extend(self._instance.get("feature", []))
+        return feats if len(feats) else default
+
+    def __str__(self):
+        return self.name
+
+
+class Driver:
+    def __init__(self, device, driver):
+        self._driver = driver
+        self.device = device
+        self.name = self._driver["name"]
+        self.type = self._driver["type"]
+
+    def instances(self, default=[]):
+        if "instance" in self._driver:
+            return [Instance(self, i) for i in self._driver["instance"]]
+        return default
+
+    def features(self, default=[]):
+        if "feature" in self._driver:
+            return list(self._driver["feature"])
+        return default
+
+    def __str__(self):
+        return self.name

--- a/modm_devices/stm32/__init__.py
+++ b/modm_devices/stm32/__init__.py
@@ -1,0 +1,1 @@
+from . import device

--- a/modm_devices/stm32/core.py
+++ b/modm_devices/stm32/core.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Niklas Hauser
+# All rights reserved.
+
+from ..cache import cached_property
+from ..driver import Driver
+from collections import defaultdict
+
+class DriverCore(Driver):
+    def __init__(self, device):
+        Driver.__init__(self, device, device._find_first_driver("core"))
+
+
+    def vectors(self, filterfn=None):
+        vecs = (v["name"] for v in self._driver["vector"])
+        if filterfn is not None:
+            vecs = filter(filterfn, vecs)
+        return vecs
+
+
+    def instance_irq_map(self, name):
+        """
+        :return: a map from int(instance) to str(name) interrupt starting with {name}.
+        """
+        vector_map = defaultdict(list)
+        for vector in self.vectors(lambda v: v.startswith(name)):
+            vrange = sorted(int(d) for d in vector[len(name):].split("_") if d.isdigit())
+            if len(vrange) == 2:
+                vrange = list(range(vrange[0], vrange[1]+1))
+            for num in vrange:
+                # if num in vector_map:
+                #     raise ValueError("Instance '{}' already in '{}' map!".format(str(num), name))
+                vector_map[num].append(vector)
+        return vector_map
+
+
+    def shared_irqs(self, name):
+        """
+        :return: a map from str(name) to range(instances) >= 2 for interrupts starting with {name}.
+        """
+        vector_range = {}
+        for vector in self.vectors(lambda v: v.startswith(name)):
+            vrange = sorted(int(d) for d in vector[len(name):].split("_") if d.isdigit())
+            if len(vrange) <= 1:
+                continue;
+            if len(vrange) == 2:
+                vrange = list(range(vrange[0], vrange[1]+1))
+            if vector in vector_range:
+                raise ValueError("Vector '{}' already in '{}' map!".format(str(vector), name))
+            vector_range[vector] = vrange
+        return vector_range
+

--- a/modm_devices/stm32/device.py
+++ b/modm_devices/stm32/device.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016, Fabian Greif
+# Copyright (c) 2016, Niklas Hauser
+# All rights reserved.
+
+from .gpio import DriverGpio
+from .core import DriverCore
+from .flash import DriverFlash
+from ..device import Device
+from ..cache import cached_property
+from ..access import copy_keys
+
+
+class Stm32Device(Device):
+    def __init__(self, identifier, device_file):
+        Device.__init__(self, identifier, device_file)
+
+    @cached_property
+    def gpio(self):
+        return DriverGpio(self)
+
+    @cached_property
+    def core(self):
+        return DriverCore(self)
+
+    @cached_property
+    def flash(self):
+        return DriverFlash(self)
+
+    @cached_property
+    def peripherals(self):
+        all_peripherals = []
+        for s in self.gpio.signals_all:
+            d = copy_keys(s, "driver", "instance")
+            if len(d): all_peripherals.append(d);
+
+        # Signals are not enough, since there are peripherals that don't have signals.
+        # Example: STM32F401RE < 64pins: SPI4 cannot be connected to any pins.
+        for d in self._properties["driver"]:
+            driver = d["name"]
+            if driver in ["gpio", "core"]:
+                continue
+            elif "instance" in d:
+                all_peripherals.extend( {"driver": driver, "instance": int(i["name"])} for i in d["instance"] )
+            else:
+                all_peripherals.append( {"driver": driver} )
+
+        for r in self.gpio._driver.get("remap", {}):
+            d = copy_keys(r, "driver", "instance")
+            if len(d): all_peripherals.append(d);
+
+        return all_peripherals

--- a/modm_devices/stm32/flash.py
+++ b/modm_devices/stm32/flash.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Niklas Hauser
+# All rights reserved.
+
+from ..cache import cached_property
+from ..driver import Driver
+from collections import defaultdict
+
+class DriverFlash(Driver):
+    def __init__(self, device):
+        Driver.__init__(self, device, device._find_first_driver("flash"))
+
+
+    @cached_property
+    def wait_states(self):
+        """
+        :return: a map from int(min Vcore): [int(max F) for 0 wait states, ..., int(max F) for N wait states].
+        """
+        states = {}
+        for vcore in self._driver.get("latency", []):
+            states[int(vcore["vcore-min"])] = sorted([int(f["hclk-max"]) for f in vcore["wait-state"]])
+        return states

--- a/modm_devices/stm32/gpio.py
+++ b/modm_devices/stm32/gpio.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Niklas Hauser
+# All rights reserved.
+
+from collections import defaultdict
+from ..cache import *
+from ..access import copy_keys, copy_deep
+from ..driver import Driver
+
+class DriverGpio(Driver):
+    def __init__(self, device):
+        Driver.__init__(self, device, device._find_first_driver("gpio"))
+
+    @cached_property
+    def ranges(self):
+        """
+        Computes all port ranges on this device in the form of a map:
+
+        - "name": port.upper()
+        - "start": min(pin)
+        - "width": max(pin) - min(pin)
+
+        :return: a list of port ranges
+        """
+        ports = defaultdict(list)
+        for gpio in self._driver["gpio"]:
+            ports[gpio["port"]].append(int(gpio["pin"]))
+
+        ports = [{"name": k,
+                  "start": min(v),
+                  "width": max(v) - min(v) + 1}  for k,v in ports.items()]
+        ports.sort(key=lambda p: p["name"])
+        return ports
+
+    @cached_property
+    def ports(self):
+        """
+        Computes all ports on this device.
+
+        :return: a sorted unique list of ports in uppercase letters.
+        """
+        ports = set(p["port"] for p in self._driver["gpio"])
+        return list(sorted(ports))
+
+    @cached_property
+    def pins(self):
+        """
+        Computes all pins on this device.
+
+        :return: a sorted unique list of (port.upper(), int(pin)) tuples.
+        """
+        pins = set((p["port"], int(p["pin"])) for p in self._driver["gpio"])
+        return list(sorted(pins))
+
+    def signals(self, port, pin):
+        return self._signals.get((port.lower(), pin))
+
+    # @cached_function
+    def signals_by_name(self, port, pin):
+        signals = self.signals(port, pin)
+        names = defaultdict(list)
+        for s in signals:
+            names[s["name"]].append(s)
+        return dict(names)
+
+    @cached_property
+    def signals_remap(self):
+        return copy_deep(self._driver.get("remap", []))
+
+    @cached_property
+    def package_remap(self):
+        # Compute the set of remapped pins
+        remapped_gpios = {}
+        for p in self._driver["package"][0]["pin"]:
+            variant = p.get("variant", "")
+            if "remap" in variant:  # also matches "remap-default"
+                name = p["name"][1:4].strip().lower()
+                if len(name) > 2 and not name[2].isdigit():
+                    name = name[:2]
+                remapped_gpios[name] = (variant == "remap") # "remap-default" -> False
+        return remapped_gpios
+
+    @cached_property
+    def signals_group(self):
+        sgroup = defaultdict(list)
+        if "f1" in self.type:
+            # Convert the map from a list of signals to a list of pins
+            for remap in self._driver["remap"]:
+                for group in remap["group"]:
+                    for signal in group["signal"]:
+                        key = (signal["port"], int(signal["pin"]))
+
+                        for sig in sgroup[key]:
+                            if ((sig["driver"], sig.get("instance", 0)) ==
+                                    (remap["driver"], int(remap.get("instance", 0))) and
+                                    sig["name"] == signal["name"]):
+                                sig["group"].append(int(group["id"]))
+                                break
+                        else:
+                            sig = copy_keys(remap, "driver", ("instance", int))
+                            sig["name"] = signal["name"]
+                            sig["group"]= [int(group["id"])]
+                            sgroup[key].append(sig)
+        return dict(sgroup)
+
+
+    @cached_property
+    def signals_all(self):
+        asigs = list()
+        for signals in self._signals.values():
+            for s in signals:
+                asigs.append(copy_keys(s, "name", "driver", ("instance", int)))
+        return asigs
+
+    @cached_property
+    def _signals(self):
+        """
+        :return:
+        """
+        signals_map = {}
+        for gpio in self._driver["gpio"]:
+            key = (gpio["port"], int(gpio["pin"]))
+
+            raw_signals = copy_deep(gpio.get("signal", []))
+            # raw_signals = gpio.get("signal", [])
+            if key in self.signals_group:
+                raw_signals.extend(self.signals_group[key])
+
+            for s in raw_signals:
+                s.update(copy_keys(s, ("af", int), ("instance", int)))
+                s["is_analog"] = any(s.get("driver", "").startswith(p) for p in {"adc", "dac", "comp"})
+                if s.get("driver", "").startswith("adc") and s["name"].startswith("in"):
+                    s["analog_channel"] = int("".join(filter(str.isdigit, s["name"])))
+
+            signals_map[key] = raw_signals
+
+        # print(signals_map)
+        return signals_map
+
+

--- a/test/device_file_test.py
+++ b/test/device_file_test.py
@@ -1,0 +1,84 @@
+
+import unittest
+import glob
+import os
+
+import modm_devices.parser
+
+DEVICE_FILES = None
+
+class DeviceFileTest(unittest.TestCase):
+
+    def setUp(self):
+        global DEVICE_FILES
+        if DEVICE_FILES is None:
+            DEVICE_FILES = {}
+            device_files = os.path.join(os.path.dirname(__file__), "../devices/**/*.xml")
+            # device_files = os.path.join(os.path.dirname(__file__), "../devices/stm32/stm32l1-51_52_62-c_d_e.xml")
+            device_file_names  = glob.glob(device_files)
+
+            # Parse the files and build the :target enumeration
+            parser = modm_devices.parser.DeviceParser()
+            for device_file_name in device_file_names:
+                for device in parser.parse(device_file_name).get_devices():
+                    DEVICE_FILES[device.partname] = device
+
+        # self.devices = {"stm32l152vdt6": DEVICE_FILES["stm32l152vdt6"]}
+        self.devices = DEVICE_FILES
+
+
+    def tearDown(self):
+        self.devices = None
+
+    def get_drivers(self, device):
+        drivers = []
+        for d in device._properties["driver"]:
+            if "instance" in d:
+                drivers.extend( (d["name"], i["name"]) for i in d["instance"] )
+            else:
+                drivers.append( (d["name"],) )
+        return drivers
+
+    def test_drivers(self):
+        failures = 0
+        for name, device in self.devices.items():
+            def assertIn(key, obj):
+                if key not in obj:
+                    print('{}: Missing "{}" key in "{}"!'.format(name, key, obj))
+                    nonlocal failures
+                    failures += 1
+                    return False
+                return True
+            drivers = self.get_drivers(device)
+            gpios = device.get_driver("gpio")
+            assertIn("gpio", gpios)
+            for gpio in gpios.get("gpio", []):
+                signals = []
+                for signal in gpio.get("signal", []):
+                    # Check for name and driver keys in each signal
+                    assertIn("name", signal)
+                    if assertIn("driver", signal):
+                        # Check if the signal driver is known
+                        if "instance" in signal:
+                            driver = (signal["driver"], signal["instance"])
+                        else:
+                            driver = (signal["driver"],)
+                        signals.append( (*driver, signal["name"]) )
+                        # assertIn(driver, drivers)
+
+                # Check for duplicate signals
+                if not len(signals) == len(set(signals)):
+                    duplicates = set(x for x in signals if signals.count(x) > 1)
+                    print("{}: duplicated signals for P{}{}: {}".format(
+                            name, gpio["port"].upper(), gpio["pin"], duplicates))
+                    failures += 1
+                    # print(gpio)
+
+        # self.assertEqual(failures, 0, "Found inconsistencies in the device files!")
+
+
+
+
+
+
+

--- a/test/device_identifier_test.py
+++ b/test/device_identifier_test.py
@@ -1,0 +1,303 @@
+
+import unittest
+
+from modm_devices.exception import DeviceIdentifierException
+from modm_devices.device_identifier import DeviceIdentifier, MultiDeviceIdentifier
+
+class DeviceIdentifierTest(unittest.TestCase):
+
+    def test_should_construct_empty(self):
+        ident = DeviceIdentifier()
+        self.assertEqual(repr(ident), "DeviceId()")
+        self.assertEqual(len(ident.keys()), 0)
+        self.assertRaises(DeviceIdentifierException,
+                          lambda: ident.string)
+        self.assertRaises(DeviceIdentifierException,
+                          lambda: str(ident))
+        self.assertRaises(AttributeError,
+                          lambda: ident.whatevs)
+
+
+    def test_setter_getter(self):
+        ident = DeviceIdentifier()
+        ident.set("platform", "stm32")
+        self.assertEqual(ident.get("platform"), "stm32")
+        self.assertEqual(ident["platform"], "stm32")
+        self.assertEqual(ident.platform, "stm32")
+        self.assertEqual(repr(ident), "DeviceId(platformstm32)")
+        self.assertRaises(DeviceIdentifierException,
+                          lambda: ident.string)
+        self.assertRaises(DeviceIdentifierException,
+                          lambda: str(ident))
+
+        ident.set("platform", "avr")
+        self.assertEqual(ident.get("platform"), "avr")
+        self.assertEqual(ident["platform"], "avr")
+        self.assertEqual(ident.platform, "avr")
+
+        self.assertEqual(ident.get("whatevs"), None)
+        self.assertEqual(ident.get("whatevs", "default"), "default")
+        self.assertEqual(ident["whatevs"], None)
+        self.assertRaises(AttributeError,
+                          lambda: ident.whatevs)
+
+
+    def test_naming_schema(self):
+        ident = DeviceIdentifier("{platform}{family}{name}")
+        self.assertEqual(ident.string, "")
+        ident.set("platform", "stm32")
+        self.assertEqual(ident.string, "stm32")
+        ident.set("name", "03")
+        self.assertEqual(ident.string, "stm3203")
+        ident.set("family", "f1")
+        self.assertEqual(ident.string, "stm32f103")
+
+        self.assertEqual(str(ident), "stm32f103")
+        self.assertEqual(repr(ident), "stm32f103")
+        self.assertEqual(hash(ident), hash("familyf1name03platformstm32{platform}{family}{name}"))
+
+        ident2 = DeviceIdentifier("{platform}{family}{name}")
+        ident2.set("platform", "stm32")
+        ident2.set("family", "f1")
+        ident2.set("name", "03")
+        self.assertEqual(hash(ident2), hash("familyf1name03platformstm32{platform}{family}{name}"))
+
+        self.assertTrue(ident == ident2)
+        self.assertFalse(ident != ident2)
+        self.assertEqual(ident, ident2)
+
+        ident3 = DeviceIdentifier("{platform}{family}")
+        ident3.set("platform", "stm32")
+        ident3.set("family", "f1")
+        self.assertEqual(hash(ident3), hash("familyf1platformstm32{platform}{family}"))
+
+        self.assertTrue(ident != ident3)
+        self.assertFalse(ident == ident3)
+        self.assertNotEqual(ident, ident3)
+
+
+    def test_copy(self):
+        ident = DeviceIdentifier("{platform}")
+        ident.set("platform", "stm32")
+
+        ident2 = ident.copy()
+        self.assertEqual(ident2.platform, "stm32")
+        self.assertEqual(ident2.naming_schema, "{platform}")
+        ident2.set("platform", "avr")
+        self.assertEqual(ident2.platform, "avr")
+        self.assertEqual(ident.platform, "stm32")
+        ident2.naming_schema = "{platform}{family}"
+        self.assertEqual(ident2.naming_schema, "{platform}{family}")
+        self.assertEqual(ident.naming_schema, "{platform}")
+
+
+def id_from_string(string):
+    i = DeviceIdentifier("{platform}{family}{name}{pin}{size}{package}{temperature}{variant}")
+    i.set("platform", string[:5])
+    i.set("family", string[5:7])
+    i.set("name", string[7:9])
+    i.set("pin", string[9])
+    i.set("size", string[10])
+    i.set("package", string[11])
+    i.set("temperature", string[12])
+    if len(string) >= 14:
+        i.set("variant", string[13])
+    else:
+        i.set("variant", "")
+    return i
+
+
+class MultiDeviceIdentifierTest(unittest.TestCase):
+
+    def setUp(self):
+        self.ident = MultiDeviceIdentifier()
+        self.devices = MultiDeviceIdentifier(list(map(id_from_string, [
+            "stm32l151cct6",
+            "stm32l151cct7",
+            "stm32l151ccu6",
+            "stm32l151ccu7",
+            "stm32l151qch6",
+            "stm32l151qdh6",
+            "stm32l151qeh6",
+            "stm32l151rct6",
+            "stm32l151rct6a",
+            "stm32l151rcy6",
+            "stm32l151rdt6",
+            "stm32l151rdt7",
+            "stm32l151rdy6",
+            "stm32l151rdy7",
+            "stm32l151ret6",
+            "stm32l151ucy6",
+            "stm32l151ucy7",
+            "stm32l151vch6",
+            "stm32l151vct6",
+            "stm32l151vct6a",
+            "stm32l151vdt6",
+            "stm32l151vdt6x",
+            "stm32l151vdy6x",
+            "stm32l151vdy7x",
+            "stm32l151vet6",
+            "stm32l151vet7",
+            "stm32l151vey6",
+            "stm32l151vey7",
+            "stm32l151zct6",
+            "stm32l151zdt6",
+            "stm32l151zet6",
+            "stm32l152cct6",
+            "stm32l152ccu6",
+            "stm32l152qch6",
+            "stm32l152qdh6",
+            "stm32l152qeh6",
+            "stm32l152rct6",
+            "stm32l152rct6a",
+            "stm32l152rdt6",
+            "stm32l152rdy6",
+            "stm32l152ret6",
+            "stm32l152ucy6",
+            "stm32l152vch6",
+            "stm32l152vct6",
+            "stm32l152vct6a",
+            "stm32l152vdt6",
+            "stm32l152vdt6x",
+            "stm32l152vet6",
+            "stm32l152vey6",
+            "stm32l152zct6",
+            "stm32l152zdt6",
+            "stm32l152zet6",
+            "stm32l162qdh6",
+            "stm32l162rct6",
+            "stm32l162rct6a",
+            "stm32l162rdt6",
+            "stm32l162rdy6",
+            "stm32l162ret6",
+            "stm32l162vch6",
+            "stm32l162vct6",
+            "stm32l162vct6a",
+            "stm32l162vdt6",
+            "stm32l162vdy6x",
+            "stm32l162vet6",
+            "stm32l162vey6",
+            "stm32l162zdt6",
+            "stm32l162zet6"
+        ])))
+        self.child_devices = MultiDeviceIdentifier(list(map(id_from_string, [
+            "stm32l152qch6",
+            "stm32l152qdh6",
+            "stm32l152qeh6",
+            "stm32l152vch6",
+            "stm32l152rct6a",
+            "stm32l152rdt6",
+            "stm32l152ret6",
+            "stm32l152vct6a",
+            "stm32l152vct6",
+            "stm32l152vdt6x",
+            "stm32l152vdt6",
+            "stm32l152vet6",
+            "stm32l152zct6",
+            "stm32l152zdt6",
+            "stm32l152zet6",
+            "stm32l152rdy6",
+            "stm32l152vey6",
+            "stm32l162qdh6",
+            "stm32l162vch6",
+            "stm32l162rct6a",
+            "stm32l162rdt6",
+            "stm32l162ret6",
+            "stm32l162vct6a",
+            "stm32l162vct6",
+            "stm32l162vdt6",
+            "stm32l162vet6",
+            "stm32l162zdt6",
+            "stm32l162zet6",
+            "stm32l162rdy6",
+            "stm32l162vdy6x",
+            "stm32l162vey6",
+        ])))
+        self.parent_devices = MultiDeviceIdentifier(list(map(id_from_string, [
+            "stm32l151qch6",
+            "stm32l151qdh6",
+            "stm32l151qeh6",
+            "stm32l151vch6",
+            "stm32l151rct6a",
+            "stm32l151rct6",
+            "stm32l151rdt6",
+            "stm32l151rdt7",
+            "stm32l151ret6",
+            "stm32l151vct6a",
+            "stm32l151vct6",
+            "stm32l151vdt6x",
+            "stm32l151vdt6",
+            "stm32l151vet6",
+            "stm32l151vet7",
+            "stm32l151zct6",
+            "stm32l151zdt6",
+            "stm32l151zet6",
+            "stm32l151rcy6",
+            "stm32l151rdy6",
+            "stm32l151rdy7",
+            "stm32l151ucy6",
+            "stm32l151ucy7",
+            "stm32l151vdy6x",
+            "stm32l151vdy7x",
+            "stm32l151vey6",
+            "stm32l151vey7",
+            "stm32l152qch6",
+            "stm32l152qdh6",
+            "stm32l152qeh6",
+            "stm32l152vch6",
+            "stm32l152rct6a",
+            "stm32l152rct6",
+            "stm32l152rdt6",
+            "stm32l152ret6",
+            "stm32l152vct6a",
+            "stm32l152vct6",
+            "stm32l152vdt6x",
+            "stm32l152vdt6",
+            "stm32l152vet6",
+            "stm32l152zct6",
+            "stm32l152zdt6",
+            "stm32l152zet6",
+            "stm32l152rdy6",
+            "stm32l152ucy6",
+            "stm32l152vey6",
+            "stm32l162qdh6",
+            "stm32l162vch6",
+            "stm32l162rct6a",
+            "stm32l162rct6",
+            "stm32l162rdt6",
+            "stm32l162ret6",
+            "stm32l162vct6a",
+            "stm32l162vct6",
+            "stm32l162vdt6",
+            "stm32l162vet6",
+            "stm32l162zdt6",
+            "stm32l162zet6",
+            "stm32l162rdy6",
+            "stm32l162vdy6x",
+            "stm32l162vey6",
+        ])))
+
+    def test_should_construct_empty(self):
+        self.assertEqual(self.ident.string, "")
+        self.assertEqual(self.ident.naming_schema, "")
+
+    def test_should_merge_naming_schemas(self):
+
+        self.ident.append(DeviceIdentifier("{one}"))
+        self.assertEqual(self.ident.naming_schema, "{one}")
+
+        self.ident.append(DeviceIdentifier("{one}"))
+        self.assertEqual(self.ident.naming_schema, "{one}")
+
+        self.ident.append(DeviceIdentifier("{one}{two}"))
+        self.assertEqual(self.ident.naming_schema, "{one}{one}{two}")
+
+    # def test_minimal_subtract_set(self):
+    #     print(self.devices)
+    #     print(self.parent_devices)
+    #     print(self.child_devices)
+
+    #     min_set = self.child_devices.minimal_subtract_set(self.devices, self.parent_devices)
+    #     for m in min_set:
+    #         print([(k, m.getAttribute(k)) for k in self.devices.keys() if m.getAttribute(k)])
+    #     self.assertEqual(min_set, "[f1]")

--- a/tools/generator/dfg/avr/avr_device_tree.py
+++ b/tools/generator/dfg/avr/avr_device_tree.py
@@ -237,10 +237,10 @@ class AVRDeviceTree:
             driver.setAttributes("name", dtype, "type", compatible)
             # Add all instances to this driver
             if any(i != dtype for i in instances):
-                driver.addSortKey(lambda e: e["value"])
+                driver.addSortKey(lambda e: e["name"])
                 for i in instances:
                     inst = driver.addChild("instance")
-                    inst.setValue(i[len(dtype):])
+                    inst.setAttribute("name", i[len(dtype):])
 
         # GPIO driver
         gpio_driver = tree.addChild("driver")

--- a/tools/generator/dfg/device_tree.py
+++ b/tools/generator/dfg/device_tree.py
@@ -119,20 +119,23 @@ class DeviceTree:
         for ch in self.children:
             ch._sortTree()
 
-    def toString(self, indent=0):
+    def toString(self, indent=0, long_ids=False):
         ind = ' ' * indent
         if indent >= 2:
             ind = ind[:-2] + '. '
         if self.parent is None or self.parent.ids == self.ids:
             ident = ""
         else:
-            ident = self.ids.string
+            if long_ids:
+                ident = " ".join(did.string for did in self.ids)
+            else:
+                ident = self.ids.string
         string = "{}{} {}\n".format(
             ind,
             self._toCompactString(),
             ident)
         for ch in self.children:
-            string += ch.toString(indent + 2)
+            string += ch.toString(indent + 2, long_ids)
         return string
 
     def _toCompactString(self):

--- a/tools/generator/dfg/nrf/nrf_device_tree.py
+++ b/tools/generator/dfg/nrf/nrf_device_tree.py
@@ -243,10 +243,10 @@ class NRFDeviceTree:
             driver.setAttributes('name', dtype, 'type', compatible)
             # Add all instances to this driver
             if any(i != dtype for i in instances):
-                driver.addSortKey(lambda e: e['value'])
+                driver.addSortKey(lambda e: e['name'])
                 for i in instances:
                     inst = driver.addChild('instance')
-                    inst.setValue(i[len(dtype):])
+                    inst.setAttribute("name", i[len(dtype):])
 
         # GPIO driver
         gpio_driver = tree.addChild('driver')

--- a/tools/generator/dfg/sam/sam_device_tree.py
+++ b/tools/generator/dfg/sam/sam_device_tree.py
@@ -226,10 +226,10 @@ class SAMDeviceTree:
             driver.setAttributes("name", dtype, "type", compatible)
             # Add all instances to this driver
             if any(i != dtype for i in instances):
-                driver.addSortKey(lambda e: e["value"])
+                driver.addSortKey(lambda e: e["name"])
                 for i in instances:
                     inst = driver.addChild("instance")
-                    inst.setValue(i[len(dtype):])
+                    inst.setAttribute("name", i[len(dtype):])
 
         # GPIO driver
         gpio_driver = tree.addChild("driver")

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -57,16 +57,14 @@ class STMDeviceTree:
 
     @staticmethod
     def _properties_from_partname(partname):
-        p = {}
+        did = STMIdentifier.from_string(partname.lower())
+        LOGGER.info("Parsing '{}'".format(did.string))
+        p = {"id": did}
 
         deviceNames = STMDeviceTree.familyFile.query('//Family/SubFamily/Mcu[starts-with(@RefName,"{}")]'
                                                      .format(partname[:12] + "x" + partname[13:]))
         comboDeviceName = sorted([d.get("Name") for d in deviceNames])[0]
         device_file = XMLReader(os.path.join(STMDeviceTree.rootpath, comboDeviceName + ".xml"))
-        did = STMIdentifier.from_string(partname.lower())
-        p["id"] = did
-
-        LOGGER.info("Parsing '{}'".format(did.string))
 
         # information about the core and architecture
         core = device_file.query('//Core')[0].text.lower().replace("arm ", "")

--- a/tools/generator/dfg/stm32/stm_header.py
+++ b/tools/generator/dfg/stm32/stm_header.py
@@ -86,6 +86,11 @@ class STMHeader:
             STMHeader.CACHE_HEADER[self.header_file]["defines"] = self._get_defines()
         return STMHeader.CACHE_HEADER[self.header_file]["defines"]
 
+    def get_filtered_defines(self):
+        if "filtered_defines" not in STMHeader.CACHE_HEADER[self.header_file]:
+            STMHeader.CACHE_HEADER[self.header_file]["filtered_defines"] = self._get_filtered_defines()
+        return STMHeader.CACHE_HEADER[self.header_file]["filtered_defines"]
+
     def get_memory_map(self):
         if "memmap" not in STMHeader.CACHE_HEADER[self.header_file]:
             STMHeader.CACHE_HEADER[self.header_file]["memmap"] = self._get_memmap()
@@ -128,7 +133,7 @@ class STMHeader:
         # create the destination directory
         destination = (STMHeader.CACHE_PATH / self.family_folder / self.header_file).with_suffix(".cpp").absolute()
         executable = destination.with_suffix("")
-        defines = self._get_filtered_defines()
+        defines = self.get_filtered_defines()
         if not executable.exists():
             # generate the cpp file from the template
             LOGGER.info("Generating {} ...".format(destination.name))

--- a/tools/generator/dfg/stm32/stm_peripherals.py
+++ b/tools/generator/dfg/stm32/stm_peripherals.py
@@ -12,38 +12,31 @@ stm_peripherals = \
             {
                 'hardware': 'stm32-f0',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['f0']}]
             },{
                 'hardware': 'stm32-l0',
                 'features': ['oversampler', 'calfact', 'prescaler'],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['l0']}]
             },{
                 'hardware': 'stm32-g0',
                 'features': ['oversampler', 'calfact', 'prescaler'],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['g0']}]
             },{
                 # F373 & F378 has a non-special ADC
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['f3'], 'name': ['73', '78']}]
             },{
                 'hardware': 'stm32-f3',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['f3', 'l4', 'g4', 'wb']}]
             },{
                 'hardware': 'stm32-h7',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['h7']}]
             },{
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': '*'
             }
         ]
@@ -54,7 +47,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32-f3',
                 'features': [],
-                'protocols': ['analog-in'],
                 'devices': [{'family': ['f3']}]
             }
         ]
@@ -66,13 +58,11 @@ stm_peripherals = \
                 # 14 shared filters
                 'hardware': 'stm32',
                 'features': ['filter-14'],
-                'protocols': ['can-v2.0a', 'can-v2.0b'],
                 'devices': [{'family': ['f0', 'g0', 'f1']}]
             },{
                 # 28 shared filters
                 'hardware': 'stm32',
                 'features': ['filter-28'],
-                'protocols': ['can-v2.0a', 'can-v2.0b'],
                 'devices': '*'
             }
         ]
@@ -83,7 +73,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -95,19 +84,16 @@ stm_peripherals = \
                 # Custom polynomial and reverse data
                 'hardware': 'stm32',
                 'features': ['polynomial', 'reverse'],
-                'protocols': ['crc32'],
                 'devices': [{'family': ['f0', 'f3', 'f7', 'h7']}]
             },{
                 # Custom polynomial and reverse data
                 'hardware': 'stm32',
                 'features': ['reverse'],
-                'protocols': ['crc32'],
                 'devices': [{'family': ['g0', 'g4']}]
             },{
                 # no poly size
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': ['crc32'],
                 'devices': '*'
             }
         ]
@@ -118,25 +104,21 @@ stm_peripherals = \
             {
                 'hardware': 'stm32-mux',
                 'features': [],
-                'protocols': ['mem2mem', 'mem2per', 'per2per'],
                 'devices': [{'family': ['h7', 'g0', 'g4', 'wb']}, {'family': ['l4'], 'name': ['p5', 'p7', 'p9', 'q5', 'q7', 'q9', 'r5', 'r7', 'r9', 's5', 's7', 's9']}]
             },
             {
                 'hardware': 'stm32-stream-channel',
                 'features': [],
-                'protocols': ['mem2mem', 'mem2per', 'per2per'],
                 'devices': [{'family': ['f2', 'f4', 'f7']}]
             },
             {
                 'hardware': 'stm32-channel-request',
                 'features': [],
-                'protocols': ['mem2mem', 'mem2per', 'per2per'],
                 'devices': [{'family': ['l0', 'l4']}, {'family': ['f0'], 'name': ['91', '98']}, {'family': ['f0'], 'name': ['30'], 'size': ['c']}]
             },
             {
                 'hardware': 'stm32-channel',
                 'features': [],
-                'protocols': ['mem2mem', 'mem2per', 'per2per'],
                 'devices': '*'
             }
         ]
@@ -147,12 +129,10 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': ['window'],
-                'protocols': [],
                 'devices': [{'family': ['f0', 'f3', 'f7', 'g0', 'g4', 'wb']}]
             },{
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -162,13 +142,7 @@ stm_peripherals = \
         'groups': [
             {
                 'hardware': 'stm32',
-                'features': ['data-size', 'nss-pulse', 'fifo'],
-                'protocols': [],
-                'devices': [{'family': ['f0', 'g0', 'f3', 'f7', 'l4', 'g4', 'wb']}]
-            },{
-                'hardware': 'stm32',
-                'features': [],
-                'protocols': [],
+                'features': {'data-size':'SPI_CR2_DS_3', 'fifo':'SPI_SR_FRLVL'},
                 'devices': '*'
             }
         ]
@@ -179,12 +153,10 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': [{'family': ['f1']}]
             },{
                 'hardware': 'stm32',
                 'features': ['status'],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -195,7 +167,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -206,7 +177,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -217,7 +187,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -229,7 +198,6 @@ stm_peripherals = \
                 {
                     'hardware': 'stm32-advanced',
                     'features': [],
-                    'protocols': [],
                     'devices': '*'
                 }
             ]
@@ -239,7 +207,6 @@ stm_peripherals = \
                 {
                     'hardware': 'stm32-general-purpose',
                     'features': [],
-                    'protocols': [],
                     'devices': '*'
                 }
             ]
@@ -249,7 +216,6 @@ stm_peripherals = \
                 {
                     'hardware': 'stm32-general-purpose',
                     'features': [],
-                    'protocols': [],
                     'devices': '*'
                 }
             ]
@@ -259,7 +225,6 @@ stm_peripherals = \
                 {
                     'hardware': 'stm32-basic',
                     'features': [],
-                    'protocols': [],
                     'devices': '*'
                 }
             ]
@@ -272,32 +237,26 @@ stm_peripherals = \
                 # Registers are called AFIO, not SYS!
                 'hardware': 'stm32-f1',
                 'features': ['exti', 'remap'],
-                'protocols': [],
                 'devices': [{'family': ['f1']}]
             },{
                 'hardware': 'stm32',
                 'features': ['exti', 'fpu', 'ccm-wp', 'cfgr2'],
-                'protocols': [],
                 'devices': [{'family': ['f3', 'g4']}]
             },{
                 'hardware': 'stm32',
                 'features': ['exti', 'sram2-wp', 'cfgr2', 'imr'],
-                'protocols': [],
                 'devices': [{'family': ['wb']}]
             },{
                 'hardware': 'stm32',
                 'features': ['exti', 'cfgr2', 'itline'],
-                'protocols': [],
                 'devices': [{'family': ['f0'], 'name': ['91', '98']}, {'family': ['g0']}]
             },{
                 'hardware': 'stm32',
                 'features': ['exti', 'cfgr2'],
-                'protocols': [],
                 'devices': [{'family': ['f0']}]
             },{
                 'hardware': 'stm32',
                 'features': ['exti'],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -308,7 +267,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': ['2d', 'blitter'],
                 'devices': '*'
             }
         ]
@@ -319,7 +277,6 @@ stm_peripherals = \
             {
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': [],
                 'devices': '*'
             }
         ]
@@ -333,12 +290,10 @@ stm_peripherals = \
                     # Some F4 have a digital noise filter
                     'hardware': 'stm32',
                     'features': ['dnf'],
-                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
                     'devices': [{'family': ['f4'], 'name': ['27', '29', '37', '39', '46', '69', '79']}]
                 },{
                     'hardware': 'stm32',
                     'features': [],
-                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
                     'devices': [{'family': ['f1', 'f2', 'f4', 'l1']}]
                 }
             ]
@@ -350,7 +305,6 @@ stm_peripherals = \
                     # This hardware supports neither FM+ (1 Mhz) nor SMBus
                     'hardware': 'stm32-extended',
                     'features': ['dnf'],
-                    'protocols': ['i2c-v3.0'],
                     'devices': [
                         {
                             'family': ['f0'],
@@ -365,13 +319,11 @@ stm_peripherals = \
                     # This hardware supports FM+ (1 Mhz) but not SMBus
                     'hardware': 'stm32-extended',
                     'features': ['dnf', 'fmp'],
-                    'protocols': ['i2c-v3.0'],
                     'devices': [{'family': ['f0', 'g0', 'l0']}]
                 },{
                     # This hardware supports FM+ (1 Mhz) and SMBus
                     'hardware': 'stm32-extended',
                     'features': ['dnf', 'fmp'],
-                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
                     'devices': [{'family': ['f3', 'f7', 'l4', 'h7', 'g4', 'wb']}]
                 }
             ]
@@ -383,7 +335,6 @@ stm_peripherals = \
                     # This hardware supports FM+ (1 Mhz) and SMBus
                     'hardware': 'stm32-extended',
                     'features': ['dnf', 'fmp'],
-                    'protocols': ['i2c-v3.0', 'smb-v2.0', 'pmb-v1.1'],
                     'devices': [{'family': ['f0', 'g0', 'f3', 'f7', 'l0', 'l4', 'h7', 'g4', 'wb']}]
                 }
             ]
@@ -394,28 +345,11 @@ stm_peripherals = \
         'groups': [
             {
                 'hardware': 'stm32-extended',
-                'features': ['wakeup'],
-                'protocols': ['uart'],
-                'devices': [{'family': ['f0', 'f3']}]
-            },{
-                'hardware': 'stm32-extended',
-                'features': ['tcbgt'],
-                'protocols': ['uart'],
-                'devices': [{'family': ['l4'], 'name': ['p5', 'p7', 'p9', 'q5', 'q7', 'q9', 'r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'g4', 'wb']}]
-            },{
-                'hardware': 'stm32-extended',
-                'features': [],
-                'protocols': ['uart'],
-                'devices': [{'family': ['f7', 'l4']}]
+                'features': {'swap': 'USART_CR2_SWAP', 'over8': 'USART_CR1_OVER8', 'half-duplex': 'USART_CR3_HDSEL', '7-bit': 'USART_CR1_M1', 'tcbgt': 'USART_CR1_RXNEIE_RXFNEIE'},
+                'devices': [{'family': ['f0', 'f3', 'f7', 'l4', 'g0', 'g4', 'wb']}]
             },{
                 'hardware': 'stm32',
-                'features': ['over8'],
-                'protocols': ['uart'],
-                'devices': [{'family': ['f2', 'f4']}]
-            },{
-                'hardware': 'stm32',
-                'features': [],
-                'protocols': ['uart'],
+                'features': {'swap': 'USART_CR2_SWAP', 'over8': 'USART_CR1_OVER8', 'half-duplex': 'USART_CR3_HDSEL', '7-bit': 'USART_CR1_M1', 'tcbgt': 'USART_CR1_RXNEIE_RXFNEIE'},
                 'devices': '*'
             }
         ]
@@ -425,28 +359,11 @@ stm_peripherals = \
         'groups': [
             {
                 'hardware': 'stm32-extended',
-                'features': ['wakeup'],
-                'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['f0', 'f3']}]
-            },{
-                'hardware': 'stm32-extended',
-                'features': ['tcbgt'],
-                'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['l4'], 'name': ['p5', 'p7', 'p9', 'q5', 'q7', 'q9', 'r5', 'r7', 'r9', 's5', 's7', 's9']}, {'family': ['g0', 'g4', 'wb']}]
-            },{
-                'hardware': 'stm32-extended',
-                'features': [],
-                'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['f7', 'l4']}]
+                'features': {'swap': 'USART_CR2_SWAP', 'over8': 'USART_CR1_OVER8', 'half-duplex': 'USART_CR3_HDSEL', '7-bit': 'USART_CR1_M1', 'tcbgt': 'USART_CR1_RXNEIE_RXFNEIE'},
+                'devices': [{'family': ['f0', 'f3', 'f7', 'l4', 'g0', 'g4', 'wb']}]
             },{
                 'hardware': 'stm32',
-                'features': ['over8'],
-                'protocols': ['uart', 'spi'],
-                'devices': [{'family': ['f2', 'f4']}]
-            },{
-                'hardware': 'stm32',
-                'features': [],
-                'protocols': ['uart', 'spi'],
+                'features': {'swap': 'USART_CR2_SWAP', 'over8': 'USART_CR1_OVER8', 'half-duplex': 'USART_CR3_HDSEL', '7-bit': 'USART_CR1_M1', 'tcbgt': 'USART_CR1_RXNEIE_RXFNEIE'},
                 'devices': '*'
             }
         ]
@@ -458,26 +375,37 @@ stm_peripherals = \
                 # The F1 remaps groups of pins
                 'hardware': 'stm32-f1',
                 'features': [],
-                'protocols': ['digital-in', 'digital-out', 'open-drain', 'exti'],
                 'devices': [{'family': ['f1']}]
             },{
                 # The rest remaps pins individually
                 'hardware': 'stm32',
                 'features': [],
-                'protocols': ['digital-in', 'digital-out', 'open-drain', 'exti'],
                 'devices': '*'
             }
         ]
     }]
 }
 
-def getPeripheralData(did, module):
+def resolvePeripheralFeatures(header, feature_map, module):
+    if isinstance(feature_map, list):
+        return []
+
+    name, instance, version = module
+    features = set()
+    for feature, registers in feature_map.items():
+        if not isinstance(registers, list): registers = [registers];
+        if any(r.format(n=name, i=instance) in header.get_filtered_defines() for r in registers):
+            features.add(feature)
+
+    return list(features)
+
+def getPeripheralData(did, module, header):
     name, inst, version = module
     if name in stm_peripherals:
         for instance_list in stm_peripherals[name]:
             if instance_list['instances'] == '*' or inst[len(name):] in instance_list['instances']:
                 for group in instance_list['groups']:
                     if group['devices'] == '*' or DeviceMerger._get_index_for_id(group['devices'], did) >= 0:
-                        return (group['hardware'], group['features'], group['protocols'])
+                        return (group['hardware'], resolvePeripheralFeatures(header, group['features'], module))
 
-    return ('stm32-' + version, [], [])
+    return ('stm32-' + version, [])


### PR DESCRIPTION
This is the initial exploration of what a shared API for accessing device file data could look like.
The goal is to decouple the device file data from the underlying format, and to move common algorithms for computing implicit data out of the using library (here modm modules) into modm-devices and to create a proper documented and versioned Python API.

Note: This is all *very* experimental, even if the technical side of this (ie. moving code) is simple, everything around it (docs, versioning, hosting) is not.

TODO:
- [x] GPIO driver
- [x] Core driver
- [ ] Dma driver
- [x] Common driver base class for all other basic classes, incl. features and instances access
- [ ] Documentation of the whole API via docstrings
- [ ] Hosting documentation on [data.modm.io](https://data.modm.io) and local docs
- [ ] Move DeviceFile Cache from modm to here
- [ ] Explore how to do proper API versioning
- [x] Device file consistency checks
  - [x] Every GPIO signal must have a driver and name key
  - [x] GPIO signals must be unique

cc @rleh @chris-durand @strongly-typed @mikewolfram @dergraaf 