### PR TITLE
Add pinout for package information to STM32 devices

### DIFF
--- a/devices/stm32/stm32f0-30.xml
+++ b/devices/stm32/stm32f0-30.xml
@@ -924,6 +924,188 @@
         <signal device-pin="c" device-size="6" driver="i2c" instance="1" name="sda"/>
         <signal device-size="8" driver="i2c" instance="2" name="sda"/>
       </gpio>
+      <package device-pin="k" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin device-size="6|8" position="3" name="PC14-OSC32_IN"/>
+        <pin device-size="c" position="3" name="PC14OSC32_IN"/>
+        <pin device-size="6|8" position="4" name="PC15-OSC32_OUT"/>
+        <pin device-size="c" position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin device-size="6|8" position="35" name="PF6"/>
+        <pin device-size="c" position="35" name="VSS" type="power"/>
+        <pin device-size="6|8" position="36" name="PF7"/>
+        <pin device-size="c" position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin device-size="8" position="3" name="PC14-OSC32_IN"/>
+        <pin device-size="c" position="3" name="PC14OSC32_IN"/>
+        <pin device-size="8" position="4" name="PC15-OSC32_OUT"/>
+        <pin device-size="c" position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin device-size="8" position="18" name="PF4"/>
+        <pin device-size="c" position="18" name="VSS" type="power"/>
+        <pin device-size="8" position="19" name="PF5"/>
+        <pin device-size="c" position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin device-size="8" position="47" name="PF6"/>
+        <pin device-size="c" position="47" name="VSS" type="power"/>
+        <pin device-size="8" position="48" name="PF7"/>
+        <pin device-size="c" position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-31.xml
+++ b/devices/stm32/stm32f0-31.xml
@@ -394,6 +394,203 @@
       <gpio device-pin="c" port="f" pin="7">
         <signal driver="i2c" instance="1" name="sda"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin position="25" name="PB4"/>
+        <pin position="26" name="PB5"/>
+        <pin position="27" name="PB6"/>
+        <pin position="28" name="PB7"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="e" name="WLCSP25">
+        <pin position="A1" name="PA13"/>
+        <pin position="A2" name="PA14"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PF0-OSC_IN"/>
+        <pin position="B1" name="PA10"/>
+        <pin position="B2" name="PB6"/>
+        <pin position="B3" name="PA4"/>
+        <pin position="B4" name="PA0"/>
+        <pin position="B5" name="PF1-OSC_OUT"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PB5"/>
+        <pin position="C3" name="PA5"/>
+        <pin position="C4" name="PA1"/>
+        <pin position="C5" name="NRST" type="reset"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PA6"/>
+        <pin position="D4" name="PA2"/>
+        <pin position="D5" name="VDDA" type="power"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="PB1"/>
+        <pin position="E3" name="PB0"/>
+        <pin position="E4" name="PA7"/>
+        <pin position="E5" name="PA3"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-38.xml
+++ b/devices/stm32/stm32f0-38.xml
@@ -375,6 +375,169 @@
       <gpio device-pin="c" port="f" pin="7">
         <signal driver="i2c" instance="1" name="sda"/>
       </gpio>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="NPOR" type="power"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="NPOR" type="power"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin position="25" name="PB4"/>
+        <pin position="26" name="PB5"/>
+        <pin position="27" name="PB6"/>
+        <pin position="28" name="PB7"/>
+      </package>
+      <package device-pin="k" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="NPOR" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="e" name="WLCSP25">
+        <pin position="A1" name="PA13"/>
+        <pin position="A2" name="PA14"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PF0-OSC_IN"/>
+        <pin position="B1" name="PA10"/>
+        <pin position="B2" name="PB6"/>
+        <pin position="B3" name="PA4"/>
+        <pin position="B4" name="PA0"/>
+        <pin position="B5" name="PF1-OSC_OUT"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PB5"/>
+        <pin position="C3" name="PA5"/>
+        <pin position="C4" name="PA1"/>
+        <pin position="C5" name="NRST" type="reset"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PA6"/>
+        <pin position="D4" name="PA2"/>
+        <pin position="D5" name="VDDA" type="power"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="PB1"/>
+        <pin position="E3" name="PB0"/>
+        <pin position="E4" name="PA7"/>
+        <pin position="E5" name="PA3"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-42.xml
+++ b/devices/stm32/stm32f0-42.xml
@@ -308,22 +308,22 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|k|t" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
-        <signal af="1" driver="usart" instance="1" name="cts"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="4" driver="can" name="rx"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|k|t" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
-        <signal af="1" driver="usart" instance="1" name="de"/>
-        <signal af="1" driver="usart" instance="1" name="rts"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="de"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
         <signal af="4" driver="can" name="tx"/>
-        <signal af="5" driver="i2c" instance="1" name="sda"/>
+        <signal device-pin="c|k|t" af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>
@@ -466,6 +466,268 @@
       </gpio>
       <gpio device-pin="c" device-package="t|u" port="f" pin="11"/>
       <gpio device-pin="k" device-package="u" port="f" pin="11"/>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDDIO2" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB8"/>
+        <pin position="32" name="VSSA" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="PB8"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSSA" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="17" name="PA11" variant="remap"/>
+        <pin position="18" name="PA10"/>
+        <pin position="18" name="PA12" variant="remap"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="PB8"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSSA" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="VDDIO2" type="power"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="PA11" variant="remap"/>
+        <pin position="20" name="PA10"/>
+        <pin position="20" name="PA12" variant="remap"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin position="25" name="PB4"/>
+        <pin position="26" name="PB5"/>
+        <pin position="27" name="PB6"/>
+        <pin position="28" name="PB7"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDDIO2" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PF11"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA12"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB4"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VDD" type="power"/>
+        <pin position="A6" name="PC13"/>
+        <pin position="B1" name="PA13"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PF0-OSC_IN"/>
+        <pin position="B6" name="PC14OSC32_IN"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA4"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PF1-OSC_OUT"/>
+        <pin position="C6" name="PC15OSC32_OUT"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PB2"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA1"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="VSSA" type="power"/>
+        <pin position="E1" name="VDDIO2" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="VDDA" type="power"/>
+        <pin position="E6" name="PB5"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PB1"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-48.xml
+++ b/devices/stm32/stm32f0-48.xml
@@ -288,20 +288,20 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|t" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|t" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
-        <signal af="5" driver="i2c" instance="1" name="sda"/>
+        <signal device-pin="c|t" af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>
@@ -432,6 +432,126 @@
         <signal af="1" driver="i2c" instance="1" name="scl"/>
       </gpio>
       <gpio device-pin="c" port="f" pin="11"/>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="PB8"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="NPOR" type="power"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="VDDIO2" type="power"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="PA11" variant="remap"/>
+        <pin position="20" name="PA10"/>
+        <pin position="20" name="PA12" variant="remap"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin position="25" name="PB4"/>
+        <pin position="26" name="PB5"/>
+        <pin position="27" name="PB6"/>
+        <pin position="28" name="PB7"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA12"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB4"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VDD" type="power"/>
+        <pin position="A6" name="PC13"/>
+        <pin position="B1" name="PA13"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PF0-OSC_IN"/>
+        <pin position="B6" name="PC14OSC32_IN"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA4"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PF1-OSC_OUT"/>
+        <pin position="C6" name="PC15OSC32_OUT"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="NPOR" type="power"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA1"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="E1" name="VDDIO2" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="VDDA" type="power"/>
+        <pin position="E6" name="PB5"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PB1"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-51.xml
+++ b/devices/stm32/stm32f0-51.xml
@@ -566,6 +566,344 @@
       <gpio device-pin="c|r" port="f" pin="7">
         <signal device-pin="c|r" device-size="8" driver="i2c" instance="2" name="sda"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PF4"/>
+        <pin position="19" name="PF5"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="PF6"/>
+        <pin position="48" name="PF7"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="PF4"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="PF5"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="PF6"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="PF7"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA12"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB4"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VDD" type="power"/>
+        <pin position="A6" name="PC13"/>
+        <pin position="B1" name="PA13"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB3"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PF0-OSC_IN"/>
+        <pin position="B6" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA4"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PF1-OSC_OUT"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PB2"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA1"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="VSSA" type="power"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="VDDA" type="power"/>
+        <pin position="E6" name="PB5"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PB1"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-58.xml
+++ b/devices/stm32/stm32f0-58.xml
@@ -504,6 +504,226 @@
       <gpio device-pin="c|r" port="f" pin="7">
         <signal driver="i2c" instance="2" name="sda"/>
       </gpio>
+      <package device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PF4"/>
+        <pin position="19" name="PF5"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="NPOR" type="power"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="PF6"/>
+        <pin position="48" name="PF7"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="PF4"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="PF5"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="PF6"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="PF7"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="NPOR" type="power"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA12"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB4"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VDD" type="power"/>
+        <pin position="A6" name="PC13"/>
+        <pin position="B1" name="PA13"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB3"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PF0-OSC_IN"/>
+        <pin position="B6" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA4"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PF1-OSC_OUT"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="NPOR" type="power"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA1"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="VSSA" type="power"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="VDDA" type="power"/>
+        <pin position="E6" name="PB5"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PB1"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-70.xml
+++ b/devices/stm32/stm32f0-70.xml
@@ -341,12 +341,13 @@
         <signal af="2" driver="tim" instance="1" name="ch3"/>
         <signal device-size="6" af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|r" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
+        <signal device-pin="f" af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|r" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
@@ -528,6 +529,148 @@
         <signal driver="rcc" name="osc_out"/>
         <signal device-size="6" af="1" driver="i2c" instance="1" name="scl"/>
       </gpio>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin device-size="6" position="3" name="PC14OSC32_IN"/>
+        <pin device-size="b" position="3" name="PC14-OSC32_IN"/>
+        <pin device-size="6" position="4" name="PC15OSC32_OUT"/>
+        <pin device-size="b" position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="17" name="PA11" variant="remap"/>
+        <pin position="18" name="PA10"/>
+        <pin position="18" name="PA12" variant="remap"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-71.xml
+++ b/devices/stm32/stm32f0-71.xml
@@ -768,6 +768,427 @@
       <gpio device-pin="v" port="f" pin="10">
         <signal af="0" driver="tim" instance="15" name="ch2"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="NC" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="PF3"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDDIO2" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="NC" type="power"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="C7" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-72.xml
+++ b/devices/stm32/stm32f0-72.xml
@@ -788,6 +788,493 @@
       <gpio device-pin="v" port="f" pin="10">
         <signal af="0" driver="tim" instance="15" name="ch2"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="NC" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="PF3"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="h|i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDDIO2" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="NC" type="power"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="C7" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-78.xml
+++ b/devices/stm32/stm32f0-78.xml
@@ -762,6 +762,493 @@
       <gpio device-pin="v" port="f" pin="10">
         <signal af="0" driver="tim" instance="15" name="ch2"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="NPOR" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="NPOR" type="power"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="NC" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="PF3"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="NPOR" type="power"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="h" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="NPOR" type="power"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDDIO2" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="NC" type="power"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="C7" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="NPOR" type="power"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-91.xml
+++ b/devices/stm32/stm32f0-91.xml
@@ -1152,6 +1152,508 @@
         <signal af="1" driver="usart" instance="6" name="rx"/>
       </gpio>
       <gpio port="f" pin="11"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14OSC32_IN"/>
+        <pin position="9" name="PC15OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PF11BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="PF11BOOT0"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PF11BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="NC" type="reset"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="PF3"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="h" name="UFBGA64">
+        <pin position="A1" name="PC14OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PF11BOOT0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDDIO2" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC10"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB8"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PA14"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="PC13"/>
+        <pin position="B8" name="VBAT" type="power"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA13"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PF11BOOT0"/>
+        <pin position="C7" name="PC15OSC32_OUT"/>
+        <pin position="C8" name="PC14OSC32_IN"/>
+        <pin position="D1" name="PC7"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PA11"/>
+        <pin position="D4" name="PB3"/>
+        <pin position="D5" name="PB4"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="NRST" type="reset"/>
+        <pin position="D8" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PC6"/>
+        <pin position="E2" name="PC8"/>
+        <pin position="E3" name="PC9"/>
+        <pin position="E4" name="PA7"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="PC3"/>
+        <pin position="E7" name="PC0"/>
+        <pin position="E8" name="PF1-OSC_OUT"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB13"/>
+        <pin position="F3" name="PB1"/>
+        <pin position="F4" name="PC5"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA1"/>
+        <pin position="F7" name="PA0"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB12"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PB0"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSSA" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="PB2"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="VDDA" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f0-98.xml
+++ b/devices/stm32/stm32f0-98.xml
@@ -1136,6 +1136,508 @@
         <signal af="1" driver="usart" instance="6" name="rx"/>
       </gpio>
       <gpio port="f" pin="11"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14OSC32_IN"/>
+        <pin position="9" name="PC15OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="NPOR" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PF11BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="NPOR" type="power"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="PF11BOOT0"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PF11BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="NC" type="reset"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="PF3"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="NPOR" type="power"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="h" name="UFBGA64">
+        <pin position="A1" name="PC14OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PF11BOOT0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PF0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PF1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="NPOR" type="power"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14OSC32_IN"/>
+        <pin position="4" name="PC15OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PF11BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDDIO2" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC10"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB8"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PA14"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="PC13"/>
+        <pin position="B8" name="VBAT" type="power"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA13"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PF11BOOT0"/>
+        <pin position="C7" name="PC15OSC32_OUT"/>
+        <pin position="C8" name="PC14OSC32_IN"/>
+        <pin position="D1" name="PC7"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PA11"/>
+        <pin position="D4" name="PB3"/>
+        <pin position="D5" name="PB4"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="NRST" type="reset"/>
+        <pin position="D8" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PC6"/>
+        <pin position="E2" name="PC8"/>
+        <pin position="E3" name="PC9"/>
+        <pin position="E4" name="PA7"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="PC3"/>
+        <pin position="E7" name="PC0"/>
+        <pin position="E8" name="PF1-OSC_OUT"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB13"/>
+        <pin position="F3" name="PB1"/>
+        <pin position="F4" name="PC5"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA1"/>
+        <pin position="F7" name="PA0"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB12"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PB0"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSSA" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="NPOR" type="power"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="VDDA" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-00-4_6.xml
+++ b/devices/stm32/stm32f1-00-4_6.xml
@@ -447,6 +447,188 @@
       <gpio device-pin="r" port="d" pin="2">
         <signal driver="tim" instance="3" name="etr"/>
       </gpio>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PD0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PD1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-00-8_b.xml
+++ b/devices/stm32/stm32f1-00-8_b.xml
@@ -571,6 +571,290 @@
       <gpio device-pin="v" port="e" pin="13"/>
       <gpio device-pin="v" port="e" pin="14"/>
       <gpio device-pin="v" port="e" pin="15"/>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PD0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PD1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-00-c_d_e.xml
+++ b/devices/stm32/stm32f1-00-c_d_e.xml
@@ -795,6 +795,320 @@
         <signal driver="fsmc" name="a25"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="15"/>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="OSC_IN"/>
+        <pin position="24" name="OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="NC" type="nc"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-01-c_d_e.xml
+++ b/devices/stm32/stm32f1-01-c_d_e.xml
@@ -686,6 +686,320 @@
         <signal driver="fsmc" name="a25"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="15"/>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="OSC_IN"/>
+        <pin position="24" name="OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="NC" type="nc"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-01-f_g.xml
+++ b/devices/stm32/stm32f1-01-f_g.xml
@@ -740,6 +740,320 @@
         <signal driver="fsmc" name="a25"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="15"/>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="OSC_IN"/>
+        <pin position="24" name="OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="NC" type="nc"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-01_02-4_6.xml
+++ b/devices/stm32/stm32f1-01_02-4_6.xml
@@ -339,6 +339,160 @@
       <gpio device-pin="r" port="d" pin="2">
         <signal driver="tim" instance="3" name="etr"/>
       </gpio>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="VFQFPN36">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PD0-OSC_IN"/>
+        <pin position="3" name="PD1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VSSA" type="power"/>
+        <pin position="6" name="VDDA" type="power"/>
+        <pin position="7" name="PA0-WKUP"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA8"/>
+        <pin position="21" name="PA9"/>
+        <pin position="22" name="PA10"/>
+        <pin position="23" name="PA11"/>
+        <pin position="24" name="PA12"/>
+        <pin position="25" name="PA13"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA14"/>
+        <pin position="29" name="PA15"/>
+        <pin position="30" name="PB3"/>
+        <pin position="31" name="PB4"/>
+        <pin position="32" name="PB5"/>
+        <pin position="33" name="PB6"/>
+        <pin position="34" name="PB7"/>
+        <pin position="35" name="BOOT0" type="boot"/>
+        <pin position="36" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-01_02-8_b.xml
+++ b/devices/stm32/stm32f1-01_02-8_b.xml
@@ -461,6 +461,378 @@
       <gpio device-pin="v" port="e" pin="13"/>
       <gpio device-pin="v" port="e" pin="14"/>
       <gpio device-pin="v" port="e" pin="15"/>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PD0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PD1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="VFQFPN36">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PD0-OSC_IN"/>
+        <pin position="3" name="PD1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VSSA" type="power"/>
+        <pin position="6" name="VDDA" type="power"/>
+        <pin position="7" name="PA0-WKUP"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA8"/>
+        <pin position="21" name="PA9"/>
+        <pin position="22" name="PA10"/>
+        <pin position="23" name="PA11"/>
+        <pin position="24" name="PA12"/>
+        <pin position="25" name="PA13"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA14"/>
+        <pin position="29" name="PA15"/>
+        <pin position="30" name="PB3"/>
+        <pin position="31" name="PB4"/>
+        <pin position="32" name="PB5"/>
+        <pin position="33" name="PB6"/>
+        <pin position="34" name="PB7"/>
+        <pin position="35" name="BOOT0" type="boot"/>
+        <pin position="36" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-03-4_6.xml
+++ b/devices/stm32/stm32f1-03-4_6.xml
@@ -421,6 +421,276 @@
       <gpio device-pin="r" port="d" pin="2">
         <signal driver="tim" instance="3" name="etr"/>
       </gpio>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PD0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PD1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="VFQFPN36">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PD0-OSC_IN"/>
+        <pin position="3" name="PD1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VSSA" type="power"/>
+        <pin position="6" name="VDDA" type="power"/>
+        <pin position="7" name="PA0-WKUP"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA8"/>
+        <pin position="21" name="PA9"/>
+        <pin position="22" name="PA10"/>
+        <pin position="23" name="PA11"/>
+        <pin position="24" name="PA12"/>
+        <pin position="25" name="PA13"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA14"/>
+        <pin position="29" name="PA15"/>
+        <pin position="30" name="PB3"/>
+        <pin position="31" name="PB4"/>
+        <pin position="32" name="PB5"/>
+        <pin position="33" name="PB6"/>
+        <pin position="34" name="PB7"/>
+        <pin position="35" name="BOOT0" type="boot"/>
+        <pin position="36" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-03-8_b.xml
+++ b/devices/stm32/stm32f1-03-8_b.xml
@@ -559,6 +559,582 @@
       <gpio device-pin="v" port="e" pin="13"/>
       <gpio device-pin="v" port="e" pin="14"/>
       <gpio device-pin="v" port="e" pin="15"/>
+      <package device-pin="v" device-package="h" name="LFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PA15"/>
+        <pin position="A9" name="PA14"/>
+        <pin position="A10" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="NC" type="nc"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PB15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="VREF-" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PD14"/>
+        <pin position="J1" name="VREF+" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDDA" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PD0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PD1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13-TAMPER-RTC"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="NC" type="nc"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0-WKUP"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="VFQFPN36">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PD0-OSC_IN"/>
+        <pin position="3" name="PD1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VSSA" type="power"/>
+        <pin position="6" name="VDDA" type="power"/>
+        <pin position="7" name="PA0-WKUP"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA8"/>
+        <pin position="21" name="PA9"/>
+        <pin position="22" name="PA10"/>
+        <pin position="23" name="PA11"/>
+        <pin position="24" name="PA12"/>
+        <pin position="25" name="PA13"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA14"/>
+        <pin position="29" name="PA15"/>
+        <pin position="30" name="PB3"/>
+        <pin position="31" name="PB4"/>
+        <pin position="32" name="PB5"/>
+        <pin position="33" name="PB6"/>
+        <pin position="34" name="PB7"/>
+        <pin position="35" name="BOOT0" type="boot"/>
+        <pin position="36" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-03-c_d_e.xml
+++ b/devices/stm32/stm32f1-03-c_d_e.xml
@@ -873,6 +873,634 @@
         <signal driver="fsmc" name="a25"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="15"/>
+      <package device-pin="v" device-package="h" name="LFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PA15"/>
+        <pin position="A9" name="PA14"/>
+        <pin position="A10" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="NC" type="nc"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PB15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="VREF-" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PD14"/>
+        <pin position="J1" name="VREF+" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDDA" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="z" device-package="h" name="LFBGA144">
+        <pin position="A1" name="PC13-TAMPER-RTC"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="NC" type="nc"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0-WKUP"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="OSC_IN"/>
+        <pin position="24" name="OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="NC" type="nc"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PB3"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="BOOT0" type="boot"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="PC15-OSC32_OUT"/>
+        <pin position="B8" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA12"/>
+        <pin position="C3" name="PA15"/>
+        <pin position="C4" name="PC12"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="VBAT" type="power"/>
+        <pin position="C7" name="NRST" type="reset"/>
+        <pin position="C8" name="PC13-TAMPER-RTC"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA13"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="PD1-OSC_OUT"/>
+        <pin position="D8" name="PD0-OSC_IN"/>
+        <pin position="E1" name="PC6"/>
+        <pin position="E2" name="PC7"/>
+        <pin position="E3" name="PC8"/>
+        <pin position="E4" name="PA8"/>
+        <pin position="E5" name="PA5"/>
+        <pin position="E6" name="PA1"/>
+        <pin position="E7" name="VSSA" type="power"/>
+        <pin position="E8" name="PC0"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB14"/>
+        <pin position="F3" name="PB11"/>
+        <pin position="F4" name="PB1"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="PA0-WKUP"/>
+        <pin position="F7" name="VREF+" type="power"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB12"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PA7"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="VDDA" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB2"/>
+        <pin position="H4" name="PB0"/>
+        <pin position="H5" name="PC5"/>
+        <pin position="H6" name="PC4"/>
+        <pin position="H7" name="PA4"/>
+        <pin position="H8" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-03-f_g.xml
+++ b/devices/stm32/stm32f1-03-f_g.xml
@@ -909,6 +909,466 @@
         <signal driver="fsmc" name="a25"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="15"/>
+      <package device-package="h" name="LFBGA144">
+        <pin position="A1" name="PC13-TAMPER-RTC"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="NC" type="nc"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0-WKUP"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="OSC_IN"/>
+        <pin position="24" name="OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="NC" type="nc"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f1-05_07.xml
+++ b/devices/stm32/stm32f1-05_07.xml
@@ -717,6 +717,276 @@
       <gpio device-pin="v" port="e" pin="13"/>
       <gpio device-pin="v" port="e" pin="14"/>
       <gpio device-pin="v" port="e" pin="15"/>
+      <package device-package="h" name="LFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-TAMPER-RTC"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PA15"/>
+        <pin position="A9" name="PA14"/>
+        <pin position="A10" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="NC" type="nc"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PB15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="VREF-" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PD14"/>
+        <pin position="J1" name="VREF+" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDDA" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-TAMPER-RTC"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="OSC_IN"/>
+        <pin position="13" name="OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="NC" type="nc"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-TAMPER-RTC"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PD0-OSC_IN"/>
+        <pin position="6" name="PD1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f2-05.xml
+++ b/devices/stm32/stm32f2-05.xml
@@ -1133,6 +1133,456 @@
       <gpio port="h" pin="1">
         <signal af="0" driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-package="e" name="EWLCSP66">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PB3"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="VBAT" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="BOOT0" type="boot"/>
+        <pin position="B7" name="PB8"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="VCAP_2" type="power"/>
+        <pin position="C3" name="PC11"/>
+        <pin position="C7" name="PD2"/>
+        <pin position="C8" name="IRROFF" type="power"/>
+        <pin position="C9" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D7" name="PC2"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VDD" type="power"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA9"/>
+        <pin position="E7" name="PA0-WKUP"/>
+        <pin position="E8" name="NRST" type="reset"/>
+        <pin position="E9" name="PH0-OSC_IN"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PC7"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F7" name="VREF+" type="power"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PH1-OSC_OUT"/>
+        <pin position="G1" name="PB15"/>
+        <pin position="G2" name="PC6"/>
+        <pin position="G3" name="PC5"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="PC3"/>
+        <pin position="G9" name="PC0"/>
+        <pin position="H1" name="PB14"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PC4"/>
+        <pin position="H5" name="PA6"/>
+        <pin position="H6" name="PA5"/>
+        <pin position="H7" name="REGOFF" type="power"/>
+        <pin position="H8" name="PA1"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="J1" name="PB12"/>
+        <pin position="J2" name="PB11"/>
+        <pin position="J3" name="VCAP_1" type="power"/>
+        <pin position="J4" name="PB2"/>
+        <pin position="J5" name="PB1"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA7"/>
+        <pin position="J8" name="PA4"/>
+        <pin position="J9" name="PA2"/>
+      </package>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VCAP_1" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="RFU" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="RFU" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VCAP_1" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VCAP_2" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP66">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PB3"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="VBAT" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="BOOT0" type="boot"/>
+        <pin position="B7" name="PB8"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="VCAP_2" type="power"/>
+        <pin position="C3" name="PC11"/>
+        <pin position="C7" name="PD2"/>
+        <pin position="C8" name="IRROFF" type="power"/>
+        <pin position="C9" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D7" name="PC2"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VDD" type="power"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA9"/>
+        <pin position="E7" name="PA0-WKUP"/>
+        <pin position="E8" name="NRST" type="reset"/>
+        <pin position="E9" name="PH0-OSC_IN"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PC7"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F7" name="VREF+" type="power"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PH1-OSC_OUT"/>
+        <pin position="G1" name="PB15"/>
+        <pin position="G2" name="PC6"/>
+        <pin position="G3" name="PC5"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="PC3"/>
+        <pin position="G9" name="PC0"/>
+        <pin position="H1" name="PB14"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PC4"/>
+        <pin position="H5" name="PA6"/>
+        <pin position="H6" name="PA5"/>
+        <pin position="H7" name="REGOFF" type="power"/>
+        <pin position="H8" name="PA1"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="J1" name="PB12"/>
+        <pin position="J2" name="PB11"/>
+        <pin position="J3" name="VCAP_1" type="power"/>
+        <pin position="J4" name="PB2"/>
+        <pin position="J5" name="PB1"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA7"/>
+        <pin position="J8" name="PA4"/>
+        <pin position="J9" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f2-07_15_17.xml
+++ b/devices/stm32/stm32f2-07_15_17.xml
@@ -1318,6 +1318,701 @@
       <gpio device-pin="i" port="i" pin="11">
         <signal af="10" driver="usb_otg_hs" name="ulpi_dir"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VCAP_1" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="RFU" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="RFU" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8-RTC_AF2"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN"/>
+        <pin position="10" name="PC15-OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN"/>
+        <pin position="30" name="PH1-OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0-WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP_2" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="RFU" type="power"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VCAP_1" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VCAP_2" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="RFU" type="power"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8-RTC_AF2"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="REGOFF" type="power"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0-WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-01.xml
+++ b/devices/stm32/stm32f3-01.xml
@@ -561,6 +561,241 @@
         <signal af="5" driver="i2s" instance="2" name="ck"/>
         <signal af="5" driver="spi" instance="2" name="sck"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 - OSC32_IN"/>
+        <pin position="4" name="PC15 - OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 - OSC32_IN"/>
+        <pin position="4" name="PC15 - OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="VSSA/VREF-" type="power"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VDDA/VREF+" type="power"/>
+        <pin position="A7" name="NC" type="reset"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VBAT" type="power"/>
+        <pin position="B7" name="VDD" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15 - OSC32_OUT"/>
+        <pin position="C7" name="PC14 - OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA/VREF-" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-02-6_8.xml
+++ b/devices/stm32/stm32f3-02-6_8.xml
@@ -574,6 +574,207 @@
         <signal af="5" driver="i2s" instance="2" name="ck"/>
         <signal af="5" driver="spi" instance="2" name="sck"/>
       </gpio>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 - OSC32_IN"/>
+        <pin position="4" name="PC15 - OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 - OSC32_IN"/>
+        <pin position="4" name="PC15 - OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="VSSA/VREF-" type="power"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VDDA/VREF+" type="power"/>
+        <pin position="A7" name="NC" type="reset"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VBAT" type="power"/>
+        <pin position="B7" name="VDD" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15 - OSC32_OUT"/>
+        <pin position="C7" name="PC14 - OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA/VREF-" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-02-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-02-b_c_d_e.xml
@@ -1089,6 +1089,581 @@
         <signal af="12" driver="fmc" name="a1"/>
       </gpio>
       <gpio device-pin="z" port="h" pin="2"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin device-size="d|e" device-temperature="6" position="20" name="VSSA" type="power"/>
+        <pin device-size="b|c" device-temperature="6" position="20" name="VSSA/VREF-" type="power"/>
+        <pin device-size="c" device-temperature="7" position="20" name="VSSA/VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin device-size="d|e" device-temperature="6" position="27" name="VSS" type="power"/>
+        <pin device-size="b|c" device-temperature="6" position="27" name="PF4"/>
+        <pin device-size="c" device-temperature="7" position="27" name="PF4"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PH0"/>
+        <pin position="11" name="PH1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PF0-OSC_IN"/>
+        <pin position="24" name="PF1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="PH2"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin device-size="d|e" device-temperature="6|7" position="12" name="VSSA" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="12" name="VSSA/VREF-" type="power"/>
+        <pin device-size="d|e" device-temperature="6|7" position="13" name="VDDA" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin device-size="d|e" device-temperature="6|7" position="18" name="VSS" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="18" name="PF4"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VREF+" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="VSS" type="power"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="PE1"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA15"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD3"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PE0"/>
+        <pin position="B8" name="VDD" type="power"/>
+        <pin position="B9" name="PE5"/>
+        <pin position="B10" name="VDD" type="power"/>
+        <pin position="C1" name="PF6"/>
+        <pin position="C2" name="PA14"/>
+        <pin position="C3" name="PD1"/>
+        <pin position="C4" name="PD4"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="VSS" type="power"/>
+        <pin position="C8" name="PE4"/>
+        <pin position="C9" name="PC13"/>
+        <pin position="C10" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA12"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PC11"/>
+        <pin position="D4" name="PD7"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PE2"/>
+        <pin position="D7" name="PE3"/>
+        <pin position="D8" name="VBAT" type="power"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="D10" name="PF9"/>
+        <pin position="E1" name="PA10"/>
+        <pin position="E2" name="PA11"/>
+        <pin position="E3" name="PA13"/>
+        <pin position="E4" name="PC10"/>
+        <pin position="E5" name="PA9"/>
+        <pin position="E6" name="PE8"/>
+        <pin position="E7" name="PE6"/>
+        <pin position="E8" name="PF2"/>
+        <pin position="E9" name="NRST" type="reset"/>
+        <pin position="E10" name="PF10"/>
+        <pin position="F1" name="PC8"/>
+        <pin position="F2" name="PC7"/>
+        <pin position="F3" name="PC9"/>
+        <pin position="F4" name="PC6"/>
+        <pin position="F5" name="PA8"/>
+        <pin position="F6" name="PC5"/>
+        <pin position="F7" name="PA2"/>
+        <pin position="F8" name="PE7"/>
+        <pin position="F9" name="PF1-OSC_OUT"/>
+        <pin position="F10" name="PF0-OSC_IN"/>
+        <pin position="G1" name="PD15"/>
+        <pin position="G2" name="PD14"/>
+        <pin position="G3" name="PD13"/>
+        <pin position="G4" name="PD9"/>
+        <pin position="G5" name="PE12"/>
+        <pin position="G6" name="PC4"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="PC2"/>
+        <pin position="G9" name="PC1"/>
+        <pin position="G10" name="PC0"/>
+        <pin position="H1" name="PD12"/>
+        <pin position="H2" name="PD11"/>
+        <pin position="H3" name="PD10"/>
+        <pin position="H4" name="PB15"/>
+        <pin position="H5" name="PE11"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="PA5"/>
+        <pin position="H8" name="VSSA/VREF-" type="power"/>
+        <pin position="H9" name="PA0"/>
+        <pin position="H10" name="PC3"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PB14"/>
+        <pin position="J3" name="PB13"/>
+        <pin position="J4" name="PB12"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA4"/>
+        <pin position="J8" name="VREF+" type="power"/>
+        <pin position="J9" name="PA1"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin position="K1" name="VSS" type="power"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PB11"/>
+        <pin position="K4" name="PB10"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K6" name="PB1"/>
+        <pin position="K7" name="PA7"/>
+        <pin position="K8" name="VDD" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-03-6_8.xml
+++ b/devices/stm32/stm32f3-03-6_8.xml
@@ -596,6 +596,241 @@
       <gpio port="f" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0 / OSC_IN"/>
+        <pin position="3" name="PF1 / OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 / OSC32_IN"/>
+        <pin position="4" name="PC15 / OSC32_OUT"/>
+        <pin position="5" name="PF0 / OSC_IN"/>
+        <pin position="6" name="PF1 / OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 / OSC32_IN"/>
+        <pin position="4" name="PC15 / OSC32_OUT"/>
+        <pin position="5" name="PF0 / OSC_IN"/>
+        <pin position="6" name="PF1 / OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0 / OSC_IN"/>
+        <pin position="3" name="PF1 / OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="VSSA/VREF-" type="power"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PB9"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PB4"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB8"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PA10"/>
+        <pin position="C5" name="PC3"/>
+        <pin position="C6" name="PF1 / OSC_OUT"/>
+        <pin position="C7" name="PF0 / OSC_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PB15"/>
+        <pin position="D4" name="PC7"/>
+        <pin position="D5" name="PA2"/>
+        <pin position="D6" name="PA0"/>
+        <pin position="D7" name="NRST" type="reset"/>
+        <pin position="E1" name="PB14"/>
+        <pin position="E2" name="PB13"/>
+        <pin position="E3" name="PC5"/>
+        <pin position="E4" name="PA6"/>
+        <pin position="E5" name="PA3"/>
+        <pin position="E6" name="VDDA" type="power"/>
+        <pin position="E7" name="VSSA/VREF-" type="power"/>
+        <pin position="F1" name="PB12"/>
+        <pin position="F2" name="PB2"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA4"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VREF+" type="power"/>
+        <pin position="G1" name="PB11"/>
+        <pin position="G2" name="PB10"/>
+        <pin position="G3" name="PB1"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PA5"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-03-b_c_d_e.xml
+++ b/devices/stm32/stm32f3-03-b_c_d_e.xml
@@ -1364,6 +1364,582 @@
         <signal af="12" driver="fmc" name="a1"/>
       </gpio>
       <gpio device-pin="z" port="h" pin="2"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin device-size="d|e" device-temperature="6" position="20" name="VSSA" type="power"/>
+        <pin device-size="e" device-temperature="7" position="20" name="VSSA" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="20" name="VSSA/VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin device-size="d|e" device-temperature="6" position="27" name="VSS" type="power"/>
+        <pin device-size="e" device-temperature="7" position="27" name="VSS" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="27" name="PF4"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PH0"/>
+        <pin position="11" name="PH1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PF0-OSC_IN"/>
+        <pin position="24" name="PF1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="PH2"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin device-size="d|e" device-temperature="6|7" position="12" name="VSSA" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="12" name="VSSA/VREF-" type="power"/>
+        <pin device-size="d|e" device-temperature="6|7" position="13" name="VDDA" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin device-size="d|e" device-temperature="6|7" position="18" name="VSS" type="power"/>
+        <pin device-size="b|c" device-temperature="6|7" position="18" name="PF4"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VREF+" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="VSS" type="power"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="PE1"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA15"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD3"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PE0"/>
+        <pin position="B8" name="VDD" type="power"/>
+        <pin position="B9" name="PE5"/>
+        <pin position="B10" name="VDD" type="power"/>
+        <pin position="C1" name="PF6"/>
+        <pin position="C2" name="PA14"/>
+        <pin position="C3" name="PD1"/>
+        <pin position="C4" name="PD4"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="VSS" type="power"/>
+        <pin position="C8" name="PE4"/>
+        <pin position="C9" name="PC13"/>
+        <pin position="C10" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA12"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PC11"/>
+        <pin position="D4" name="PD7"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PE2"/>
+        <pin position="D7" name="PE3"/>
+        <pin position="D8" name="VBAT" type="power"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="D10" name="PF9"/>
+        <pin position="E1" name="PA10"/>
+        <pin position="E2" name="PA11"/>
+        <pin position="E3" name="PA13"/>
+        <pin position="E4" name="PC10"/>
+        <pin position="E5" name="PA9"/>
+        <pin position="E6" name="PE8"/>
+        <pin position="E7" name="PE6"/>
+        <pin position="E8" name="PF2"/>
+        <pin position="E9" name="NRST" type="reset"/>
+        <pin position="E10" name="PF10"/>
+        <pin position="F1" name="PC8"/>
+        <pin position="F2" name="PC7"/>
+        <pin position="F3" name="PC9"/>
+        <pin position="F4" name="PC6"/>
+        <pin position="F5" name="PA8"/>
+        <pin position="F6" name="PC5"/>
+        <pin position="F7" name="PA2"/>
+        <pin position="F8" name="PE7"/>
+        <pin position="F9" name="PF1-OSC_OUT"/>
+        <pin position="F10" name="PF0-OSC_IN"/>
+        <pin position="G1" name="PD15"/>
+        <pin position="G2" name="PD14"/>
+        <pin position="G3" name="PD13"/>
+        <pin position="G4" name="PD9"/>
+        <pin position="G5" name="PE12"/>
+        <pin position="G6" name="PC4"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="PC2"/>
+        <pin position="G9" name="PC1"/>
+        <pin position="G10" name="PC0"/>
+        <pin position="H1" name="PD12"/>
+        <pin position="H2" name="PD11"/>
+        <pin position="H3" name="PD10"/>
+        <pin position="H4" name="PB15"/>
+        <pin position="H5" name="PE11"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="PA5"/>
+        <pin device-size="e" device-temperature="6|7" position="H8" name="VSSA" type="power"/>
+        <pin device-size="c" device-temperature="6|7" position="H8" name="VSSA/VREF-" type="power"/>
+        <pin position="H9" name="PA0"/>
+        <pin position="H10" name="PC3"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PB14"/>
+        <pin position="J3" name="PB13"/>
+        <pin position="J4" name="PB12"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA4"/>
+        <pin position="J8" name="VREF+" type="power"/>
+        <pin position="J9" name="PA1"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin position="K1" name="VSS" type="power"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PB11"/>
+        <pin position="K4" name="PB10"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K6" name="PB1"/>
+        <pin position="K7" name="PA7"/>
+        <pin position="K8" name="VDD" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-18_28.xml
+++ b/devices/stm32/stm32f3-18_28.xml
@@ -579,6 +579,146 @@
         <signal device-name="18" af="5" driver="i2s" instance="2" name="ck"/>
         <signal device-name="18" af="5" driver="spi" instance="2" name="sck"/>
       </gpio>
+      <package device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin device-name="18" position="3" name="PC14 - OSC32_IN"/>
+        <pin device-name="28" position="3" name="PC14 / OSC32_IN"/>
+        <pin device-name="18" position="4" name="PC15 - OSC32_OUT"/>
+        <pin device-name="28" position="4" name="PC15 / OSC32_OUT"/>
+        <pin device-name="18" position="5" name="PF0-OSC_IN"/>
+        <pin device-name="28" position="5" name="PF0 / OSC_IN"/>
+        <pin device-name="18" position="6" name="PF1-OSC_OUT"/>
+        <pin device-name="28" position="6" name="PF1 / OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin device-name="18" position="20" name="NPOR" type="reset"/>
+        <pin device-name="28" position="20" name="NPOR" type="power"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="VSSA/VREF-" type="power"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="NPOR" type="reset"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VDDA/VREF+" type="power"/>
+        <pin position="A7" name="NC" type="reset"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VBAT" type="power"/>
+        <pin position="B7" name="VDD" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15 - OSC32_OUT"/>
+        <pin position="C7" name="PC14 - OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13"/>
+        <pin position="D6" name="PF1-OSC_OUT"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VSSA/VREF-" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB11"/>
+        <pin position="G3" name="NPOR" type="reset"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-34.xml
+++ b/devices/stm32/stm32f3-34.xml
@@ -655,6 +655,241 @@
       <gpio port="f" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0 / OSC_IN"/>
+        <pin position="3" name="PF1 / OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 / OSC32_IN"/>
+        <pin position="4" name="PC15 / OSC32_OUT"/>
+        <pin position="5" name="PF0 / OSC_IN"/>
+        <pin position="6" name="PF1 / OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14 / OSC32_IN"/>
+        <pin position="4" name="PC15 / OSC32_OUT"/>
+        <pin position="5" name="PF0 / OSC_IN"/>
+        <pin position="6" name="PF1 / OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0 / OSC_IN"/>
+        <pin position="3" name="PF1 / OSC_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="VSSA/VREF-" type="power"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PB9"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PB4"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB8"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PA10"/>
+        <pin position="C5" name="PC3"/>
+        <pin position="C6" name="PF1 / OSC_OUT"/>
+        <pin position="C7" name="PF0 / OSC_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PB15"/>
+        <pin position="D4" name="PC7"/>
+        <pin position="D5" name="PA2"/>
+        <pin position="D6" name="PA0"/>
+        <pin position="D7" name="NRST" type="reset"/>
+        <pin position="E1" name="PB14"/>
+        <pin position="E2" name="PB13"/>
+        <pin position="E3" name="PC5"/>
+        <pin position="E4" name="PA6"/>
+        <pin position="E5" name="PA3"/>
+        <pin position="E6" name="VDDA" type="power"/>
+        <pin position="E7" name="VSSA/VREF-" type="power"/>
+        <pin position="F1" name="PB12"/>
+        <pin position="F2" name="PB2"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA4"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VREF+" type="power"/>
+        <pin position="G1" name="PB11"/>
+        <pin position="G2" name="PB10"/>
+        <pin position="G3" name="PB1"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PA5"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-58_98.xml
+++ b/devices/stm32/stm32f3-58_98.xml
@@ -1089,6 +1089,226 @@
         <signal af="5" driver="spi" instance="2" name="sck"/>
         <signal device-name="98" af="12" driver="fmc" name="intr"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin device-name="58" device-size="c" position="20" name="VSSA/VREF-" type="power"/>
+        <pin device-name="98" position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin device-name="58" device-size="c" position="27" name="PF4"/>
+        <pin device-name="98" position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="NPOR" type="reset"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="NPOR" type="reset"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PF4"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="NPOR" type="reset"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f3-73_78.xml
+++ b/devices/stm32/stm32f3-73_78.xml
@@ -912,6 +912,402 @@
         <signal af="2" driver="tim" instance="14" name="ch1"/>
       </gpio>
       <gpio device-pin="v" port="f" pin="10"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="VSSA/VREF-" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="VREF+" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="PF4"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin device-name="73" device-size="8|b|c" device-temperature="6" position="37" name="PB2"/>
+        <pin device-name="73" device-size="b|c" device-temperature="7" position="37" name="PB2"/>
+        <pin device-name="78" device-size="c" device-temperature="6" position="37" name="NPOR" type="reset"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VREFSD-" type="power"/>
+        <pin position="49" name="VSSSD" type="power"/>
+        <pin position="50" name="VDDSD12" type="power"/>
+        <pin position="51" name="VDDSD3" type="power"/>
+        <pin position="52" name="VREFSD+" type="power"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PF6"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin device-name="73" device-size="8|b|c" device-temperature="6" position="20" name="PB2"/>
+        <pin device-name="73" device-size="b|c" device-temperature="7" position="20" name="PB2"/>
+        <pin device-name="78" device-size="c" device-temperature="6" position="20" name="NPOR" type="reset"/>
+        <pin position="21" name="PE8"/>
+        <pin position="22" name="PE9"/>
+        <pin position="23" name="VSSSD/VREFSD-" type="power"/>
+        <pin position="24" name="VDDSD" type="power"/>
+        <pin position="25" name="VREFSD+" type="power"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PD8"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="PF6"/>
+        <pin position="36" name="PF7"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="VREF+" type="power"/>
+        <pin position="18" name="PA3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin device-name="73" device-size="8|b|c" device-temperature="6" position="28" name="PB2"/>
+        <pin device-name="73" device-size="b" device-temperature="7" position="28" name="PB2"/>
+        <pin device-name="78" device-size="c" device-temperature="6" position="28" name="NPOR" type="reset"/>
+        <pin position="29" name="PE8"/>
+        <pin position="30" name="PE9"/>
+        <pin position="31" name="VSSSD/VREFSD-" type="power"/>
+        <pin position="32" name="VDDSD" type="power"/>
+        <pin position="33" name="VREFSD+" type="power"/>
+        <pin position="34" name="PB14"/>
+        <pin position="35" name="PB15"/>
+        <pin position="36" name="PD8"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="PF6"/>
+        <pin position="48" name="PF7"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PF6"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSSSD" type="power"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PF10"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDDSD12" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="PF2"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VSSA/VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="VREFSD+" type="power"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin device-name="73" device-size="8|b|c" device-temperature="6" position="L6" name="PB2"/>
+        <pin device-name="73" device-size="b|c" device-temperature="7" position="L6" name="PB2"/>
+        <pin device-name="78" device-size="c" device-temperature="6" position="L6" name="NPOR" type="reset"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="VREFSD-" type="power"/>
+        <pin position="L12" name="VDDSD3" type="power"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="y" name="WLCSP66">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC11"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VBAT" type="power"/>
+        <pin position="B1" name="PF7"/>
+        <pin position="B2" name="PF6"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PB8"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PA13"/>
+        <pin position="C5" name="PB3"/>
+        <pin position="C6" name="VSS" type="power"/>
+        <pin position="C7" name="BOOT0" type="boot"/>
+        <pin position="C8" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA9"/>
+        <pin position="D6" name="VDD" type="power"/>
+        <pin position="D7" name="PF0-OSC_IN"/>
+        <pin position="D8" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC6"/>
+        <pin position="E3" name="PC8"/>
+        <pin position="E6" name="PC0"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="E8" name="PF1-OSC_OUT"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB14"/>
+        <pin position="F3" name="PD8"/>
+        <pin position="F6" name="PC3"/>
+        <pin position="F7" name="PC2"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="VREFSD+" type="power"/>
+        <pin position="G2" name="NPOR" type="reset"/>
+        <pin position="G3" name="PA7"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VSS" type="power"/>
+        <pin position="G6" name="VREF+" type="power"/>
+        <pin position="G7" name="VDDA" type="power"/>
+        <pin position="G8" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="VDDSD" type="power"/>
+        <pin position="H2" name="PE8"/>
+        <pin position="H3" name="PB0"/>
+        <pin position="H4" name="PC4"/>
+        <pin position="H5" name="PA5"/>
+        <pin position="H6" name="PA3"/>
+        <pin position="H7" name="PA1"/>
+        <pin position="H8" name="PA0"/>
+        <pin position="J1" name="VSSSD/VREFSD-" type="power"/>
+        <pin position="J2" name="PE9"/>
+        <pin position="J3" name="PB1"/>
+        <pin position="J4" name="PC5"/>
+        <pin position="J5" name="PA6"/>
+        <pin position="J6" name="PA4"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-01_11.xml
+++ b/devices/stm32/stm32f4-01_11.xml
@@ -949,6 +949,394 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-ANTI_TAMP"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0 - OSC_IN"/>
+        <pin position="13" name="PH1 - OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin device-name="11" device-size="c|e" device-temperature="6" position="20" name="VSSA" type="power"/>
+        <pin device-name="01" device-size="d|e" device-temperature="6" position="20" name="VSSA/VREF-" type="power"/>
+        <pin device-name="01" device-size="b" device-temperature="3|6|7" position="20" name="VSSA/VREF-" type="power"/>
+        <pin device-name="01" device-size="c" device-temperature="6|7" position="20" name="VSSA/VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VCAP1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin device-name="11" device-size="c|e" device-temperature="6|7" position="12" name="VSSA" type="power"/>
+        <pin device-name="01" device-size="b|c|d|e" device-temperature="6" position="12" name="VSSA/VREF-" type="power"/>
+        <pin device-name="01" device-size="c|d|e" device-temperature="7" position="12" name="VSSA/VREF-" type="power"/>
+        <pin device-name="11" device-size="c|e" device-temperature="6|7" position="13" name="VDDA" type="power"/>
+        <pin device-name="01" device-size="b|c|d|e" device-temperature="6" position="13" name="VREF+" type="power"/>
+        <pin device-name="01" device-size="c|d|e" device-temperature="7" position="13" name="VREF+" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13-ANTI_TAMP"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VCAP2" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="BYPASS_REG" type="boot"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0 - OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1 - OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PDR_ON" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0-WKUP"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="VCAP1" type="power"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin device-name="11" device-size="c|e" device-temperature="6|7" position="8" name="VSSA" type="power"/>
+        <pin device-name="11" device-size="e" device-temperature="3" position="8" name="VSSA" type="power"/>
+        <pin device-name="01" device-size="d|e" device-temperature="6" position="8" name="VSSA/VREF-" type="power"/>
+        <pin device-name="01" device-size="b" device-temperature="3|6|7" position="8" name="VSSA/VREF-" type="power"/>
+        <pin device-name="01" device-size="c" device-temperature="6|7" position="8" name="VSSA/VREF-" type="power"/>
+        <pin device-name="11" device-size="c|e" device-temperature="6|7" position="9" name="VDDA" type="power"/>
+        <pin device-name="11" device-size="e" device-temperature="3" position="9" name="VDDA" type="power"/>
+        <pin device-name="01" device-size="d|e" device-temperature="6" position="9" name="VREF+" type="power"/>
+        <pin device-name="01" device-size="b" device-temperature="3|6|7" position="9" name="VREF+" type="power"/>
+        <pin device-name="01" device-size="c" device-temperature="6|7" position="9" name="VREF+" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="VCAP1" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="f|y" name="WLCSP49">
+        <pin position="A1" name="PA14"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PA13"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PDR_ON" type="power"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="C7" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="PC13-ANTI_TAMP"/>
+        <pin position="D6" name="PH1 - OSC_OUT"/>
+        <pin position="D7" name="PH0 - OSC_IN"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB12"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin device-name="11" device-package="y" position="E6" name="VSSA" type="power"/>
+        <pin device-name="01" device-package="f|y" position="E6" name="VSSA/VREF-" type="power"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="VDD" type="power"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0-WKUP"/>
+        <pin device-name="11" device-package="y" position="F7" name="VDDA" type="power"/>
+        <pin device-name="01" device-package="f|y" position="F7" name="VREF+" type="power"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="VCAP1" type="power"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-05_07_15_17.xml
+++ b/devices/stm32/stm32f4-05_07_15_17.xml
@@ -1341,6 +1341,793 @@
       <gpio device-pin="i" port="i" pin="11">
         <signal af="10" driver="usb_otg_hs" name="ulpi_dir"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-ANTI_TAMP"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VCAP_1" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13-ANTI_TAMP"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8- ANTI TAMP2"/>
+        <pin position="8" name="PC13-ANTI_TAMP"/>
+        <pin position="9" name="PC14-OSC32_IN"/>
+        <pin position="10" name="PC15-OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN"/>
+        <pin position="30" name="PH1-OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0-WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP_2" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VCAP_1" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VCAP_2" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13-ANTI_TAMP"/>
+        <pin position="D2" name="PI8- ANTI TAMP2"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0-WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="o" name="WLCSP90">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA14"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD4"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="PDR_ON" type="reset"/>
+        <pin position="A9" name="PC13-ANTI_TAMP"/>
+        <pin position="A10" name="VBAT" type="power"/>
+        <pin position="B1" name="VCAP_2" type="power"/>
+        <pin position="B2" name="PI1"/>
+        <pin position="B3" name="PA15"/>
+        <pin position="B4" name="PD2"/>
+        <pin position="B5" name="PD6"/>
+        <pin position="B6" name="PB3"/>
+        <pin position="B7" name="PB7"/>
+        <pin position="B8" name="VDD" type="power"/>
+        <pin position="B9" name="PC15-OSC32_OUT"/>
+        <pin position="B10" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA12"/>
+        <pin position="C3" name="PI0"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PD1"/>
+        <pin position="C6" name="PD5"/>
+        <pin position="C7" name="PB6"/>
+        <pin position="C8" name="PB9"/>
+        <pin position="C9" name="VSS" type="power"/>
+        <pin position="C10" name="PA0-WKUP"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA13"/>
+        <pin position="D5" name="PC10"/>
+        <pin position="D6" name="PD0"/>
+        <pin position="D7" name="PB5"/>
+        <pin position="D8" name="PB8"/>
+        <pin position="D9" name="BYPASS_REG" type="reset"/>
+        <pin position="D10" name="PC2"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC8"/>
+        <pin position="E3" name="PC9"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="VSS" type="power"/>
+        <pin position="E9" name="PC3"/>
+        <pin position="E10" name="PC0"/>
+        <pin position="F1" name="PD15"/>
+        <pin position="F2" name="PD14"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F4" name="VCAP_1" type="power"/>
+        <pin position="F5" name="PE14"/>
+        <pin position="F6" name="PE10"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="PA1"/>
+        <pin position="F9" name="PH1-OSC_OUT"/>
+        <pin position="F10" name="PH0-OSC_IN"/>
+        <pin position="G1" name="PD11"/>
+        <pin position="G2" name="PD12"/>
+        <pin position="G3" name="PD10"/>
+        <pin position="G4" name="PE15"/>
+        <pin position="G5" name="PE13"/>
+        <pin position="G6" name="PE7"/>
+        <pin position="G7" name="PB0"/>
+        <pin position="G8" name="PA5"/>
+        <pin position="G9" name="VDDA" type="power"/>
+        <pin position="G10" name="NRST" type="reset"/>
+        <pin position="H1" name="PB15"/>
+        <pin position="H2" name="PD8"/>
+        <pin position="H3" name="PD9"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PE12"/>
+        <pin position="H6" name="PE8"/>
+        <pin position="H7" name="PB1"/>
+        <pin position="H8" name="PA6"/>
+        <pin position="H9" name="PA3"/>
+        <pin position="H10" name="VSSA" type="power"/>
+        <pin position="J1" name="PB13"/>
+        <pin position="J2" name="PB14"/>
+        <pin position="J3" name="PB12"/>
+        <pin position="J4" name="PB11"/>
+        <pin position="J5" name="PE11"/>
+        <pin position="J6" name="PE9"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA7"/>
+        <pin position="J9" name="PA4"/>
+        <pin position="J10" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-10.xml
+++ b/devices/stm32/stm32f4-10.xml
@@ -642,6 +642,276 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="VCAP1" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="VSS" type="power"/>
+        <pin position="47" name="PDR_ON" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PB11"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="VBAT" type="power"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PC12"/>
+        <pin position="A7" name="PA15"/>
+        <pin position="A8" name="PA12"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PC13-ANTI_TAMP"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB11"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PA14"/>
+        <pin position="B8" name="PA9"/>
+        <pin position="C1" name="PH0 - OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PDR_ON" type="power"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB4"/>
+        <pin position="C6" name="PC10"/>
+        <pin position="C7" name="PA13"/>
+        <pin position="C8" name="PA8"/>
+        <pin position="D1" name="PH1 - OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PC0"/>
+        <pin position="D4" name="PB5"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA11"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC2"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="PA10"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA/VREF-" type="power"/>
+        <pin position="F2" name="PC3"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VDDA/VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PC4"/>
+        <pin position="G6" name="PB1"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC5"/>
+        <pin position="H6" name="PB2"/>
+        <pin position="H7" name="VCAP1" type="power"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0-WKUP"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="VCAP1" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB5"/>
+        <pin position="A4" name="PB8"/>
+        <pin position="A5" name="VSS" type="power"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB6"/>
+        <pin position="B4" name="PDR_ON" type="power"/>
+        <pin position="B5" name="VBAT" type="power"/>
+        <pin position="B6" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA13"/>
+        <pin position="C2" name="PB3"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PC13-ANTI_TAMP"/>
+        <pin position="C5" name="PH0 - OSC_IN"/>
+        <pin position="C6" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA12"/>
+        <pin position="D3" name="PB4"/>
+        <pin position="D4" name="BOOT0" type="boot"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="PH1 - OSC_OUT"/>
+        <pin position="E1" name="PB12"/>
+        <pin position="E2" name="VCAP1" type="power"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="PA0-WKUP"/>
+        <pin position="E6" name="VSSA/VREF-" type="power"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PB2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="VDDA/VREF+" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-12.xml
+++ b/devices/stm32/stm32f4-12.xml
@@ -1310,6 +1310,684 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0 - OSC_IN"/>
+        <pin position="13" name="PH1 - OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0 - OSC_IN"/>
+        <pin position="24" name="PH1 - OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD_USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP_1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VCAP_2" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="BYPASS_REG" type="boot"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0 - OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1 - OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PDR_ON" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDD_USB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0 - OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1 - OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP_2" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="BYPASS_REG" type="boot"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP_1" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="VCAP_1" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PC10"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PDR_ON" type="power"/>
+        <pin position="C7" name="PC15-OSC32_OUT"/>
+        <pin position="C8" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA11"/>
+        <pin position="D4" name="BOOT0" type="boot"/>
+        <pin position="D5" name="PC0"/>
+        <pin position="D6" name="PC3"/>
+        <pin position="D7" name="NRST" type="reset"/>
+        <pin position="D8" name="PH0 - OSC_IN"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PC4"/>
+        <pin position="E5" name="PA7"/>
+        <pin position="E6" name="PA0"/>
+        <pin position="E7" name="PC2"/>
+        <pin position="E8" name="PH1 - OSC_OUT"/>
+        <pin position="F1" name="PC6"/>
+        <pin position="F2" name="PB15"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F4" name="PB1"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA3"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB13"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PB2"/>
+        <pin position="G5" name="PC5"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+        <pin position="G8" name="VSSA" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="VCAP_1" type="power"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PB0"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-13_23.xml
+++ b/devices/stm32/stm32f4-13_23.xml
@@ -1595,6 +1595,701 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0 - OSC_IN"/>
+        <pin position="13" name="PH1 - OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0 - OSC_IN"/>
+        <pin position="24" name="PH1 - OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP_1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VCAP_2" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="BYPASS_REG" type="boot"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0 - OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1 - OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PDR_ON" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0 - OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1 - OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP_2" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="BYPASS_REG" type="boot"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP_1" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0 - OSC_IN"/>
+        <pin position="6" name="PH1 - OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="VCAP_1" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="m" name="WLCSP81">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PA15"/>
+        <pin position="A4" name="PD0"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PA12"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PB7"/>
+        <pin position="B8" name="PDR_ON" type="power"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="VCAP_2" type="power"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PA11"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PD2"/>
+        <pin position="C6" name="PB8"/>
+        <pin position="C7" name="PC1"/>
+        <pin position="C8" name="PC13"/>
+        <pin position="C9" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA10"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D4" name="PC7"/>
+        <pin position="D5" name="PC6"/>
+        <pin position="D6" name="PB9"/>
+        <pin position="D7" name="PC2"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="PC8"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PB14"/>
+        <pin position="E4" name="PB0"/>
+        <pin position="E5" name="PA4"/>
+        <pin position="E6" name="PA3"/>
+        <pin position="E7" name="PC3"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="PH0 - OSC_IN"/>
+        <pin position="F1" name="VDDUSB" type="power"/>
+        <pin position="F2" name="PD9"/>
+        <pin position="F3" name="PB12"/>
+        <pin position="F4" name="PE13"/>
+        <pin position="F5" name="PA6"/>
+        <pin position="F6" name="BYPASS_REG" type="boot"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="F8" name="PC0"/>
+        <pin position="F9" name="PH1 - OSC_OUT"/>
+        <pin position="G1" name="PD10"/>
+        <pin position="G2" name="PB13"/>
+        <pin position="G3" name="PE14"/>
+        <pin position="G4" name="PE10"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PA5"/>
+        <pin position="G7" name="PA0"/>
+        <pin position="G8" name="VREF+" type="power"/>
+        <pin position="G9" name="NRST" type="reset"/>
+        <pin position="H1" name="PB15"/>
+        <pin position="H2" name="VCAP_1" type="power"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PE11"/>
+        <pin position="H5" name="PB2"/>
+        <pin position="H6" name="PC4"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PA1"/>
+        <pin position="H9" name="VSSA" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PE15"/>
+        <pin position="J4" name="PE12"/>
+        <pin position="J5" name="PE9"/>
+        <pin position="J6" name="PC5"/>
+        <pin position="J7" name="PA7"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-27_29_37_39.xml
+++ b/devices/stm32/stm32f4-27_29_37_39.xml
@@ -1680,6 +1680,1379 @@
       <gpio device-pin="b|n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0/OSC_IN"/>
+        <pin position="13" name="PH1/OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0/WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2/BOOT1"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VCAP_1" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0/OSC_IN"/>
+        <pin position="24" name="PH1/OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0/WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2/BOOT1"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0/OSC_IN"/>
+        <pin position="30" name="PH1/OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0/WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2/BOOT1"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP_2" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0/OSC_IN"/>
+        <pin position="33" name="PH1/OSC_OUT"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2"/>
+        <pin position="38" name="PC3"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="power"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0/WKUP"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2/BOOT1"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP_1" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin position="118" name="PJ6"/>
+        <pin position="119" name="PJ7"/>
+        <pin position="120" name="PJ8"/>
+        <pin position="121" name="PJ9"/>
+        <pin position="122" name="PJ10"/>
+        <pin position="123" name="PJ11"/>
+        <pin position="124" name="VDD" type="power"/>
+        <pin position="125" name="VSS" type="power"/>
+        <pin position="126" name="PK0"/>
+        <pin position="127" name="PK1"/>
+        <pin position="128" name="PK2"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDD" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13"/>
+        <pin position="148" name="VCAP_2" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14"/>
+        <pin position="160" name="PA15"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDD" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3"/>
+        <pin position="193" name="PB4"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP_2" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="PK1"/>
+        <pin position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="PJ11"/>
+        <pin position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD" type="power"/>
+        <pin position="H12" name="PJ8"/>
+        <pin position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PJ7"/>
+        <pin position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3"/>
+        <pin position="L5" name="BYPASS_REG" type="reset"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PB2/BOOT1"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="NC" type="nc"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PC12"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PI3"/>
+        <pin position="A13" name="NC" type="nc"/>
+        <pin position="B1" name="PI7"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PI4"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB3"/>
+        <pin position="B7" name="PG11"/>
+        <pin position="B8" name="PD6"/>
+        <pin position="B9" name="PD2"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PA15"/>
+        <pin position="B12" name="PI2"/>
+        <pin position="B13" name="PI0"/>
+        <pin position="C1" name="PE3"/>
+        <pin position="C2" name="PE4"/>
+        <pin position="C3" name="PDR_ON" type="reset"/>
+        <pin position="C4" name="PB9"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PG15"/>
+        <pin position="C7" name="PG10"/>
+        <pin position="C8" name="PD5"/>
+        <pin position="C9" name="PD1"/>
+        <pin position="C10" name="PC10"/>
+        <pin position="C11" name="PI1"/>
+        <pin position="C12" name="PH15"/>
+        <pin position="C13" name="PH14"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PB8"/>
+        <pin position="D5" name="PB5"/>
+        <pin position="D6" name="VDD" type="power"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="PD4"/>
+        <pin position="D9" name="PD0"/>
+        <pin position="D10" name="VDD" type="power"/>
+        <pin position="D11" name="VSS" type="power"/>
+        <pin position="D12" name="VCAP_2" type="power"/>
+        <pin position="D13" name="PH13"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PC13"/>
+        <pin position="E5" name="VBAT" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PA9"/>
+        <pin position="E9" name="PA10"/>
+        <pin position="E10" name="PA11"/>
+        <pin position="E11" name="PA12"/>
+        <pin position="E12" name="PA13"/>
+        <pin position="E13" name="PA8"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="PF0"/>
+        <pin position="F3" name="PF1"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC9"/>
+        <pin position="F13" name="PG8"/>
+        <pin position="G1" name="PH1/OSC_OUT"/>
+        <pin position="G2" name="PH0/OSC_IN"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF3"/>
+        <pin position="G5" name="PF2"/>
+        <pin position="G6" name="PC0"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VDD" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VDD" type="power"/>
+        <pin position="G11" name="PG6"/>
+        <pin position="G12" name="PG7"/>
+        <pin position="G13" name="PG5"/>
+        <pin position="H1" name="PF10"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="VDD" type="power"/>
+        <pin position="H5" name="PC1"/>
+        <pin position="H6" name="PC2"/>
+        <pin position="H7" name="PC3"/>
+        <pin position="H8" name="VDD" type="power"/>
+        <pin position="H9" name="PE13"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PG4"/>
+        <pin position="H13" name="PG2"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="VREF-" type="power"/>
+        <pin position="J3" name="VREF+" type="power"/>
+        <pin position="J4" name="VDDA" type="power"/>
+        <pin position="J5" name="PA0/WKUP"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="PE8"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD12"/>
+        <pin position="K1" name="PA1"/>
+        <pin position="K2" name="PA2"/>
+        <pin position="K3" name="PA3"/>
+        <pin position="K4" name="PA7"/>
+        <pin position="K5" name="PB1"/>
+        <pin position="K6" name="VDD" type="power"/>
+        <pin position="K7" name="PF14"/>
+        <pin position="K8" name="PE9"/>
+        <pin position="K9" name="PE15"/>
+        <pin position="K10" name="PH9"/>
+        <pin position="K11" name="PD10"/>
+        <pin position="K12" name="PD13"/>
+        <pin position="K13" name="PD9"/>
+        <pin position="L1" name="PH3"/>
+        <pin position="L2" name="PH2"/>
+        <pin position="L3" name="PH5"/>
+        <pin position="L4" name="PC4"/>
+        <pin position="L5" name="PB2/BOOT1"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PF15"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH8"/>
+        <pin position="L11" name="PH12"/>
+        <pin position="L12" name="PD8"/>
+        <pin position="L13" name="PB15"/>
+        <pin position="M1" name="BYPASS_REG" type="reset"/>
+        <pin position="M2" name="PH4"/>
+        <pin position="M3" name="PA5"/>
+        <pin position="M4" name="PC5"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PE11"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="PH7"/>
+        <pin position="M11" name="PH11"/>
+        <pin position="M12" name="PB13"/>
+        <pin position="M13" name="PB14"/>
+        <pin position="N1" name="NC" type="nc"/>
+        <pin position="N2" name="PA4"/>
+        <pin position="N3" name="PA6"/>
+        <pin position="N4" name="PB0"/>
+        <pin position="N5" name="PF12"/>
+        <pin position="N6" name="PG0"/>
+        <pin position="N7" name="PE7"/>
+        <pin position="N8" name="PE12"/>
+        <pin position="N9" name="VCAP_1" type="power"/>
+        <pin position="N10" name="PH6"/>
+        <pin position="N11" name="PH10"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="NC" type="nc"/>
+      </package>
+      <package device-pin="i" device-package="h" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2/BOOT1"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="y" name="WLCSP143">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PD5"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PG12"/>
+        <pin position="A7" name="PG15"/>
+        <pin position="A8" name="PB6"/>
+        <pin position="A9" name="PB8"/>
+        <pin position="A10" name="PE1"/>
+        <pin position="A11" name="PDR_ON" type="reset"/>
+        <pin position="B1" name="PA14"/>
+        <pin position="B2" name="PC11"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD3"/>
+        <pin position="B5" name="PD4"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="PB3"/>
+        <pin position="B8" name="PB7"/>
+        <pin position="B9" name="PB9"/>
+        <pin position="B10" name="PE0"/>
+        <pin position="B11" name="PE4"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="PA15"/>
+        <pin position="C3" name="PC12"/>
+        <pin position="C4" name="PD1"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PG10"/>
+        <pin position="C7" name="PB4"/>
+        <pin position="C8" name="PB5"/>
+        <pin position="C9" name="BOOT0" type="boot"/>
+        <pin position="C10" name="PE3"/>
+        <pin position="C11" name="VBAT" type="power"/>
+        <pin position="D1" name="VCAP_2" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PA13"/>
+        <pin position="D4" name="PA11"/>
+        <pin position="D5" name="PA10"/>
+        <pin position="D6" name="PG13"/>
+        <pin position="D7" name="VDD" type="power"/>
+        <pin position="D8" name="PE2"/>
+        <pin position="D9" name="PE5"/>
+        <pin position="D10" name="PC13"/>
+        <pin position="D11" name="PC14/OSC32_IN"/>
+        <pin position="E1" name="PA12"/>
+        <pin position="E2" name="PA9"/>
+        <pin position="E3" name="PC9"/>
+        <pin position="E4" name="PC8"/>
+        <pin position="E5" name="PG9"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PE6"/>
+        <pin position="E9" name="PF1"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="PC15/OSC32_OUT"/>
+        <pin position="F1" name="PA8"/>
+        <pin position="F2" name="PC6"/>
+        <pin position="F3" name="PC7"/>
+        <pin position="F4" name="PD6"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="PG14"/>
+        <pin position="F7" name="PF7"/>
+        <pin position="F8" name="PF5"/>
+        <pin position="F9" name="PF4"/>
+        <pin position="F10" name="PF2"/>
+        <pin position="F11" name="PF0"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="PG8"/>
+        <pin position="G3" name="PG3"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G5" name="PG4"/>
+        <pin position="G6" name="PG5"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="PF9"/>
+        <pin position="G9" name="PF10"/>
+        <pin position="G10" name="PF6"/>
+        <pin position="G11" name="PF3"/>
+        <pin position="H1" name="PG7"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H4" name="PD10"/>
+        <pin position="H5" name="PD13"/>
+        <pin position="H6" name="PD12"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PC0"/>
+        <pin position="H9" name="NRST" type="reset"/>
+        <pin position="H10" name="PH1/OSC_OUT"/>
+        <pin position="H11" name="PF8"/>
+        <pin position="J1" name="PG2"/>
+        <pin position="J2" name="PD14"/>
+        <pin position="J3" name="PB15"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VDD" type="power"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PC3"/>
+        <pin position="J10" name="PC2"/>
+        <pin position="J11" name="PH0/OSC_IN"/>
+        <pin position="K1" name="PD15"/>
+        <pin position="K2" name="PD11"/>
+        <pin position="K3" name="PB14"/>
+        <pin position="K4" name="PE11"/>
+        <pin position="K5" name="PG1"/>
+        <pin position="K6" name="PF13"/>
+        <pin position="K7" name="PB1"/>
+        <pin position="K8" name="PA1"/>
+        <pin position="K9" name="PA0/WKUP"/>
+        <pin position="K10" name="VSSA" type="power"/>
+        <pin position="K11" name="PC1"/>
+        <pin position="L1" name="VDD" type="power"/>
+        <pin position="L2" name="PD8"/>
+        <pin position="L3" name="PE15"/>
+        <pin position="L4" name="PE12"/>
+        <pin position="L5" name="PE7"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PB2/BOOT1"/>
+        <pin position="L8" name="PA7"/>
+        <pin position="L9" name="PA2"/>
+        <pin position="L10" name="VDDA" type="power"/>
+        <pin position="L11" name="VREF+" type="power"/>
+        <pin position="M1" name="PD9"/>
+        <pin position="M2" name="PB12"/>
+        <pin position="M3" name="PB10"/>
+        <pin position="M4" name="PE14"/>
+        <pin position="M5" name="PE8"/>
+        <pin position="M6" name="PF15"/>
+        <pin position="M7" name="PF11"/>
+        <pin position="M8" name="PC4"/>
+        <pin position="M9" name="PA5"/>
+        <pin position="M10" name="PA4"/>
+        <pin position="M11" name="PA3"/>
+        <pin position="N1" name="PB13"/>
+        <pin position="N2" name="VCAP_1" type="power"/>
+        <pin position="N3" name="PB11"/>
+        <pin position="N4" name="PE13"/>
+        <pin position="N5" name="PE9"/>
+        <pin position="N6" name="PG0"/>
+        <pin position="N7" name="PF12"/>
+        <pin position="N8" name="PB0"/>
+        <pin position="N9" name="PC5"/>
+        <pin position="N10" name="PA6"/>
+        <pin position="N11" name="BYPASS_REG" type="reset"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-46.xml
+++ b/devices/stm32/stm32f4-46.xml
@@ -1386,6 +1386,549 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="VSSA" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP_1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h|j" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0-OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1-OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP_2" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="BYPASS_REG" type="reset"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP_1" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0-WKUP"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="m" name="WLCSP81">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC12"/>
+        <pin position="A3" name="PD4"/>
+        <pin position="A4" name="PD7"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PE4"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA15"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD6"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PB7"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PDR_ON" type="reset"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="VCAP_2" type="power"/>
+        <pin position="C3" name="PA14"/>
+        <pin position="C4" name="PD1"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PB8"/>
+        <pin position="C7" name="PB9"/>
+        <pin position="C8" name="PC13"/>
+        <pin position="C9" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PA13"/>
+        <pin position="D3" name="PC10"/>
+        <pin position="D4" name="PC11"/>
+        <pin position="D5" name="PD2"/>
+        <pin position="D6" name="PE3"/>
+        <pin position="D7" name="PE2"/>
+        <pin position="D8" name="NRST" type="reset"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="VDDUSB" type="power"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA10"/>
+        <pin position="E4" name="PA12"/>
+        <pin position="E5" name="PA7"/>
+        <pin position="E6" name="PA3"/>
+        <pin position="E7" name="PA2"/>
+        <pin position="E8" name="PC2"/>
+        <pin position="E9" name="PH0-OSC_IN"/>
+        <pin position="F1" name="PC6"/>
+        <pin position="F2" name="PC7"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F4" name="PA9"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PA5"/>
+        <pin position="F7" name="VSSA" type="power"/>
+        <pin position="F8" name="PC3"/>
+        <pin position="F9" name="PH1-OSC_OUT"/>
+        <pin position="G1" name="PD13"/>
+        <pin position="G2" name="PD12"/>
+        <pin position="G3" name="PB15"/>
+        <pin position="G4" name="PB12"/>
+        <pin position="G5" name="PE9"/>
+        <pin position="G6" name="PA6"/>
+        <pin position="G7" name="PA1"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="PC0"/>
+        <pin position="H1" name="PD11"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PE8"/>
+        <pin position="H6" name="PB1"/>
+        <pin position="H7" name="PA4"/>
+        <pin position="H8" name="VREF+" type="power"/>
+        <pin position="H9" name="VDD" type="power"/>
+        <pin position="J1" name="PB14"/>
+        <pin position="J2" name="VDD" type="power"/>
+        <pin position="J3" name="VCAP_1" type="power"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="PE7"/>
+        <pin position="J6" name="PB2"/>
+        <pin position="J7" name="PC4"/>
+        <pin position="J8" name="BYPASS_REG" type="reset"/>
+        <pin position="J9" name="PA0-WKUP"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f4-69_79.xml
+++ b/devices/stm32/stm32f4-69_79.xml
@@ -1677,6 +1677,1404 @@
       <gpio device-pin="b|n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="VSS" type="power"/>
+        <pin position="3" name="VBAT" type="power"/>
+        <pin position="4" name="PC13"/>
+        <pin position="5" name="PC14/OSC32_IN"/>
+        <pin position="6" name="PC15/OSC32_OUT"/>
+        <pin position="7" name="VSS" type="power"/>
+        <pin position="8" name="VDD" type="power"/>
+        <pin position="9" name="PH0/OSC_IN"/>
+        <pin position="10" name="PH1/OSC_OUT"/>
+        <pin position="11" name="NRST" type="reset"/>
+        <pin position="12" name="PC0"/>
+        <pin position="13" name="PC1"/>
+        <pin position="14" name="PC2"/>
+        <pin position="15" name="PC3"/>
+        <pin position="16" name="VSSA" type="power"/>
+        <pin position="17" name="VREF+" type="power"/>
+        <pin position="18" name="VDDA" type="power"/>
+        <pin position="19" name="PA0/WKUP"/>
+        <pin position="20" name="PA1"/>
+        <pin position="21" name="PA2"/>
+        <pin position="22" name="PA3"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PA4"/>
+        <pin position="26" name="PA5"/>
+        <pin position="27" name="PA6"/>
+        <pin position="28" name="PA7"/>
+        <pin position="29" name="PB0"/>
+        <pin position="30" name="PB1"/>
+        <pin position="31" name="PB2/BOOT1"/>
+        <pin position="32" name="PE7"/>
+        <pin position="33" name="PE8"/>
+        <pin position="34" name="PE9"/>
+        <pin position="35" name="PE10"/>
+        <pin position="36" name="PE11"/>
+        <pin position="37" name="PE12"/>
+        <pin position="38" name="PE13"/>
+        <pin position="39" name="PE14"/>
+        <pin position="40" name="PE15"/>
+        <pin position="41" name="PB10"/>
+        <pin position="42" name="PB11"/>
+        <pin position="43" name="VCAP1" type="power"/>
+        <pin position="44" name="VSS" type="power"/>
+        <pin position="45" name="VDD" type="power"/>
+        <pin position="46" name="PB12"/>
+        <pin position="47" name="PB13"/>
+        <pin position="48" name="PB14"/>
+        <pin position="49" name="PB15"/>
+        <pin position="50" name="PD8"/>
+        <pin position="51" name="PD9"/>
+        <pin position="52" name="PD10"/>
+        <pin position="53" name="PD14"/>
+        <pin position="54" name="PD15"/>
+        <pin position="55" name="VDDDSI" type="power"/>
+        <pin position="56" name="VCAPDSI" type="power"/>
+        <pin position="57" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="58" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="59" name="VSSDSI" type="power"/>
+        <pin position="60" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="61" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="62" name="VDD12DSI" type="power"/>
+        <pin position="63" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="64" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="65" name="VDDUSB" type="power"/>
+        <pin position="66" name="PC6"/>
+        <pin position="67" name="PC7"/>
+        <pin position="68" name="PC8"/>
+        <pin position="69" name="PC9"/>
+        <pin position="70" name="PA8"/>
+        <pin position="71" name="PA9"/>
+        <pin position="72" name="PA10"/>
+        <pin position="73" name="PA11"/>
+        <pin position="74" name="PA12"/>
+        <pin position="75" name="PA13"/>
+        <pin position="76" name="VCAP2" type="power"/>
+        <pin position="77" name="VDD" type="power"/>
+        <pin position="78" name="VSS" type="power"/>
+        <pin position="79" name="PA14"/>
+        <pin position="80" name="PA15"/>
+        <pin position="81" name="PC10"/>
+        <pin position="82" name="PC11"/>
+        <pin position="83" name="PC12"/>
+        <pin position="84" name="PD0"/>
+        <pin position="85" name="PD1"/>
+        <pin position="86" name="PD2"/>
+        <pin position="87" name="PD3"/>
+        <pin position="88" name="PD4"/>
+        <pin position="89" name="PD5"/>
+        <pin position="90" name="PD6"/>
+        <pin position="91" name="PD7"/>
+        <pin position="92" name="PB3"/>
+        <pin position="93" name="PB4"/>
+        <pin position="94" name="PB5"/>
+        <pin position="95" name="PB6"/>
+        <pin position="96" name="PB7"/>
+        <pin position="97" name="BOOT0" type="boot"/>
+        <pin position="98" name="PB8"/>
+        <pin position="99" name="PB9"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE3"/>
+        <pin position="2" name="PE4"/>
+        <pin position="3" name="PE5"/>
+        <pin position="4" name="PE6"/>
+        <pin position="5" name="VBAT" type="power"/>
+        <pin position="6" name="PC13"/>
+        <pin position="7" name="PC14/OSC32_IN"/>
+        <pin position="8" name="PC15/OSC32_OUT"/>
+        <pin position="9" name="PF0"/>
+        <pin position="10" name="PF1"/>
+        <pin position="11" name="PF2"/>
+        <pin position="12" name="PF3"/>
+        <pin position="13" name="PF4"/>
+        <pin position="14" name="PF5"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PF10"/>
+        <pin position="18" name="PH0/OSC_IN"/>
+        <pin position="19" name="PH1/OSC_OUT"/>
+        <pin position="20" name="NRST" type="reset"/>
+        <pin position="21" name="PC0"/>
+        <pin position="22" name="PC1"/>
+        <pin position="23" name="PC2"/>
+        <pin position="24" name="PC3"/>
+        <pin position="25" name="VDD" type="power"/>
+        <pin position="26" name="VSSA" type="power"/>
+        <pin position="27" name="VREF+" type="power"/>
+        <pin position="28" name="VDDA" type="power"/>
+        <pin position="29" name="PA0/WKUP"/>
+        <pin position="30" name="PA1"/>
+        <pin position="31" name="PA2"/>
+        <pin position="32" name="PA3"/>
+        <pin position="33" name="VSS" type="power"/>
+        <pin position="34" name="VDD" type="power"/>
+        <pin position="35" name="PA4"/>
+        <pin position="36" name="PA5"/>
+        <pin position="37" name="PA6"/>
+        <pin position="38" name="PA7"/>
+        <pin position="39" name="PC4"/>
+        <pin position="40" name="PC5"/>
+        <pin position="41" name="PB0"/>
+        <pin position="42" name="PB1"/>
+        <pin position="43" name="PB2/BOOT1"/>
+        <pin position="44" name="PF11"/>
+        <pin position="45" name="PF12"/>
+        <pin position="46" name="VDD" type="power"/>
+        <pin position="47" name="PF13"/>
+        <pin position="48" name="PF14"/>
+        <pin position="49" name="PF15"/>
+        <pin position="50" name="PG0"/>
+        <pin position="51" name="PG1"/>
+        <pin position="52" name="PE7"/>
+        <pin position="53" name="PE8"/>
+        <pin position="54" name="PE9"/>
+        <pin position="55" name="VSS" type="power"/>
+        <pin position="56" name="VDD" type="power"/>
+        <pin position="57" name="PE10"/>
+        <pin position="58" name="PE11"/>
+        <pin position="59" name="PE12"/>
+        <pin position="60" name="PE13"/>
+        <pin position="61" name="PE14"/>
+        <pin position="62" name="PE15"/>
+        <pin position="63" name="PB10"/>
+        <pin position="64" name="PB11"/>
+        <pin position="65" name="VCAP1" type="power"/>
+        <pin position="66" name="VDD" type="power"/>
+        <pin position="67" name="PB12"/>
+        <pin position="68" name="PB13"/>
+        <pin position="69" name="PB14"/>
+        <pin position="70" name="PB15"/>
+        <pin position="71" name="PD8"/>
+        <pin position="72" name="PD9"/>
+        <pin position="73" name="PD10"/>
+        <pin position="74" name="PD11"/>
+        <pin position="75" name="PD12"/>
+        <pin position="76" name="VSS" type="power"/>
+        <pin position="77" name="VDD" type="power"/>
+        <pin position="78" name="PD14"/>
+        <pin position="79" name="PD15"/>
+        <pin position="80" name="VDDDSI" type="power"/>
+        <pin position="81" name="VCAPDSI" type="power"/>
+        <pin position="82" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="83" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="84" name="VSSDSI" type="power"/>
+        <pin position="85" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="86" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="87" name="VDD12DSI" type="power"/>
+        <pin position="88" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="89" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="90" name="PG2"/>
+        <pin position="91" name="PG3"/>
+        <pin position="92" name="PG4"/>
+        <pin position="93" name="PG5"/>
+        <pin position="94" name="PG6"/>
+        <pin position="95" name="PG7"/>
+        <pin position="96" name="PG8"/>
+        <pin position="97" name="VDDUSB" type="power"/>
+        <pin position="98" name="PC6"/>
+        <pin position="99" name="PC7"/>
+        <pin position="100" name="PC8"/>
+        <pin position="101" name="PC9"/>
+        <pin position="102" name="PA8"/>
+        <pin position="103" name="PA9"/>
+        <pin position="104" name="PA10"/>
+        <pin position="105" name="PA11"/>
+        <pin position="106" name="PA12"/>
+        <pin position="107" name="PA13"/>
+        <pin position="108" name="VCAP2" type="power"/>
+        <pin position="109" name="VSS" type="power"/>
+        <pin position="110" name="VDD" type="power"/>
+        <pin position="111" name="PA14"/>
+        <pin position="112" name="PA15"/>
+        <pin position="113" name="PC10"/>
+        <pin position="114" name="PC11"/>
+        <pin position="115" name="PC12"/>
+        <pin position="116" name="PD0"/>
+        <pin position="117" name="PD1"/>
+        <pin position="118" name="PD2"/>
+        <pin position="119" name="PD3"/>
+        <pin position="120" name="PD4"/>
+        <pin position="121" name="PD5"/>
+        <pin position="122" name="VSS" type="power"/>
+        <pin position="123" name="VDD" type="power"/>
+        <pin position="124" name="PD6"/>
+        <pin position="125" name="PG9"/>
+        <pin position="126" name="PG10"/>
+        <pin position="127" name="PG11"/>
+        <pin position="128" name="PG12"/>
+        <pin position="129" name="VSS" type="power"/>
+        <pin position="130" name="VDD" type="power"/>
+        <pin position="131" name="PG15"/>
+        <pin position="132" name="PB3"/>
+        <pin position="133" name="PB4"/>
+        <pin position="134" name="PB5"/>
+        <pin position="135" name="PB6"/>
+        <pin position="136" name="PB7"/>
+        <pin position="137" name="BOOT0" type="boot"/>
+        <pin position="138" name="PB8"/>
+        <pin position="139" name="PB9"/>
+        <pin position="140" name="PE0"/>
+        <pin position="141" name="PE1"/>
+        <pin position="142" name="PDR_ON" type="reset"/>
+        <pin position="143" name="VDD" type="power"/>
+        <pin position="144" name="PE2"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0/OSC_IN"/>
+        <pin position="30" name="PH1/OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0/WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2/BOOT1"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PB12"/>
+        <pin position="86" name="PB13"/>
+        <pin position="87" name="PB14"/>
+        <pin position="88" name="PB15"/>
+        <pin position="89" name="PD8"/>
+        <pin position="90" name="PD9"/>
+        <pin position="91" name="PD10"/>
+        <pin position="92" name="PD11"/>
+        <pin position="93" name="PD12"/>
+        <pin position="94" name="PD13"/>
+        <pin position="95" name="VSS" type="power"/>
+        <pin position="96" name="VDD" type="power"/>
+        <pin position="97" name="PD14"/>
+        <pin position="98" name="PD15"/>
+        <pin position="99" name="VDDDSI" type="power"/>
+        <pin position="100" name="VCAPDSI" type="power"/>
+        <pin position="101" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="102" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="103" name="VSSDSI" type="power"/>
+        <pin position="104" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="105" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="106" name="VDD12DSI" type="power"/>
+        <pin position="107" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="108" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="109" name="VSSDSI" type="power"/>
+        <pin position="110" name="PG2"/>
+        <pin position="111" name="PG3"/>
+        <pin position="112" name="PG4"/>
+        <pin position="113" name="PG5"/>
+        <pin position="114" name="PG6"/>
+        <pin position="115" name="PG7"/>
+        <pin position="116" name="PG8"/>
+        <pin position="117" name="VSS" type="power"/>
+        <pin position="118" name="VDDUSB" type="power"/>
+        <pin position="119" name="PC6"/>
+        <pin position="120" name="PC7"/>
+        <pin position="121" name="PC8"/>
+        <pin position="122" name="PC9"/>
+        <pin position="123" name="PA8"/>
+        <pin position="124" name="PA9"/>
+        <pin position="125" name="PA10"/>
+        <pin position="126" name="PA11"/>
+        <pin position="127" name="PA12"/>
+        <pin position="128" name="PA13"/>
+        <pin position="129" name="VCAP2" type="power"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PI0"/>
+        <pin position="133" name="PI1"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0/OSC_IN"/>
+        <pin position="33" name="PH1/OSC_OUT"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2"/>
+        <pin position="38" name="PC3"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="power"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0/WKUP"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2/BOOT1"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP1" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin position="118" name="VDDDSI" type="power"/>
+        <pin position="119" name="VCAPDSI" type="power"/>
+        <pin position="120" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="121" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="122" name="VSSDSI" type="power"/>
+        <pin position="123" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="124" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="125" name="VDD12DSI" type="power"/>
+        <pin position="126" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="127" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="128" name="VSSDSI" type="power"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDDUSB" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13"/>
+        <pin position="148" name="VCAP2" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14"/>
+        <pin position="160" name="PA15"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDD" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3"/>
+        <pin position="193" name="PB4"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP2" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="F13" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDDUSB" type="power"/>
+        <pin position="G12" name="VSSDSI" type="power"/>
+        <pin position="G13" name="VDD12DSI" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDDDSI" type="power"/>
+        <pin position="H12" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="H13" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="J13" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="VCAPDSI" type="power"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3"/>
+        <pin position="L5" name="BYPASS_REG" type="reset"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP1" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PB2/BOOT1"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="a" device-package="h" name="UFBGA169">
+        <pin position="A1" name="PI6"/>
+        <pin position="A2" name="PI5"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PG13"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="PC12"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="A13" name="PA11"/>
+        <pin position="B1" name="PI7"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PI4"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB3"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="PD5"/>
+        <pin position="B8" name="PD2"/>
+        <pin position="B9" name="PC11"/>
+        <pin position="B10" name="PI3"/>
+        <pin position="B11" name="PA15"/>
+        <pin position="B12" name="PI2"/>
+        <pin position="B13" name="PI0"/>
+        <pin position="C1" name="PE3"/>
+        <pin position="C2" name="PE4"/>
+        <pin position="C3" name="PDR_ON" type="reset"/>
+        <pin position="C4" name="PB9"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PD4"/>
+        <pin position="C7" name="PD1"/>
+        <pin position="C8" name="PD3"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC10"/>
+        <pin position="C11" name="PI1"/>
+        <pin position="C12" name="PH15"/>
+        <pin position="C13" name="PH14"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PB8"/>
+        <pin position="D5" name="PB5"/>
+        <pin position="D6" name="PB4"/>
+        <pin position="D7" name="PD6"/>
+        <pin position="D8" name="PA8"/>
+        <pin position="D9" name="PH13"/>
+        <pin position="D10" name="VDD" type="power"/>
+        <pin position="D11" name="VSS" type="power"/>
+        <pin position="D12" name="VCAP2" type="power"/>
+        <pin position="D13" name="PG8"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PI10"/>
+        <pin position="E5" name="VBAT" type="power"/>
+        <pin position="E6" name="PG9"/>
+        <pin position="E7" name="PG10"/>
+        <pin position="E8" name="PA9"/>
+        <pin position="E9" name="PA10"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PG7"/>
+        <pin position="E12" name="PG5"/>
+        <pin position="E13" name="PG4"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="PI11"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="PG15"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PG6"/>
+        <pin position="F12" name="PG3"/>
+        <pin position="F13" name="PG2"/>
+        <pin position="G1" name="PH1/OSC_OUT"/>
+        <pin position="G2" name="PH0/OSC_IN"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PC13"/>
+        <pin position="G5" name="PF2"/>
+        <pin position="G6" name="PE8"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VDD" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="PC9"/>
+        <pin position="G11" name="VDDUSB" type="power"/>
+        <pin position="G12" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="G13" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="H1" name="PF10"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="PF14"/>
+        <pin position="H6" name="PE9"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PH8"/>
+        <pin position="H9" name="PH9"/>
+        <pin position="H10" name="PH12"/>
+        <pin position="H11" name="VSSDSI" type="power"/>
+        <pin position="H12" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="H13" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="VSSA" type="power"/>
+        <pin position="J3" name="VDDA" type="power"/>
+        <pin position="J4" name="VDD" type="power"/>
+        <pin position="J5" name="PA0/WKUP"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="PE13"/>
+        <pin position="J9" name="PH10"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD12DSI" type="power"/>
+        <pin position="J12" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="J13" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="K1" name="PA1"/>
+        <pin position="K2" name="PA2"/>
+        <pin position="K3" name="PA3"/>
+        <pin position="K4" name="PA7"/>
+        <pin position="K5" name="PB1"/>
+        <pin position="K6" name="VDD" type="power"/>
+        <pin position="K7" name="PE11"/>
+        <pin position="K8" name="PE14"/>
+        <pin position="K9" name="PH11"/>
+        <pin position="K10" name="VDD" type="power"/>
+        <pin position="K11" name="VSSDSI" type="power"/>
+        <pin position="K12" name="VCAPDSI" type="power"/>
+        <pin position="K13" name="VDDDSI" type="power"/>
+        <pin position="L1" name="PH3"/>
+        <pin position="L2" name="PH2"/>
+        <pin position="L3" name="PH5"/>
+        <pin position="L4" name="PF4"/>
+        <pin position="L5" name="PB2/BOOT1"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PE12"/>
+        <pin position="L8" name="PE15"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="PD8"/>
+        <pin position="L11" name="PD10"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PD15"/>
+        <pin position="M1" name="PC0"/>
+        <pin position="M2" name="PH4"/>
+        <pin position="M3" name="PA5"/>
+        <pin position="M4" name="PF13"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF15"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PB10"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="PD9"/>
+        <pin position="M11" name="PD11"/>
+        <pin position="M12" name="PD13"/>
+        <pin position="M13" name="PD12"/>
+        <pin position="N1" name="PC1"/>
+        <pin position="N2" name="PA4"/>
+        <pin position="N3" name="PA6"/>
+        <pin position="N4" name="PB0"/>
+        <pin position="N5" name="PF12"/>
+        <pin position="N6" name="PG0"/>
+        <pin position="N7" name="PE7"/>
+        <pin position="N8" name="PB11"/>
+        <pin position="N9" name="VCAP1" type="power"/>
+        <pin position="N10" name="PB12"/>
+        <pin position="N11" name="PB13"/>
+        <pin position="N12" name="PB14"/>
+        <pin position="N13" name="PB15"/>
+      </package>
+      <package device-pin="i" device-package="h" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="NC" type="nc"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="VDD12DSI" type="power"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="E13" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSSDSI" type="power"/>
+        <pin position="H13" name="VDDUSB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDDDSI" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="VCAPDSI" type="power"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="L13" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2/BOOT1"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="M13" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="y" name="WLCSP168">
+        <pin position="A1" name="PI2"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PD1"/>
+        <pin position="A4" name="VSS" type="power"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PG12"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PB7"/>
+        <pin position="A10" name="PE0"/>
+        <pin position="A11" name="VDD" type="power"/>
+        <pin position="A12" name="PI7"/>
+        <pin position="B1" name="PH13"/>
+        <pin position="B2" name="PI3"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PD4"/>
+        <pin position="B5" name="VDD" type="power"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PB5"/>
+        <pin position="B9" name="PB8"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PI6"/>
+        <pin position="B12" name="PE5"/>
+        <pin position="C1" name="VSS" type="power"/>
+        <pin position="C2" name="VDD" type="power"/>
+        <pin position="C3" name="PI1"/>
+        <pin position="C4" name="PC12"/>
+        <pin position="C5" name="PD2"/>
+        <pin position="C6" name="PD5"/>
+        <pin position="C7" name="PG10"/>
+        <pin position="C8" name="PB4"/>
+        <pin position="C9" name="PE1"/>
+        <pin position="C10" name="PI5"/>
+        <pin position="C11" name="PE4"/>
+        <pin position="C12" name="VBAT" type="power"/>
+        <pin position="D1" name="PA13"/>
+        <pin position="D2" name="VCAP2" type="power"/>
+        <pin position="D3" name="PH14"/>
+        <pin position="D4" name="PA14"/>
+        <pin position="D5" name="PC10"/>
+        <pin position="D6" name="PD3"/>
+        <pin position="D7" name="PG9"/>
+        <pin position="D8" name="PG15"/>
+        <pin position="D9" name="PDR_ON" type="reset"/>
+        <pin position="D10" name="PI4"/>
+        <pin position="D11" name="PE6"/>
+        <pin position="D12" name="PC13"/>
+        <pin position="E1" name="PA8"/>
+        <pin position="E2" name="PA9"/>
+        <pin position="E3" name="PA10"/>
+        <pin position="E4" name="PH15"/>
+        <pin position="E5" name="PI0"/>
+        <pin position="E6" name="PD0"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PG13"/>
+        <pin position="E9" name="PB9"/>
+        <pin position="E10" name="PE3"/>
+        <pin position="E11" name="PC14/OSC32_IN"/>
+        <pin position="E12" name="PC15/OSC32_OUT"/>
+        <pin position="F1" name="VDDUSB" type="power"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F4" name="PC8"/>
+        <pin position="F5" name="PC9"/>
+        <pin position="F6" name="PA12"/>
+        <pin position="F7" name="PA11"/>
+        <pin position="F8" name="BOOT0" type="boot"/>
+        <pin position="F9" name="PE2"/>
+        <pin position="F10" name="PI10"/>
+        <pin position="F11" name="PI11"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PG5"/>
+        <pin position="G2" name="PG4"/>
+        <pin position="G3" name="PG6"/>
+        <pin position="G4" name="PG3"/>
+        <pin position="G5" name="PG2"/>
+        <pin position="G6" name="PG8"/>
+        <pin position="G7" name="PC7"/>
+        <pin position="G8" name="PB6"/>
+        <pin position="G9" name="PI9"/>
+        <pin position="G10" name="PF0"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="PF2"/>
+        <pin position="H1" name="VSSDSI" type="power"/>
+        <pin position="H2" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="H3" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="H4" name="PD13"/>
+        <pin position="H5" name="PB12"/>
+        <pin position="H6" name="PG7"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PF15"/>
+        <pin position="H9" name="NRST" type="reset"/>
+        <pin position="H10" name="PF1"/>
+        <pin position="H11" name="PF3"/>
+        <pin position="H12" name="PF5"/>
+        <pin position="J1" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="J2" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="J3" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="J4" name="PD11"/>
+        <pin position="J5" name="PE14"/>
+        <pin position="J6" name="PG0"/>
+        <pin position="J7" name="PF13"/>
+        <pin position="J8" name="PA7"/>
+        <pin position="J9" name="PC0"/>
+        <pin position="J10" name="PF4"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="K1" name="VCAPDSI" type="power"/>
+        <pin position="K2" name="VDD12DSI" type="power"/>
+        <pin position="K3" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="K4" name="PB13"/>
+        <pin position="K5" name="PB11"/>
+        <pin position="K6" name="PE9"/>
+        <pin position="K7" name="PF11"/>
+        <pin position="K8" name="PH5"/>
+        <pin position="K9" name="PA1"/>
+        <pin position="K10" name="PF10"/>
+        <pin position="K11" name="PH0/OSC_IN"/>
+        <pin position="K12" name="PH1/OSC_OUT"/>
+        <pin position="L1" name="VDDDSI" type="power"/>
+        <pin position="L2" name="PD15"/>
+        <pin position="L3" name="PD14"/>
+        <pin position="L4" name="PD8"/>
+        <pin position="L5" name="PH9"/>
+        <pin position="L6" name="PE13"/>
+        <pin position="L7" name="PF14"/>
+        <pin position="L8" name="PA5"/>
+        <pin position="L9" name="PA2"/>
+        <pin position="L10" name="PA0/WKUP"/>
+        <pin position="L11" name="VSSA" type="power"/>
+        <pin position="L12" name="PC1"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PD12"/>
+        <pin position="M3" name="PD10"/>
+        <pin position="M4" name="PH10"/>
+        <pin position="M5" name="PH8"/>
+        <pin position="M6" name="PE12"/>
+        <pin position="M7" name="PE8"/>
+        <pin position="M8" name="PF12"/>
+        <pin position="M9" name="PA4"/>
+        <pin position="M10" name="PH4"/>
+        <pin position="M11" name="PH2"/>
+        <pin position="M12" name="VDDA" type="power"/>
+        <pin position="N1" name="PD9"/>
+        <pin position="N2" name="PB15"/>
+        <pin position="N3" name="PH11"/>
+        <pin position="N4" name="VCAP1" type="power"/>
+        <pin position="N5" name="PB10"/>
+        <pin position="N6" name="PE11"/>
+        <pin position="N7" name="PE7"/>
+        <pin position="N8" name="VSS" type="power"/>
+        <pin position="N9" name="PB1"/>
+        <pin position="N10" name="PA3"/>
+        <pin position="N11" name="VSS" type="power"/>
+        <pin position="N12" name="PH3"/>
+        <pin position="P1" name="PB14"/>
+        <pin position="P2" name="PH12"/>
+        <pin position="P3" name="VDD" type="power"/>
+        <pin position="P4" name="VSS" type="power"/>
+        <pin position="P5" name="PE15"/>
+        <pin position="P6" name="PE10"/>
+        <pin position="P7" name="PG1"/>
+        <pin position="P8" name="VDD" type="power"/>
+        <pin position="P9" name="PB2/BOOT1"/>
+        <pin position="P10" name="PB0"/>
+        <pin position="P11" name="PA6"/>
+        <pin position="P12" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f7-22_23_32_33.xml
+++ b/devices/stm32/stm32f7-22_23_32_33.xml
@@ -1581,6 +1581,1078 @@
         <signal device-name="22" device-size="c|e" device-package="k|t" device-temperature="6" af="10" driver="usb_otg_hs" name="ulpi_dir"/>
         <signal device-name="22|32" device-size="e" device-package="k|t" device-temperature="6|7" af="10" driver="usb_otg_hs" name="ulpi_dir"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0-WKUP"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="53" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="33" device-size="e" device-temperature="6" position="53" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="53" name="PB14"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="53" name="PB14"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="54" name="VDDPHYHS" type="power"/>
+        <pin device-name="33" device-size="e" device-temperature="6" position="54" name="VDDPHYHS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="54" name="PB15"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="54" name="PB15"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="55" name="V12PHYHS" type="power"/>
+        <pin device-name="33" device-size="e" device-temperature="6" position="55" name="V12PHYHS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="55" name="PD8"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="55" name="PD8"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="56" name="PB14"/>
+        <pin device-name="33" device-size="e" device-temperature="6" position="56" name="PB14"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="56" name="PD9"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="56" name="PD9"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="57" name="PB15"/>
+        <pin device-name="33" device-size="e" device-temperature="6" position="57" name="PB15"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="57" name="PD10"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="75" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="75" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="75" name="PB14"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="75" name="PB14"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="76" name="V12PHYHS" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="76" name="V12PHYHS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="76" name="PB15"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="76" name="PB15"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="77" name="PB14"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="77" name="PB14"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="77" name="PD8"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="77" name="PD8"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="78" name="PB15"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="78" name="PB15"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="78" name="PD9"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="78" name="PD9"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="79" name="PD8"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="79" name="PD8"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="79" name="PD10"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="79" name="PD10"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="80" name="PD9"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="80" name="PD9"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="80" name="PD11"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="80" name="PD11"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="81" name="PD10"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="81" name="PD10"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="81" name="PD12"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="81" name="PD12"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="82" name="PD11"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="82" name="PD11"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="82" name="PD13"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="82" name="PD13"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="83" name="PD12"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="83" name="PD12"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="83" name="VSS" type="power"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="83" name="VSS" type="power"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="84" name="PD13"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="84" name="PD13"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="84" name="VDD" type="power"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="84" name="VDD" type="power"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="85" name="VSS" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="85" name="VSS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="85" name="PD14"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="85" name="PD14"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="86" name="VDD" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="86" name="VDD" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="86" name="PD15"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="86" name="PD15"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="87" name="PD14"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="87" name="PD14"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="87" name="PG2"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="87" name="PG2"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="88" name="PD15"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="88" name="PD15"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="88" name="PG3"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="88" name="PG3"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="89" name="PG2"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="89" name="PG2"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="89" name="PG4"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="89" name="PG4"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="90" name="PG3"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="90" name="PG3"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="90" name="PG5"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="90" name="PG5"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="91" name="PG4"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="91" name="PG4"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="91" name="PG6"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="91" name="PG6"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="92" name="PG5"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="92" name="PG5"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="92" name="PG7"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDDSDMMC" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN"/>
+        <pin position="10" name="PC15-OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN"/>
+        <pin position="30" name="PH1-OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0-WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="94" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="94" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="94" name="PB14"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="94" name="PB14"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="95" name="V12PHYHS" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="95" name="V12PHYHS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="95" name="PB15"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="95" name="PB15"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="96" name="PB14"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="96" name="PB14"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="96" name="PD8"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="96" name="PD8"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="97" name="PB15"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="97" name="PB15"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="97" name="PD9"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="97" name="PD9"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="98" name="PD8"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="98" name="PD8"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="98" name="PD10"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="98" name="PD10"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="99" name="PD9"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="99" name="PD9"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="99" name="PD11"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="99" name="PD11"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="100" name="PD10"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="100" name="PD10"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="100" name="PD12"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="100" name="PD12"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="101" name="PD11"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="101" name="PD11"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="101" name="PD13"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="101" name="PD13"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="102" name="PD12"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="102" name="PD12"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="102" name="VSS" type="power"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="102" name="VSS" type="power"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="103" name="PD13"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="103" name="PD13"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="103" name="VDD" type="power"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="103" name="VDD" type="power"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="104" name="VSS" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="104" name="VSS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="104" name="PD14"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="104" name="PD14"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="105" name="VDD" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="105" name="VDD" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="105" name="PD15"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="105" name="PD15"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="106" name="PD14"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="106" name="PD14"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="106" name="PG2"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="106" name="PG2"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="107" name="PD15"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="107" name="PD15"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="107" name="PG3"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="107" name="PG3"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="108" name="PG2"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="108" name="PG2"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="108" name="PG4"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="108" name="PG4"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="109" name="PG3"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="109" name="PG3"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="109" name="PG5"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="109" name="PG5"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="110" name="PG4"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="110" name="PG4"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="110" name="PG6"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="110" name="PG6"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="111" name="PG5"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="111" name="PG5"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="111" name="PG7"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDDUSB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP_2" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDDSDMMC" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VREF+" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PB0"/>
+        <pin position="26" name="PB1"/>
+        <pin position="27" name="PB2"/>
+        <pin position="28" name="PB10"/>
+        <pin position="29" name="PB11"/>
+        <pin position="30" name="VCAP_1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="i" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PA14"/>
+        <pin position="A12" name="PA13"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0-OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1-OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDDSDMMC" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP_2" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="BYPASS_REG" type="reset"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP_1" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="V12PHYHS" type="power"/>
+        <pin position="H11" name="REXTPHYHS" type="monoio"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0-WKUP"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDDSDMMC" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDDUSB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="J14" name="V12PHYHS" type="power"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="J14" name="V12PHYHS" type="power"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="J14" name="PG7"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="J14" name="PG7"/>
+        <pin device-name="23" device-size="c|e" device-temperature="6" position="J15" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="23|33" device-size="e" device-temperature="6|7" position="J15" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="22" device-size="c|e" device-temperature="6" position="J15" name="PG6"/>
+        <pin device-name="22|32" device-size="e" device-temperature="6|7" position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0-WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="VSS" type="power"/>
+        <pin position="A3" name="PC10"/>
+        <pin position="A4" name="PD1"/>
+        <pin position="A5" name="PD5"/>
+        <pin position="A6" name="PB3"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="A10" name="PE3"/>
+        <pin position="B1" name="PA13"/>
+        <pin position="B2" name="PA12"/>
+        <pin position="B3" name="VCAP_2" type="power"/>
+        <pin position="B4" name="PA15"/>
+        <pin position="B5" name="PD0"/>
+        <pin position="B6" name="PD4"/>
+        <pin position="B7" name="PB4"/>
+        <pin position="B8" name="PB7"/>
+        <pin position="B9" name="PE1"/>
+        <pin position="B10" name="PE6"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA9"/>
+        <pin position="C4" name="PA14"/>
+        <pin position="C5" name="PC11"/>
+        <pin position="C6" name="PD3"/>
+        <pin position="C7" name="PB5"/>
+        <pin position="C8" name="PB8"/>
+        <pin position="C9" name="PE2"/>
+        <pin position="C10" name="VBAT" type="power"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PC8"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D4" name="PC7"/>
+        <pin position="D5" name="PC12"/>
+        <pin position="D6" name="PD6"/>
+        <pin position="D7" name="PB6"/>
+        <pin position="D8" name="PB9"/>
+        <pin position="D9" name="PE4"/>
+        <pin position="D10" name="PC13"/>
+        <pin position="E1" name="PC6"/>
+        <pin position="E2" name="PD15"/>
+        <pin position="E3" name="PD13"/>
+        <pin position="E4" name="PE10"/>
+        <pin position="E5" name="PD2"/>
+        <pin position="E6" name="PD7"/>
+        <pin position="E7" name="PE0"/>
+        <pin position="E8" name="PE5"/>
+        <pin position="E9" name="PC14-OSC32_IN"/>
+        <pin position="E10" name="PC15-OSC32_OUT"/>
+        <pin position="F1" name="PD14"/>
+        <pin position="F2" name="PD12"/>
+        <pin position="F3" name="PD11"/>
+        <pin position="F4" name="PE15"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PA5"/>
+        <pin position="F7" name="PC3"/>
+        <pin position="F8" name="PC0"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="G1" name="V12PHYHS" type="power"/>
+        <pin position="G2" name="REXTPHYHS" type="monoio"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PE11"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PA6"/>
+        <pin position="G7" name="PA4"/>
+        <pin position="G8" name="PA0-WKUP"/>
+        <pin position="G9" name="NRST" type="reset"/>
+        <pin position="G10" name="PH0-OSC_IN"/>
+        <pin position="H1" name="PB15"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="PE12"/>
+        <pin position="H5" name="PE8"/>
+        <pin position="H6" name="PC4"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="PA2"/>
+        <pin position="H9" name="PC1"/>
+        <pin position="H10" name="PH1-OSC_OUT"/>
+        <pin position="J1" name="PB14"/>
+        <pin position="J2" name="PB12"/>
+        <pin position="J3" name="VCAP_1" type="power"/>
+        <pin position="J4" name="PE13"/>
+        <pin position="J5" name="PE7"/>
+        <pin position="J6" name="PC5"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="PA1"/>
+        <pin position="J9" name="VREF+" type="power"/>
+        <pin position="J10" name="PC2"/>
+        <pin position="K1" name="VDDPHYHS" type="power"/>
+        <pin position="K2" name="VDD" type="power"/>
+        <pin position="K3" name="VSS" type="power"/>
+        <pin position="K4" name="PE14"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PB2"/>
+        <pin position="K7" name="PA7"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VDDA" type="power"/>
+        <pin position="K10" name="VSSA" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f7-30_50.xml
+++ b/devices/stm32/stm32f7-30_50.xml
@@ -1885,6 +1885,770 @@
       <gpio device-pin="n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin device-name="50" device-temperature="6|7" position="8" name="PC14/OSC32_IN"/>
+        <pin device-name="30" device-temperature="6|7" position="8" name="PC14-OSC32_IN"/>
+        <pin device-name="50" device-temperature="6|7" position="9" name="PC15/OSC32_OUT"/>
+        <pin device-name="30" device-temperature="6|7" position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="12" name="PH0/OSC_IN"/>
+        <pin device-name="30" device-temperature="6|7" position="12" name="PH0-OSC_IN"/>
+        <pin device-name="50" device-temperature="6|7" position="13" name="PH1/OSC_OUT"/>
+        <pin device-name="30" device-temperature="6|7" position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="22" name="PA0/WKUP"/>
+        <pin device-name="30" device-temperature="6|7" position="22" name="PA0-WKUP"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin device-name="50" device-temperature="6|7" position="8" name="PC14/OSC32_IN"/>
+        <pin device-name="30" device-temperature="6|7" position="8" name="PC14-OSC32_IN"/>
+        <pin device-name="50" device-temperature="6|7" position="9" name="PC15/OSC32_OUT"/>
+        <pin device-name="30" device-temperature="6|7" position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin device-name="50" device-temperature="6|7" position="23" name="PH0/OSC_IN"/>
+        <pin device-name="30" device-temperature="6|7" position="23" name="PH0-OSC_IN"/>
+        <pin device-name="50" device-temperature="6|7" position="24" name="PH1/OSC_OUT"/>
+        <pin device-name="30" device-temperature="6|7" position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="34" name="PA0/WKUP"/>
+        <pin device-name="30" device-temperature="6|7" position="34" name="PA0-WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin device-name="50" device-temperature="6|7" position="75" name="PB14"/>
+        <pin device-name="30" device-temperature="6|7" position="75" name="REXTPHYHS" type="monoio"/>
+        <pin device-name="50" device-temperature="6|7" position="76" name="PB15"/>
+        <pin device-name="30" device-temperature="6|7" position="76" name="V12PHYHS" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="77" name="PD8"/>
+        <pin device-name="30" device-temperature="6|7" position="77" name="PB14"/>
+        <pin device-name="50" device-temperature="6|7" position="78" name="PD9"/>
+        <pin device-name="30" device-temperature="6|7" position="78" name="PB15"/>
+        <pin device-name="50" device-temperature="6|7" position="79" name="PD10"/>
+        <pin device-name="30" device-temperature="6|7" position="79" name="PD8"/>
+        <pin device-name="50" device-temperature="6|7" position="80" name="PD11"/>
+        <pin device-name="30" device-temperature="6|7" position="80" name="PD9"/>
+        <pin device-name="50" device-temperature="6|7" position="81" name="PD12"/>
+        <pin device-name="30" device-temperature="6|7" position="81" name="PD10"/>
+        <pin device-name="50" device-temperature="6|7" position="82" name="PD13"/>
+        <pin device-name="30" device-temperature="6|7" position="82" name="PD11"/>
+        <pin device-name="50" device-temperature="6|7" position="83" name="VSS" type="power"/>
+        <pin device-name="30" device-temperature="6|7" position="83" name="PD12"/>
+        <pin device-name="50" device-temperature="6|7" position="84" name="VDD" type="power"/>
+        <pin device-name="30" device-temperature="6|7" position="84" name="PD13"/>
+        <pin device-name="50" device-temperature="6|7" position="85" name="PD14"/>
+        <pin device-name="30" device-temperature="6|7" position="85" name="VSS" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="86" name="PD15"/>
+        <pin device-name="30" device-temperature="6|7" position="86" name="VDD" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="87" name="PG2"/>
+        <pin device-name="30" device-temperature="6|7" position="87" name="PD14"/>
+        <pin device-name="50" device-temperature="6|7" position="88" name="PG3"/>
+        <pin device-name="30" device-temperature="6|7" position="88" name="PD15"/>
+        <pin device-name="50" device-temperature="6|7" position="89" name="PG4"/>
+        <pin device-name="30" device-temperature="6|7" position="89" name="PG2"/>
+        <pin device-name="50" device-temperature="6|7" position="90" name="PG5"/>
+        <pin device-name="30" device-temperature="6|7" position="90" name="PG3"/>
+        <pin device-name="50" device-temperature="6|7" position="91" name="PG6"/>
+        <pin device-name="30" device-temperature="6|7" position="91" name="PG4"/>
+        <pin device-name="50" device-temperature="6|7" position="92" name="PG7"/>
+        <pin device-name="30" device-temperature="6|7" position="92" name="PG5"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin device-name="50" device-temperature="6|7" position="121" name="VDD" type="power"/>
+        <pin device-name="30" device-temperature="6|7" position="121" name="VDDSDMMC" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VREF+" type="power"/>
+        <pin position="14" name="PA0-WKUP"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PB0"/>
+        <pin position="26" name="PB1"/>
+        <pin position="27" name="PB2"/>
+        <pin position="28" name="PB10"/>
+        <pin position="29" name="PB11"/>
+        <pin position="30" name="VCAP_1" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP_2" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="PK1"/>
+        <pin position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDDUSB" type="power"/>
+        <pin position="G12" name="PJ11"/>
+        <pin position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD" type="power"/>
+        <pin position="H12" name="PJ8"/>
+        <pin position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PJ7"/>
+        <pin position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3"/>
+        <pin position="L5" name="BYPASS_REG" type="reset"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PB2"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="i" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDDSDMMC" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDDUSB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="V12PHYHS" type="power"/>
+        <pin position="J15" name="REXTPHYHS" type="monoio"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0-WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f7-45_46_56.xml
+++ b/devices/stm32/stm32f7-45_46_56.xml
@@ -1855,6 +1855,1310 @@
       <gpio device-pin="b|n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0/OSC_IN"/>
+        <pin position="13" name="PH1/OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0/WKUP"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0/OSC_IN"/>
+        <pin position="24" name="PH1/OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0/WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0/OSC_IN"/>
+        <pin position="30" name="PH1/OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0/WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDDUSB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP_2" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0/OSC_IN"/>
+        <pin position="33" name="PH1/OSC_OUT"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2"/>
+        <pin position="38" name="PC3"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="power"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0/WKUP"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP_1" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin position="118" name="PJ6"/>
+        <pin position="119" name="PJ7"/>
+        <pin position="120" name="PJ8"/>
+        <pin position="121" name="PJ9"/>
+        <pin position="122" name="PJ10"/>
+        <pin position="123" name="PJ11"/>
+        <pin position="124" name="VDD" type="power"/>
+        <pin position="125" name="VSS" type="power"/>
+        <pin position="126" name="PK0"/>
+        <pin position="127" name="PK1"/>
+        <pin position="128" name="PK2"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDDUSB" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13"/>
+        <pin position="148" name="VCAP_2" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14"/>
+        <pin position="160" name="PA15"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDD" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3"/>
+        <pin position="193" name="PB4"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14/OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PA15"/>
+        <pin position="A9" name="PA14"/>
+        <pin position="A10" name="PA13"/>
+        <pin position="B1" name="PC15/OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0/OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1/OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="BYPASS_REG" type="reset"/>
+        <pin position="E7" name="VCAP_2" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDDUSB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="reset"/>
+        <pin position="F8" name="VCAP_1" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0/WKUP"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP_2" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="PK1"/>
+        <pin position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDDUSB" type="power"/>
+        <pin position="G12" name="PJ11"/>
+        <pin position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD" type="power"/>
+        <pin position="H12" name="PJ8"/>
+        <pin position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PJ7"/>
+        <pin position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3"/>
+        <pin position="L5" name="BYPASS_REG" type="reset"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PB2"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDDUSB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="y" name="WLCSP143">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PD5"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PG12"/>
+        <pin position="A7" name="PG15"/>
+        <pin position="A8" name="PB6"/>
+        <pin position="A9" name="PB8"/>
+        <pin position="A10" name="PE1"/>
+        <pin position="A11" name="PDR_ON" type="reset"/>
+        <pin position="B1" name="PA14"/>
+        <pin position="B2" name="PC11"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD3"/>
+        <pin position="B5" name="PD4"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="PB3"/>
+        <pin position="B8" name="PB7"/>
+        <pin position="B9" name="PB9"/>
+        <pin position="B10" name="PE0"/>
+        <pin position="B11" name="PE4"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="PA15"/>
+        <pin position="C3" name="PC12"/>
+        <pin position="C4" name="PD1"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PG10"/>
+        <pin position="C7" name="PB4"/>
+        <pin position="C8" name="PB5"/>
+        <pin position="C9" name="BOOT0" type="boot"/>
+        <pin position="C10" name="PE3"/>
+        <pin position="C11" name="VBAT" type="power"/>
+        <pin position="D1" name="VCAP_2" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PA13"/>
+        <pin position="D4" name="PA11"/>
+        <pin position="D5" name="PA10"/>
+        <pin position="D6" name="PG13"/>
+        <pin position="D7" name="VDD" type="power"/>
+        <pin position="D8" name="PE2"/>
+        <pin position="D9" name="PE5"/>
+        <pin position="D10" name="PC13"/>
+        <pin position="D11" name="PC14/OSC32_IN"/>
+        <pin position="E1" name="PA12"/>
+        <pin position="E2" name="PA9"/>
+        <pin position="E3" name="PC9"/>
+        <pin position="E4" name="PC8"/>
+        <pin position="E5" name="PG9"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PE6"/>
+        <pin position="E9" name="PF1"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="PC15/OSC32_OUT"/>
+        <pin position="F1" name="PA8"/>
+        <pin position="F2" name="PC6"/>
+        <pin position="F3" name="PC7"/>
+        <pin position="F4" name="PD6"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="PG14"/>
+        <pin position="F7" name="PF7"/>
+        <pin position="F8" name="PF5"/>
+        <pin position="F9" name="PF4"/>
+        <pin position="F10" name="PF2"/>
+        <pin position="F11" name="PF0"/>
+        <pin position="G1" name="VDDUSB" type="power"/>
+        <pin position="G2" name="PG8"/>
+        <pin position="G3" name="PG3"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G5" name="PG4"/>
+        <pin position="G6" name="PG5"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="PF9"/>
+        <pin position="G9" name="PF10"/>
+        <pin position="G10" name="PF6"/>
+        <pin position="G11" name="PF3"/>
+        <pin position="H1" name="PG7"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H4" name="PD10"/>
+        <pin position="H5" name="PD13"/>
+        <pin position="H6" name="PD12"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="PC0"/>
+        <pin position="H9" name="NRST" type="reset"/>
+        <pin position="H10" name="PH1/OSC_OUT"/>
+        <pin position="H11" name="PF8"/>
+        <pin position="J1" name="PG2"/>
+        <pin position="J2" name="PD14"/>
+        <pin position="J3" name="PB15"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VDD" type="power"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PC3"/>
+        <pin position="J10" name="PC2"/>
+        <pin position="J11" name="PH0/OSC_IN"/>
+        <pin position="K1" name="PD15"/>
+        <pin position="K2" name="PD11"/>
+        <pin position="K3" name="PB14"/>
+        <pin position="K4" name="PE11"/>
+        <pin position="K5" name="PG1"/>
+        <pin position="K6" name="PF13"/>
+        <pin position="K7" name="PB1"/>
+        <pin position="K8" name="PA1"/>
+        <pin position="K9" name="PA0/WKUP"/>
+        <pin position="K10" name="VSSA" type="power"/>
+        <pin position="K11" name="PC1"/>
+        <pin position="L1" name="VDD" type="power"/>
+        <pin position="L2" name="PD8"/>
+        <pin position="L3" name="PE15"/>
+        <pin position="L4" name="PE12"/>
+        <pin position="L5" name="PE7"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PB2"/>
+        <pin position="L8" name="PA7"/>
+        <pin position="L9" name="PA2"/>
+        <pin position="L10" name="VDDA" type="power"/>
+        <pin position="L11" name="VREF+" type="power"/>
+        <pin position="M1" name="PD9"/>
+        <pin position="M2" name="PB12"/>
+        <pin position="M3" name="PB10"/>
+        <pin position="M4" name="PE14"/>
+        <pin position="M5" name="PE8"/>
+        <pin position="M6" name="PF15"/>
+        <pin position="M7" name="PF11"/>
+        <pin position="M8" name="PC4"/>
+        <pin position="M9" name="PA5"/>
+        <pin position="M10" name="PA4"/>
+        <pin position="M11" name="PA3"/>
+        <pin position="N1" name="PB13"/>
+        <pin position="N2" name="VCAP_1" type="power"/>
+        <pin position="N3" name="PB11"/>
+        <pin position="N4" name="PE13"/>
+        <pin position="N5" name="PE9"/>
+        <pin position="N6" name="PG0"/>
+        <pin position="N7" name="PF12"/>
+        <pin position="N8" name="PB0"/>
+        <pin position="N9" name="PC5"/>
+        <pin position="N10" name="PA6"/>
+        <pin position="N11" name="BYPASS_REG" type="reset"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
+++ b/devices/stm32/stm32f7-65_67_68_69_77_78_79.xml
@@ -2297,6 +2297,1567 @@
       <gpio device-pin="b|n" port="k" pin="7">
         <signal device-name="67|69|77|79" device-pin="b|n" af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0/OSC_IN"/>
+        <pin position="13" name="PH1/OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="power"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0/WKUP"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP_1" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP_2" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14/OSC32_IN"/>
+        <pin position="9" name="PC15/OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0/OSC_IN"/>
+        <pin position="24" name="PH1/OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0/WKUP"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP_1" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDUSB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP_2" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDDSDMMC" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0/OSC_IN"/>
+        <pin position="30" name="PH1/OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2"/>
+        <pin position="35" name="PC3"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="power"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0/WKUP"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="BYPASS_REG" type="reset"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP_1" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="85" name="PB12"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="85" name="PB12"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="85" name="PH8"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="85" name="PH8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="86" name="PB13"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="86" name="PB13"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="86" name="PH9"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="86" name="PH9"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="87" name="PB14"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="87" name="PB14"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="87" name="PH10"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="87" name="PH10"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="88" name="PB15"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="88" name="PB15"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="88" name="PH11"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="88" name="PH11"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="89" name="PD8"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="89" name="PD8"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="89" name="PH12"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="89" name="PH12"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="90" name="PD9"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="90" name="PD9"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="90" name="VSS" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="90" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="91" name="PD10"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="91" name="PD10"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="91" name="VDD" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="91" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="92" name="PD11"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="92" name="PD11"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="92" name="PB12"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="92" name="PB12"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="93" name="PD12"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="93" name="PD12"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="93" name="PB13"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="93" name="PB13"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="94" name="PD13"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="94" name="PD13"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="94" name="PB14"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="94" name="PB14"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="95" name="VSS" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="95" name="VSS" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="95" name="PB15"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="95" name="PB15"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="96" name="VDD" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="96" name="VDD" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="96" name="PD8"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="96" name="PD8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="97" name="PD14"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="97" name="PD14"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="97" name="PD9"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="97" name="PD9"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="98" name="PD15"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="98" name="PD15"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="98" name="PD10"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="98" name="PD10"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="99" name="VDDDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="99" name="VDDDSI" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="99" name="PD11"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="99" name="PD11"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="100" name="VCAPDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="100" name="VCAPDSI" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="100" name="PD12"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="100" name="PD12"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="101" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="101" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="101" name="PD13"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="101" name="PD13"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="102" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="102" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="102" name="VSS" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="102" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="103" name="VSSDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="103" name="VSSDSI" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="103" name="VDD" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="103" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="104" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="104" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="104" name="PD14"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="104" name="PD14"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="105" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="105" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="105" name="PD15"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="105" name="PD15"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="106" name="VDD12DSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="106" name="VDD12DSI" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="106" name="PG2"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="106" name="PG2"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="107" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="107" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="107" name="PG3"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="107" name="PG3"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="108" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="108" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="108" name="PG4"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="108" name="PG4"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="109" name="VSSDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="109" name="VSSDSI" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="109" name="PG5"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="109" name="PG5"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="110" name="PG2"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="110" name="PG2"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="110" name="PG6"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="110" name="PG6"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="111" name="PG3"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="111" name="PG3"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="111" name="PG7"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="111" name="PG7"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="112" name="PG4"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="112" name="PG4"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="112" name="PG8"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="112" name="PG8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="113" name="PG5"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="113" name="PG5"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="113" name="VSS" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="113" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="114" name="PG6"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="114" name="PG6"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="114" name="VDDUSB" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="114" name="VDDUSB" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="115" name="PG7"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="115" name="PG7"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="115" name="PC6"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="115" name="PC6"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="116" name="PG8"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="116" name="PG8"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="116" name="PC7"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="116" name="PC7"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="117" name="VSS" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="117" name="VSS" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="117" name="PC8"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="117" name="PC8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="118" name="VDDUSB" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="118" name="VDDUSB" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="118" name="PC9"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="118" name="PC9"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="119" name="PC6"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="119" name="PC6"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="119" name="PA8"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="119" name="PA8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="120" name="PC7"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="120" name="PC7"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="120" name="PA9"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="120" name="PA9"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="121" name="PC8"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="121" name="PC8"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="121" name="PA10"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="121" name="PA10"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="122" name="PC9"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="122" name="PC9"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="122" name="PA11"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="122" name="PA11"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="123" name="PA8"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="123" name="PA8"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="123" name="PA12"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="123" name="PA12"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="124" name="PA9"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="124" name="PA9"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="124" name="PA13"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="124" name="PA13"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="125" name="PA10"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="125" name="PA10"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="125" name="VCAP_2" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="125" name="VCAP_2" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="126" name="PA11"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="126" name="PA11"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="126" name="VSS" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="126" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="127" name="PA12"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="127" name="PA12"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="127" name="VDD" type="power"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="127" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="128" name="PA13"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="128" name="PA13"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="128" name="PH13"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="128" name="PH13"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="129" name="VCAP_2" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="129" name="VCAP_2" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="129" name="PH14"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="129" name="PH14"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="130" name="VSS" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="130" name="VSS" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="130" name="PH15"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="130" name="PH15"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="131" name="VDD" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="131" name="VDD" type="power"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="131" name="PI0"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="131" name="PI0"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="132" name="PI0"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="132" name="PI0"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="132" name="PI1"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="132" name="PI1"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="133" name="PI1"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="133" name="PI1"/>
+        <pin device-name="65|67" device-size="g|i" device-temperature="6" position="133" name="PI2"/>
+        <pin device-name="65|77" device-size="i" device-temperature="6|7" position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDDSDMMC" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14/OSC32_IN"/>
+        <pin position="10" name="PC15/OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0/OSC_IN"/>
+        <pin position="33" name="PH1/OSC_OUT"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2"/>
+        <pin position="38" name="PC3"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="power"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0/WKUP"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP_1" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin device-name="69" device-size="g|i" position="118" name="VDDDSI" type="power"/>
+        <pin device-name="79" device-size="i" position="118" name="VDDDSI" type="power"/>
+        <pin device-name="77" device-size="i" position="118" name="PJ6"/>
+        <pin device-name="65|67" device-size="g|i" position="118" name="PJ6"/>
+        <pin device-name="69" device-size="g|i" position="119" name="VCAPDSI" type="power"/>
+        <pin device-name="79" device-size="i" position="119" name="VCAPDSI" type="power"/>
+        <pin device-name="77" device-size="i" position="119" name="PJ7"/>
+        <pin device-name="65|67" device-size="g|i" position="119" name="PJ7"/>
+        <pin device-name="69" device-size="g|i" position="120" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="79" device-size="i" position="120" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="77" device-size="i" position="120" name="PJ8"/>
+        <pin device-name="65|67" device-size="g|i" position="120" name="PJ8"/>
+        <pin device-name="69" device-size="g|i" position="121" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="79" device-size="i" position="121" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="77" device-size="i" position="121" name="PJ9"/>
+        <pin device-name="65|67" device-size="g|i" position="121" name="PJ9"/>
+        <pin device-name="69" device-size="g|i" position="122" name="VSSDSI" type="power"/>
+        <pin device-name="79" device-size="i" position="122" name="VSSDSI" type="power"/>
+        <pin device-name="77" device-size="i" position="122" name="PJ10"/>
+        <pin device-name="65|67" device-size="g|i" position="122" name="PJ10"/>
+        <pin device-name="69" device-size="g|i" position="123" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="79" device-size="i" position="123" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="77" device-size="i" position="123" name="PJ11"/>
+        <pin device-name="65|67" device-size="g|i" position="123" name="PJ11"/>
+        <pin device-name="69" device-size="g|i" position="124" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="79" device-size="i" position="124" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="77" device-size="i" position="124" name="VDD" type="power"/>
+        <pin device-name="65|67" device-size="g|i" position="124" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" position="125" name="VDD12DSI" type="power"/>
+        <pin device-name="79" device-size="i" position="125" name="VDD12DSI" type="power"/>
+        <pin device-name="77" device-size="i" position="125" name="VSS" type="power"/>
+        <pin device-name="65|67" device-size="g|i" position="125" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" position="126" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="79" device-size="i" position="126" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="77" device-size="i" position="126" name="PK0"/>
+        <pin device-name="65|67" device-size="g|i" position="126" name="PK0"/>
+        <pin device-name="69" device-size="g|i" position="127" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="79" device-size="i" position="127" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="77" device-size="i" position="127" name="PK1"/>
+        <pin device-name="65|67" device-size="g|i" position="127" name="PK1"/>
+        <pin device-name="69" device-size="g|i" position="128" name="VSSDSI" type="power"/>
+        <pin device-name="79" device-size="i" position="128" name="VSSDSI" type="power"/>
+        <pin device-name="77" device-size="i" position="128" name="PK2"/>
+        <pin device-name="65|67" device-size="g|i" position="128" name="PK2"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDDUSB" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13"/>
+        <pin position="148" name="VCAP_2" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14"/>
+        <pin position="160" name="PA15"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDDSDMMC" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3"/>
+        <pin position="193" name="PB4"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14/OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4"/>
+        <pin position="A7" name="PB3"/>
+        <pin position="A8" name="PA15"/>
+        <pin position="A9" name="PA14"/>
+        <pin position="A10" name="PA13"/>
+        <pin position="B1" name="PC15/OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0/OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1/OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="BYPASS_REG" type="reset"/>
+        <pin position="E7" name="VCAP_2" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDDUSB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="reset"/>
+        <pin position="F8" name="VCAP_1" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0/WKUP"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDDSDMMC" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP_2" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="F12" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="F12" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="F12" name="PK1"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="F12" name="PK1"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="F12" name="PK1"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="F13" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="F13" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="F13" name="PK2"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="F13" name="PK2"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDDUSB" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="G12" name="VSSDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="G12" name="VSSDSI" type="power"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="G12" name="PJ11"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="G12" name="PJ11"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="G12" name="PJ11"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="G13" name="VDD12DSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="G13" name="VDD12DSI" type="power"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="G13" name="PK0"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="G13" name="PK0"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="H11" name="VDDDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="H11" name="VDDDSI" type="power"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="H11" name="VDD" type="power"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="H11" name="VDD" type="power"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="H11" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="H12" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="H12" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="H12" name="PJ8"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="H12" name="PJ8"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="H12" name="PJ8"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="H13" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="H13" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="H13" name="PJ10"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="H13" name="PJ10"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="J12" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="J12" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="J12" name="PJ7"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="J12" name="PJ7"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="J12" name="PJ7"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="J13" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="J13" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="J13" name="PJ9"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="J13" name="PJ9"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin device-name="69" device-size="g|i" device-temperature="6" position="K12" name="VCAPDSI" type="power"/>
+        <pin device-name="79" device-size="i" device-temperature="6" position="K12" name="VCAPDSI" type="power"/>
+        <pin device-name="65" device-size="g|i" device-temperature="6|7" position="K12" name="PJ6"/>
+        <pin device-name="67" device-size="g|i" device-temperature="6" position="K12" name="PJ6"/>
+        <pin device-name="67|77" device-size="i" device-temperature="6|7" position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3"/>
+        <pin position="L5" name="BYPASS_REG" type="reset"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP_1" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PB2"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDDSDMMC" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14/OSC32_IN"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15/OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP_2" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0/OSC_IN"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1/OSC_OUT"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDDUSB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="BYPASS_REG" type="reset"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2"/>
+        <pin position="M5" name="PC3"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP_1" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0/WKUP"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="power"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="a" name="WLCSP180">
+        <pin position="A1" name="NC" type="nc"/>
+        <pin position="A2" name="NC" type="nc"/>
+        <pin position="A3" name="PA14"/>
+        <pin position="A4" name="PD0"/>
+        <pin position="A5" name="PD4"/>
+        <pin position="A6" name="VDDSDMMC" type="power"/>
+        <pin position="A7" name="PG10"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="PB5"/>
+        <pin position="A10" name="BOOT0" type="boot"/>
+        <pin position="A11" name="VSS" type="power"/>
+        <pin position="A12" name="NC" type="nc"/>
+        <pin position="A13" name="NC" type="nc"/>
+        <pin position="B1" name="NC" type="nc"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PI1"/>
+        <pin position="B4" name="PC10"/>
+        <pin position="B5" name="PD3"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PG11"/>
+        <pin position="B8" name="VDD" type="power"/>
+        <pin position="B9" name="PB6"/>
+        <pin position="B10" name="PE1"/>
+        <pin position="B11" name="VDD" type="power"/>
+        <pin position="B12" name="PI7"/>
+        <pin position="B13" name="NC" type="nc"/>
+        <pin position="C1" name="VCAP_2" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI2"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PD5"/>
+        <pin position="C6" name="PG9"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PB7"/>
+        <pin position="C9" name="PE0"/>
+        <pin position="C10" name="PDR_ON" type="reset"/>
+        <pin position="C11" name="PI6"/>
+        <pin position="C12" name="PE4"/>
+        <pin position="C13" name="VBAT" type="power"/>
+        <pin position="D1" name="PA12"/>
+        <pin position="D2" name="PA13"/>
+        <pin position="D3" name="PI3"/>
+        <pin position="D4" name="PC12"/>
+        <pin position="D5" name="PD1"/>
+        <pin position="D6" name="PD2"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PB4"/>
+        <pin position="D9" name="PB9"/>
+        <pin position="D10" name="PI4"/>
+        <pin position="D11" name="PI5"/>
+        <pin position="D12" name="PE5"/>
+        <pin position="D13" name="PC13"/>
+        <pin position="E1" name="PC9"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA11"/>
+        <pin position="E4" name="PI0"/>
+        <pin position="E5" name="PH15"/>
+        <pin position="E6" name="PD6"/>
+        <pin position="E7" name="PD7"/>
+        <pin position="E8" name="PB3"/>
+        <pin position="E9" name="PB8"/>
+        <pin position="E10" name="PE2"/>
+        <pin position="E11" name="PE6"/>
+        <pin position="E12" name="PC14/OSC32_IN"/>
+        <pin position="E13" name="PC15/OSC32_OUT"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="VDDUSB" type="power"/>
+        <pin position="F3" name="PC7"/>
+        <pin position="F4" name="PA9"/>
+        <pin position="F5" name="PA10"/>
+        <pin position="F6" name="PH13"/>
+        <pin position="F7" name="PH14"/>
+        <pin position="F8" name="PA15"/>
+        <pin position="F9" name="PG15"/>
+        <pin position="F10" name="PE3"/>
+        <pin position="F11" name="PI11"/>
+        <pin position="F12" name="VDD" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PG4"/>
+        <pin position="G2" name="PG5"/>
+        <pin position="G3" name="PG6"/>
+        <pin position="G4" name="PG7"/>
+        <pin position="G5" name="PG8"/>
+        <pin position="G6" name="PC6"/>
+        <pin position="G8" name="PC8"/>
+        <pin position="G9" name="PG3"/>
+        <pin position="G10" name="PI9"/>
+        <pin position="G11" name="PF0"/>
+        <pin position="G12" name="PF1"/>
+        <pin position="G13" name="PF2"/>
+        <pin position="H1" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="H2" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="H3" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="H4" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="H5" name="VSSDSI" type="power"/>
+        <pin position="H6" name="VCAPDSI" type="power"/>
+        <pin position="H8" name="PB12"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PI10"/>
+        <pin position="H11" name="PF3"/>
+        <pin position="H12" name="PF4"/>
+        <pin position="H13" name="PF5"/>
+        <pin position="J1" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="J2" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="J3" name="VDD12DSI" type="power"/>
+        <pin position="J4" name="PD12"/>
+        <pin position="J5" name="PB13"/>
+        <pin position="J6" name="PE10"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PB1"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="PA2"/>
+        <pin position="J11" name="PA1"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VSS" type="power"/>
+        <pin position="K1" name="VDDDSI" type="power"/>
+        <pin position="K2" name="PD15"/>
+        <pin position="K3" name="PD11"/>
+        <pin position="K4" name="PH9"/>
+        <pin position="K5" name="PB10"/>
+        <pin position="K6" name="PE11"/>
+        <pin position="K7" name="PF12"/>
+        <pin position="K8" name="PF14"/>
+        <pin position="K9" name="VDD" type="power"/>
+        <pin position="K10" name="PH3"/>
+        <pin position="K11" name="PF10"/>
+        <pin position="K12" name="PH0/OSC_IN"/>
+        <pin position="K13" name="PH1/OSC_OUT"/>
+        <pin position="L1" name="PD14"/>
+        <pin position="L2" name="PD13"/>
+        <pin position="L3" name="PD9"/>
+        <pin position="L4" name="PH10"/>
+        <pin position="L5" name="PB11"/>
+        <pin position="L6" name="PE12"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PF13"/>
+        <pin position="L9" name="PA4"/>
+        <pin position="L10" name="PH2"/>
+        <pin position="L11" name="NRST" type="reset"/>
+        <pin position="L12" name="PC0"/>
+        <pin position="L13" name="PC1"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PD10"/>
+        <pin position="M3" name="PD8"/>
+        <pin position="M4" name="PH11"/>
+        <pin position="M5" name="PH8"/>
+        <pin position="M6" name="PE15"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="VDD" type="power"/>
+        <pin position="M9" name="PA7"/>
+        <pin position="M10" name="PA3"/>
+        <pin position="M11" name="VSSA" type="power"/>
+        <pin position="M12" name="VDDA" type="power"/>
+        <pin position="M13" name="PA0/WKUP"/>
+        <pin position="N1" name="NC" type="nc"/>
+        <pin position="N2" name="PB15"/>
+        <pin position="N3" name="PB14"/>
+        <pin position="N4" name="VSS" type="power"/>
+        <pin position="N5" name="VSS" type="power"/>
+        <pin position="N6" name="PE14"/>
+        <pin position="N7" name="PE8"/>
+        <pin position="N8" name="PG0"/>
+        <pin position="N9" name="PF11"/>
+        <pin position="N10" name="PA6"/>
+        <pin position="N11" name="PH5"/>
+        <pin position="N12" name="PH4"/>
+        <pin position="N13" name="NC" type="nc"/>
+        <pin position="P1" name="NC" type="nc"/>
+        <pin position="P2" name="NC" type="nc"/>
+        <pin position="P3" name="PH12"/>
+        <pin position="P4" name="VDD" type="power"/>
+        <pin position="P5" name="VCAP_1" type="power"/>
+        <pin position="P6" name="PE13"/>
+        <pin position="P7" name="PE9"/>
+        <pin position="P8" name="PF15"/>
+        <pin position="P9" name="VSS" type="power"/>
+        <pin position="P10" name="PB0"/>
+        <pin position="P11" name="PA5"/>
+        <pin position="P12" name="NC" type="nc"/>
+        <pin position="P13" name="NC" type="nc"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g0-30.xml
+++ b/devices/stm32/stm32g0-30.xml
@@ -279,12 +279,26 @@
         <signal af="1" driver="spi" instance="2" name="nss"/>
         <signal af="2" driver="tim" instance="1" name="ch1"/>
       </gpio>
+      <gpio port="a" pin="9">
+        <signal af="0" driver="rcc" name="mco"/>
+        <signal af="1" driver="usart" instance="1" name="tx"/>
+        <signal af="2" driver="tim" instance="1" name="ch2"/>
+        <signal af="4" driver="spi" instance="2" name="miso"/>
+        <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
       <gpio device-pin="c|k" port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
+      <gpio port="a" pin="10">
+        <signal af="0" driver="spi" instance="2" name="mosi"/>
+        <signal af="1" driver="usart" instance="1" name="rx"/>
+        <signal af="2" driver="tim" instance="1" name="ch3"/>
+        <signal af="5" driver="tim" instance="17" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k" port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
@@ -476,6 +490,155 @@
         <signal driver="rcc" name="osc_out"/>
         <signal af="0" driver="rcc" name="osc_en"/>
       </gpio>
+      <package device-pin="k" name="LQFP32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD/VDDA" type="power"/>
+        <pin position="5" name="VSS/VSSA" type="power"/>
+        <pin position="6" name="NRST" type="reset"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin position="26" name="PA15"/>
+        <pin position="27" name="PB3"/>
+        <pin position="28" name="PB4"/>
+        <pin position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD/VDDA" type="power"/>
+        <pin position="7" name="VSS/VSSA" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="NRST" type="reset"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="NC" type="nc" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="NC" type="nc" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="j" name="SO8N">
+        <pin position="1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="1" name="PB7"/>
+        <pin position="1" name="PB8"/>
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="VDD/VDDA" type="power"/>
+        <pin position="3" name="VSS/VSSA" type="power"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="4" name="PA0"/>
+        <pin position="4" name="PA1"/>
+        <pin position="4" name="PA2"/>
+        <pin position="5" name="PB0"/>
+        <pin position="5" name="PB1"/>
+        <pin position="5" name="PA8"/>
+        <pin position="5" name="PA11 [PA9]"/>
+        <pin position="5" name="PA9 [PA11]" variant="remap"/>
+        <pin position="6" name="PA12 [PA10]"/>
+        <pin position="6" name="PA10 [PA12]" variant="remap"/>
+        <pin position="7" name="PA13"/>
+        <pin position="8" name="PA14-BOOT0"/>
+        <pin position="8" name="PA15"/>
+        <pin position="8" name="PB5"/>
+        <pin position="8" name="PB6"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="PB7"/>
+        <pin position="1" name="PB8"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="2" name="PB9"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD/VDDA" type="power"/>
+        <pin position="5" name="VSS/VSSA" type="power"/>
+        <pin position="6" name="NRST" type="reset"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="15" name="PB2"/>
+        <pin position="15" name="PA8"/>
+        <pin position="16" name="PA11 [PA9]"/>
+        <pin position="16" name="PA9 [PA11]" variant="remap"/>
+        <pin position="17" name="PA12 [PA10]"/>
+        <pin position="17" name="PA10 [PA12]" variant="remap"/>
+        <pin position="18" name="PA13"/>
+        <pin position="19" name="PA14-BOOT0"/>
+        <pin position="19" name="PA15"/>
+        <pin position="20" name="PB3"/>
+        <pin position="20" name="PB4"/>
+        <pin position="20" name="PB5"/>
+        <pin position="20" name="PB6"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g0-31_41.xml
+++ b/devices/stm32/stm32g0-31_41.xml
@@ -377,12 +377,26 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
+      <gpio port="a" pin="9">
+        <signal af="0" driver="rcc" name="mco"/>
+        <signal af="1" driver="usart" instance="1" name="tx"/>
+        <signal af="2" driver="tim" instance="1" name="ch2"/>
+        <signal af="4" driver="spi" instance="2" name="miso"/>
+        <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
       <gpio device-pin="c|k" port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
+      <gpio port="a" pin="10">
+        <signal af="0" driver="spi" instance="2" name="mosi"/>
+        <signal af="1" driver="usart" instance="1" name="rx"/>
+        <signal af="2" driver="tim" instance="1" name="ch3"/>
+        <signal af="5" driver="tim" instance="17" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k" port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
@@ -597,6 +611,312 @@
       <gpio port="f" pin="2">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD/VDDA" type="power"/>
+        <pin position="5" name="VSS/VSSA" type="power"/>
+        <pin position="6" name="PF2 - NRST"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin position="26" name="PA15"/>
+        <pin position="27" name="PB3"/>
+        <pin position="28" name="PB4"/>
+        <pin position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD/VDDA" type="power"/>
+        <pin position="7" name="VSS/VSSA" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="PF2 - NRST"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="NC" type="nc" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="NC" type="nc" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="j" name="SO8N">
+        <pin position="1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="1" name="PB7"/>
+        <pin position="1" name="PB8"/>
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="VDD/VDDA" type="power"/>
+        <pin position="3" name="VSS/VSSA" type="power"/>
+        <pin position="4" name="PF2 - NRST"/>
+        <pin position="4" name="PA0"/>
+        <pin position="4" name="PA1"/>
+        <pin position="4" name="PA2"/>
+        <pin position="5" name="PB0"/>
+        <pin position="5" name="PB1"/>
+        <pin position="5" name="PA8"/>
+        <pin position="5" name="PA11 [PA9]"/>
+        <pin position="5" name="PA9 [PA11]" variant="remap"/>
+        <pin position="6" name="PA12 [PA10]"/>
+        <pin position="6" name="PA10 [PA12]" variant="remap"/>
+        <pin position="7" name="PA13"/>
+        <pin position="8" name="PA14-BOOT0"/>
+        <pin position="8" name="PA15"/>
+        <pin position="8" name="PB5"/>
+        <pin position="8" name="PB6"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="PB7"/>
+        <pin position="1" name="PB8"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="2" name="PB9"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD/VDDA" type="power"/>
+        <pin position="5" name="VSS/VSSA" type="power"/>
+        <pin position="6" name="PF2 - NRST"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="15" name="PB2"/>
+        <pin position="15" name="PA8"/>
+        <pin position="16" name="PA11 [PA9]"/>
+        <pin position="16" name="PA9 [PA11]" variant="remap"/>
+        <pin position="17" name="PA12 [PA10]"/>
+        <pin position="17" name="PA10 [PA12]" variant="remap"/>
+        <pin position="18" name="PA13"/>
+        <pin position="19" name="PA14-BOOT0"/>
+        <pin position="19" name="PA15"/>
+        <pin position="20" name="PB3"/>
+        <pin position="20" name="PB4"/>
+        <pin position="20" name="PB5"/>
+        <pin position="20" name="PB6"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="2" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="3" name="VDD/VDDA" type="power"/>
+        <pin position="4" name="VSS/VSSA" type="power"/>
+        <pin position="5" name="PF2 - NRST"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PA8"/>
+        <pin position="17" name="PC6"/>
+        <pin position="18" name="PA11 [PA9]"/>
+        <pin position="18" name="PA9 [PA11]" variant="remap"/>
+        <pin position="19" name="PA12 [PA10]"/>
+        <pin position="19" name="PA10 [PA12]" variant="remap"/>
+        <pin position="20" name="PA13"/>
+        <pin position="21" name="PA14-BOOT0"/>
+        <pin position="22" name="PA15"/>
+        <pin position="23" name="PB3"/>
+        <pin position="24" name="PB4"/>
+        <pin position="25" name="PB5"/>
+        <pin position="26" name="PB6"/>
+        <pin position="27" name="PB7"/>
+        <pin position="28" name="PB8"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD/VDDA" type="power"/>
+        <pin position="5" name="VSS/VSSA" type="power"/>
+        <pin position="6" name="PF2 - NRST"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin position="26" name="PA15"/>
+        <pin position="27" name="PB3"/>
+        <pin position="28" name="PB4"/>
+        <pin position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD/VDDA" type="power"/>
+        <pin position="7" name="VSS/VSSA" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="PF2 - NRST"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="NC" type="nc" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="NC" type="nc" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="y" name="WLCSP18">
+        <pin position="A1" name="PA13"/>
+        <pin position="A3" name="PA14-BOOT0"/>
+        <pin position="A3" name="PA15"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A7" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="PA12 [PA10]"/>
+        <pin position="B2" name="PA10 [PA12]" variant="remap"/>
+        <pin position="B4" name="PB3"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B4" name="PB6"/>
+        <pin position="B6" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="C1" name="PA11 [PA9]"/>
+        <pin position="C1" name="PA9 [PA11]" variant="remap"/>
+        <pin position="C3" name="PA5"/>
+        <pin position="C5" name="PA1"/>
+        <pin position="C7" name="VDD/VDDA" type="power"/>
+        <pin position="D2" name="PA7"/>
+        <pin position="D4" name="PA3"/>
+        <pin position="D4" name="PA4"/>
+        <pin position="D6" name="VSS/VSSA" type="power"/>
+        <pin position="E1" name="PB0"/>
+        <pin position="E1" name="PB1"/>
+        <pin position="E1" name="PB2"/>
+        <pin position="E1" name="PA8"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E7" name="PF2 - NRST"/>
+        <pin position="E7" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g0-70.xml
+++ b/devices/stm32/stm32g0-70.xml
@@ -329,6 +329,21 @@
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
+      <gpio port="a" pin="9">
+        <signal af="0" driver="rcc" name="mco"/>
+        <signal af="1" driver="usart" instance="1" name="tx"/>
+        <signal af="2" driver="tim" instance="1" name="ch2"/>
+        <signal af="4" driver="spi" instance="2" name="miso"/>
+        <signal af="5" driver="tim" instance="15" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
+      <gpio port="a" pin="10">
+        <signal af="0" driver="spi" instance="2" name="mosi"/>
+        <signal af="1" driver="usart" instance="1" name="rx"/>
+        <signal af="2" driver="tim" instance="1" name="ch3"/>
+        <signal af="5" driver="tim" instance="17" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="sda"/>
+      </gpio>
       <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
@@ -619,6 +634,168 @@
         <signal af="0" driver="rcc" name="osc_en"/>
         <signal af="2" driver="tim" instance="15" name="ch1n"/>
       </gpio>
+      <package device-pin="k" name="LQFP32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD" type="power"/>
+        <pin position="5" name="VSS" type="power"/>
+        <pin position="6" name="NRST" type="reset"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin position="26" name="PA15"/>
+        <pin position="27" name="PB3"/>
+        <pin position="28" name="PB4"/>
+        <pin position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD" type="power"/>
+        <pin position="7" name="VSS" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="NRST" type="reset"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="NC" type="nc" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="NC" type="nc" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="PC11"/>
+        <pin position="2" name="PC12"/>
+        <pin position="3" name="PC13"/>
+        <pin position="4" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="5" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="VREF+" type="monoio"/>
+        <pin position="8" name="VDD" type="power"/>
+        <pin position="9" name="VSS" type="power"/>
+        <pin position="10" name="PF0-OSC_IN (PF0)"/>
+        <pin position="11" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="12" name="NRST" type="reset"/>
+        <pin position="13" name="PC0"/>
+        <pin position="14" name="PC1"/>
+        <pin position="15" name="PC2"/>
+        <pin position="16" name="PC3"/>
+        <pin position="17" name="PA0"/>
+        <pin position="18" name="PA1"/>
+        <pin position="19" name="PA2"/>
+        <pin position="20" name="PA3"/>
+        <pin position="21" name="PA4"/>
+        <pin position="22" name="PA5"/>
+        <pin position="23" name="PA6"/>
+        <pin position="24" name="PA7"/>
+        <pin position="25" name="PC4"/>
+        <pin position="26" name="PC5"/>
+        <pin position="27" name="PB0"/>
+        <pin position="28" name="PB1"/>
+        <pin position="29" name="PB2"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="PB11"/>
+        <pin position="32" name="PB12"/>
+        <pin position="33" name="PB13"/>
+        <pin position="34" name="PB14"/>
+        <pin position="35" name="PB15"/>
+        <pin position="36" name="PA8"/>
+        <pin position="37" name="PA9"/>
+        <pin position="37" name="NC" type="nc" variant="remap"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PD8"/>
+        <pin position="41" name="PD9"/>
+        <pin position="42" name="PA10"/>
+        <pin position="42" name="NC" type="nc" variant="remap"/>
+        <pin position="43" name="PA11 [PA9]"/>
+        <pin position="43" name="PA9 [PA11]" variant="remap"/>
+        <pin position="44" name="PA12 [PA10]"/>
+        <pin position="44" name="PA10 [PA12]" variant="remap"/>
+        <pin position="45" name="PA13"/>
+        <pin position="46" name="PA14-BOOT0"/>
+        <pin position="47" name="PA15"/>
+        <pin position="48" name="PC8"/>
+        <pin position="49" name="PC9"/>
+        <pin position="50" name="PD0"/>
+        <pin position="51" name="PD1"/>
+        <pin position="52" name="PD2"/>
+        <pin position="53" name="PD3"/>
+        <pin position="54" name="PD4"/>
+        <pin position="55" name="PD5"/>
+        <pin position="56" name="PD6"/>
+        <pin position="57" name="PB3"/>
+        <pin position="58" name="PB4"/>
+        <pin position="59" name="PB5"/>
+        <pin position="60" name="PB6"/>
+        <pin position="61" name="PB7"/>
+        <pin position="62" name="PB8"/>
+        <pin position="63" name="PB9"/>
+        <pin position="64" name="PC10"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g0-71_81.xml
+++ b/devices/stm32/stm32g0-71_81.xml
@@ -535,8 +535,9 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio device-pin="c|k|r" port="a" pin="9">
-        <signal driver="ucpd" instance="1" name="dbcc1"/>
+      <gpio port="a" pin="9">
+        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc1"/>
+        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc1"/>
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
@@ -544,8 +545,26 @@
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
+      <gpio device-pin="c|k|r" port="a" pin="9">
+        <signal device-package="i" driver="ucpd" instance="1" name="dbcc1"/>
+        <signal af="0" driver="rcc" name="mco"/>
+        <signal af="1" driver="usart" instance="1" name="tx"/>
+        <signal af="2" driver="tim" instance="1" name="ch2"/>
+        <signal af="4" driver="spi" instance="2" name="miso"/>
+        <signal af="5" driver="tim" instance="15" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="scl"/>
+      </gpio>
+      <gpio port="a" pin="10">
+        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc2"/>
+        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc2"/>
+        <signal af="0" driver="spi" instance="2" name="mosi"/>
+        <signal af="1" driver="usart" instance="1" name="rx"/>
+        <signal af="2" driver="tim" instance="1" name="ch3"/>
+        <signal af="5" driver="tim" instance="17" name="bk"/>
+        <signal af="6" driver="i2c" instance="1" name="sda"/>
+      </gpio>
       <gpio device-pin="c|k|r" port="a" pin="10">
-        <signal driver="ucpd" instance="1" name="dbcc2"/>
+        <signal device-package="i" driver="ucpd" instance="1" name="dbcc2"/>
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>
@@ -965,6 +984,463 @@
       <gpio port="f" pin="2">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD" type="power"/>
+        <pin position="5" name="VSS" type="power"/>
+        <pin position="6" name="PF2 - NRST"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="17" name="PB15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="17" name="PB15"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="17" name="PB2"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|7" device-variant="" position="17" name="PB2"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="|n" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="|n" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="26" name="PD0"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="26" name="PD0"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="26" name="PA15"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|7" device-variant="" position="26" name="PA15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="26" name="PA15"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="27" name="PD1"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="27" name="PD1"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="27" name="PB3"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|7" device-variant="" position="27" name="PB3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="27" name="PB3"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="28" name="PD2"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="28" name="PD2"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="28" name="PB4"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|7" device-variant="" position="28" name="PB4"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="28" name="PB4"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="29" name="PD3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="29" name="PD3"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="6" device-variant="" position="29" name="PB5"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|7" device-variant="" position="29" name="PB5"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD" type="power"/>
+        <pin position="7" name="VSS" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="PF2 - NRST"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="PC11"/>
+        <pin position="2" name="PC12"/>
+        <pin position="3" name="PC13"/>
+        <pin position="4" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="5" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="VREF+" type="monoio"/>
+        <pin position="8" name="VDD" type="power"/>
+        <pin position="9" name="VSS" type="power"/>
+        <pin position="10" name="PF0-OSC_IN (PF0)"/>
+        <pin position="11" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="12" name="PF2 - NRST"/>
+        <pin position="13" name="PC0"/>
+        <pin position="14" name="PC1"/>
+        <pin position="15" name="PC2"/>
+        <pin position="16" name="PC3"/>
+        <pin position="17" name="PA0"/>
+        <pin position="18" name="PA1"/>
+        <pin position="19" name="PA2"/>
+        <pin position="20" name="PA3"/>
+        <pin position="21" name="PA4"/>
+        <pin position="22" name="PA5"/>
+        <pin position="23" name="PA6"/>
+        <pin position="24" name="PA7"/>
+        <pin position="25" name="PC4"/>
+        <pin position="26" name="PC5"/>
+        <pin position="27" name="PB0"/>
+        <pin position="28" name="PB1"/>
+        <pin position="29" name="PB2"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="PB11"/>
+        <pin position="32" name="PB12"/>
+        <pin position="33" name="PB13"/>
+        <pin position="34" name="PB14"/>
+        <pin position="35" name="PB15"/>
+        <pin position="36" name="PA8"/>
+        <pin position="37" name="PA9"/>
+        <pin position="37" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PD8"/>
+        <pin position="41" name="PD9"/>
+        <pin position="42" name="PA10"/>
+        <pin position="42" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin position="43" name="PA11 [PA9]"/>
+        <pin position="43" name="PA9 [PA11]" variant="remap"/>
+        <pin position="44" name="PA12 [PA10]"/>
+        <pin position="44" name="PA10 [PA12]" variant="remap"/>
+        <pin position="45" name="PA13"/>
+        <pin position="46" name="PA14-BOOT0"/>
+        <pin position="47" name="PA15"/>
+        <pin position="48" name="PC8"/>
+        <pin position="49" name="PC9"/>
+        <pin position="50" name="PD0"/>
+        <pin position="51" name="PD1"/>
+        <pin position="52" name="PD2"/>
+        <pin position="53" name="PD3"/>
+        <pin position="54" name="PD4"/>
+        <pin position="55" name="PD5"/>
+        <pin position="56" name="PD6"/>
+        <pin position="57" name="PB3"/>
+        <pin position="58" name="PB4"/>
+        <pin position="59" name="PB5"/>
+        <pin position="60" name="PB6"/>
+        <pin position="61" name="PB7"/>
+        <pin position="62" name="PB8"/>
+        <pin position="63" name="PB9"/>
+        <pin position="64" name="PC10"/>
+      </package>
+      <package device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC11"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PD6"/>
+        <pin position="A6" name="PD2"/>
+        <pin position="A7" name="PD0"/>
+        <pin position="A8" name="PC8"/>
+        <pin position="B1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="PC12"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PB3"/>
+        <pin position="B5" name="PD5"/>
+        <pin position="B6" name="PD1"/>
+        <pin position="B7" name="PC9"/>
+        <pin position="B8" name="PA12 [PA10]"/>
+        <pin position="B8" name="PA10 [PA12]" variant="remap"/>
+        <pin position="C1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="C2" name="PC13"/>
+        <pin position="C3" name="PB9"/>
+        <pin position="C4" name="PB4"/>
+        <pin position="C5" name="PD4"/>
+        <pin position="C6" name="PA15"/>
+        <pin position="C7" name="PA14-BOOT0"/>
+        <pin position="C8" name="PA11 [PA9]"/>
+        <pin position="C8" name="PA9 [PA11]" variant="remap"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VREF+" type="monoio"/>
+        <pin position="D3" name="VBAT" type="power"/>
+        <pin position="D4" name="PB5"/>
+        <pin position="D5" name="PD3"/>
+        <pin position="D6" name="PA10"/>
+        <pin position="D6" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin position="D7" name="PA13"/>
+        <pin position="D8" name="PD9"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="PF2 - NRST"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="PA7"/>
+        <pin position="E5" name="PC7"/>
+        <pin position="E6" name="PA9"/>
+        <pin position="E6" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin position="E7" name="PC6"/>
+        <pin position="E8" name="PD8"/>
+        <pin position="F1" name="PF0-OSC_IN (PF0)"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PA3"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PB14"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PA8"/>
+        <pin position="G1" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="G2" name="PC2"/>
+        <pin position="G3" name="PA2"/>
+        <pin position="G4" name="PA5"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB10"/>
+        <pin position="G7" name="PB12"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="PC3"/>
+        <pin position="H2" name="PA0"/>
+        <pin position="H3" name="PA1"/>
+        <pin position="H4" name="PA4"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB2"/>
+        <pin position="H8" name="PB11"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="2" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="3" name="VDD" type="power"/>
+        <pin position="4" name="VSS" type="power"/>
+        <pin position="5" name="PF2 - NRST"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin device-name="71" device-size="8|b" device-temperature="6" device-variant="n" position="15" name="PB15"/>
+        <pin device-name="71" device-size="b" device-temperature="3|7" device-variant="n" position="15" name="PB15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="15" name="PB15"/>
+        <pin device-name="71" device-size="8" device-temperature="6" device-variant="" position="15" name="PB1"/>
+        <pin device-name="71" device-size="6|b" device-temperature="3|6|7" device-variant="" position="15" name="PB1"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="15" name="PB1"/>
+        <pin position="16" name="PA8"/>
+        <pin position="17" name="PC6"/>
+        <pin position="18" name="PA11 [PA9]"/>
+        <pin position="18" name="PA9 [PA11]" variant="remap"/>
+        <pin position="19" name="PA12 [PA10]"/>
+        <pin position="19" name="PA10 [PA12]" variant="remap"/>
+        <pin position="20" name="PA13"/>
+        <pin position="21" name="PA14-BOOT0"/>
+        <pin device-name="71" device-size="8|b" device-temperature="6" device-variant="n" position="22" name="PD0"/>
+        <pin device-name="71" device-size="b" device-temperature="3|7" device-variant="n" position="22" name="PD0"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="22" name="PD0"/>
+        <pin device-name="71" device-size="8" device-temperature="6" device-variant="" position="22" name="PA15"/>
+        <pin device-name="71" device-size="6|b" device-temperature="3|6|7" device-variant="" position="22" name="PA15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="22" name="PA15"/>
+        <pin device-name="71" device-size="8|b" device-temperature="6" device-variant="n" position="23" name="PD1"/>
+        <pin device-name="71" device-size="b" device-temperature="3|7" device-variant="n" position="23" name="PD1"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="23" name="PD1"/>
+        <pin device-name="71" device-size="8" device-temperature="6" device-variant="" position="23" name="PB3"/>
+        <pin device-name="71" device-size="6|b" device-temperature="3|6|7" device-variant="" position="23" name="PB3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="23" name="PB3"/>
+        <pin device-name="71" device-size="8|b" device-temperature="6" device-variant="n" position="24" name="PD2"/>
+        <pin device-name="71" device-size="b" device-temperature="3|7" device-variant="n" position="24" name="PD2"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="24" name="PD2"/>
+        <pin device-name="71" device-size="8" device-temperature="6" device-variant="" position="24" name="PB4"/>
+        <pin device-name="71" device-size="6|b" device-temperature="3|6|7" device-variant="" position="24" name="PB4"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="24" name="PB4"/>
+        <pin device-name="71" device-size="8|b" device-temperature="6" device-variant="n" position="25" name="PD3"/>
+        <pin device-name="71" device-size="b" device-temperature="3|7" device-variant="n" position="25" name="PD3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="25" name="PD3"/>
+        <pin device-name="71" device-size="8" device-temperature="6" device-variant="" position="25" name="PB5"/>
+        <pin device-name="71" device-size="6|b" device-temperature="3|6|7" device-variant="" position="25" name="PB5"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="25" name="PB5"/>
+        <pin position="26" name="PB6"/>
+        <pin position="27" name="PB7"/>
+        <pin position="28" name="PB8"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="PB9"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VDD" type="power"/>
+        <pin position="5" name="VSS" type="power"/>
+        <pin position="6" name="PF2 - NRST"/>
+        <pin position="7" name="PA0"/>
+        <pin position="8" name="PA1"/>
+        <pin position="9" name="PA2"/>
+        <pin position="10" name="PA3"/>
+        <pin position="11" name="PA4"/>
+        <pin position="12" name="PA5"/>
+        <pin position="13" name="PA6"/>
+        <pin position="14" name="PA7"/>
+        <pin position="15" name="PB0"/>
+        <pin position="16" name="PB1"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="17" name="PB15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="17" name="PB15"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="17" name="PB2"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="17" name="PB2"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="19" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="19" name="NC" type="nc" variant="remap"/>
+        <pin position="20" name="PC6"/>
+        <pin position="21" name="PA10"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="21" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="21" name="NC" type="nc" variant="remap"/>
+        <pin position="22" name="PA11 [PA9]"/>
+        <pin position="22" name="PA9 [PA11]" variant="remap"/>
+        <pin position="23" name="PA12 [PA10]"/>
+        <pin position="23" name="PA10 [PA12]" variant="remap"/>
+        <pin position="24" name="PA13"/>
+        <pin position="25" name="PA14-BOOT0"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="26" name="PD0"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="26" name="PD0"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="26" name="PA15"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="26" name="PA15"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="27" name="PD1"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="27" name="PD1"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="27" name="PB3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="27" name="PB3"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="28" name="PD2"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="28" name="PD2"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="28" name="PB4"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="28" name="PB4"/>
+        <pin device-name="71" device-size="8|b" device-temperature="3|6|7" device-variant="n" position="29" name="PD3"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="n" position="29" name="PD3"/>
+        <pin device-name="71" device-size="6|8|b" device-temperature="3|6|7" device-variant="" position="29" name="PB5"/>
+        <pin device-name="81" device-size="b" device-temperature="6" device-variant="" position="29" name="PB5"/>
+        <pin position="30" name="PB6"/>
+        <pin position="31" name="PB7"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="PC13"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="VBAT" type="power"/>
+        <pin position="5" name="VREF+" type="monoio"/>
+        <pin position="6" name="VDD" type="power"/>
+        <pin position="7" name="VSS" type="power"/>
+        <pin position="8" name="PF0-OSC_IN (PF0)"/>
+        <pin position="9" name="PF1-OSC_OUT (PF1)"/>
+        <pin position="10" name="PF2 - NRST"/>
+        <pin position="11" name="PA0"/>
+        <pin position="12" name="PA1"/>
+        <pin position="13" name="PA2"/>
+        <pin position="14" name="PA3"/>
+        <pin position="15" name="PA4"/>
+        <pin position="16" name="PA5"/>
+        <pin position="17" name="PA6"/>
+        <pin position="18" name="PA7"/>
+        <pin position="19" name="PB0"/>
+        <pin position="20" name="PB1"/>
+        <pin position="21" name="PB2"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="PB11"/>
+        <pin position="24" name="PB12"/>
+        <pin position="25" name="PB13"/>
+        <pin position="26" name="PB14"/>
+        <pin position="27" name="PB15"/>
+        <pin position="28" name="PA8"/>
+        <pin position="29" name="PA9"/>
+        <pin position="29" name="UCPD1_DBCC1" type="monoio" variant="remap"/>
+        <pin position="30" name="PC6"/>
+        <pin position="31" name="PC7"/>
+        <pin position="32" name="PA10"/>
+        <pin position="32" name="UCPD1_DBCC2" type="monoio" variant="remap"/>
+        <pin position="33" name="PA11 [PA9]"/>
+        <pin position="33" name="PA9 [PA11]" variant="remap"/>
+        <pin position="34" name="PA12 [PA10]"/>
+        <pin position="34" name="PA10 [PA12]" variant="remap"/>
+        <pin position="35" name="PA13"/>
+        <pin position="36" name="PA14-BOOT0"/>
+        <pin position="37" name="PA15"/>
+        <pin position="38" name="PD0"/>
+        <pin position="39" name="PD1"/>
+        <pin position="40" name="PD2"/>
+        <pin position="41" name="PD3"/>
+        <pin position="42" name="PB3"/>
+        <pin position="43" name="PB4"/>
+        <pin position="44" name="PB5"/>
+        <pin position="45" name="PB6"/>
+        <pin position="46" name="PB7"/>
+        <pin position="47" name="PB8"/>
+        <pin position="48" name="PB9"/>
+      </package>
+      <package device-pin="e" name="WLCSP25">
+        <pin position="A1" name="PA15"/>
+        <pin position="A2" name="PA14-BOOT0"/>
+        <pin position="A3" name="PB5"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="B1" name="PA12 [PA10]"/>
+        <pin position="B1" name="PA10 [PA12]" variant="remap"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PB6"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C1" name="PA11 [PA9]"/>
+        <pin position="C1" name="PA9 [PA11]" variant="remap"/>
+        <pin position="C2" name="PA6"/>
+        <pin position="C3" name="PA3"/>
+        <pin position="C4" name="PA0"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA7"/>
+        <pin position="D3" name="PA4"/>
+        <pin position="D4" name="PA1"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="E1" name="PB1"/>
+        <pin position="E2" name="PB0"/>
+        <pin position="E3" name="PA5"/>
+        <pin position="E4" name="PA2"/>
+        <pin position="E5" name="PF2 - NRST"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g4-31_41.xml
+++ b/devices/stm32/stm32g4-31_41.xml
@@ -1251,6 +1251,541 @@
       <gpio port="g" pin="10">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="PG10-NRST"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="PA0"/>
+        <pin position="21" name="PA1"/>
+        <pin position="22" name="PA2"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="PA4"/>
+        <pin position="27" name="PA5"/>
+        <pin position="28" name="PA6"/>
+        <pin position="29" name="PA7"/>
+        <pin position="30" name="PC4"/>
+        <pin position="31" name="PC5"/>
+        <pin position="32" name="PB0"/>
+        <pin position="33" name="PB1"/>
+        <pin position="34" name="PB2"/>
+        <pin position="35" name="VSSA" type="power"/>
+        <pin position="36" name="VREF+" type="monoio"/>
+        <pin position="37" name="VDDA" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PB11"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PC6"/>
+        <pin position="66" name="PC7"/>
+        <pin position="67" name="PC8"/>
+        <pin position="68" name="PC9"/>
+        <pin position="69" name="PA8"/>
+        <pin position="70" name="PA9"/>
+        <pin position="71" name="PA10"/>
+        <pin position="72" name="PA11"/>
+        <pin position="73" name="PA12"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA13"/>
+        <pin position="77" name="PA14"/>
+        <pin position="78" name="PA15"/>
+        <pin position="79" name="PC10"/>
+        <pin position="80" name="PC11"/>
+        <pin position="81" name="PC12"/>
+        <pin position="82" name="PD0"/>
+        <pin position="83" name="PD1"/>
+        <pin position="84" name="PD2"/>
+        <pin position="85" name="PD3"/>
+        <pin position="86" name="PD4"/>
+        <pin position="87" name="PD5"/>
+        <pin position="88" name="PD6"/>
+        <pin position="89" name="PD7"/>
+        <pin position="90" name="PB3"/>
+        <pin position="91" name="PB4"/>
+        <pin position="92" name="PB5"/>
+        <pin position="93" name="PB6"/>
+        <pin position="94" name="PB7"/>
+        <pin position="95" name="PB8-BOOT0"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="PG10-NRST"/>
+        <pin position="5" name="PA0"/>
+        <pin position="6" name="PA1"/>
+        <pin position="7" name="PA2"/>
+        <pin position="8" name="PA3"/>
+        <pin position="9" name="PA4"/>
+        <pin position="10" name="PA5"/>
+        <pin position="11" name="PA6"/>
+        <pin position="12" name="PA7"/>
+        <pin position="13" name="PB0"/>
+        <pin position="14" name="VSSA" type="power"/>
+        <pin position="15" name="VDDA" type="power"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB8-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PB0"/>
+        <pin position="17" name="PB1"/>
+        <pin position="18" name="PB2"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB11"/>
+        <pin position="26" name="PB12"/>
+        <pin position="27" name="PB13"/>
+        <pin position="28" name="PB14"/>
+        <pin position="29" name="PB15"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA13"/>
+        <pin position="38" name="PA14"/>
+        <pin position="39" name="PA15"/>
+        <pin position="40" name="PB3"/>
+        <pin position="41" name="PB4"/>
+        <pin position="42" name="PB5"/>
+        <pin position="43" name="PB6"/>
+        <pin position="44" name="PB7"/>
+        <pin position="45" name="PB8-BOOT0"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB11"/>
+        <pin position="34" name="PB12"/>
+        <pin position="35" name="PB13"/>
+        <pin position="36" name="PB14"/>
+        <pin position="37" name="PB15"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PC8"/>
+        <pin position="41" name="PC9"/>
+        <pin position="42" name="PA8"/>
+        <pin position="43" name="PA9"/>
+        <pin position="44" name="PA10"/>
+        <pin position="45" name="PA11"/>
+        <pin position="46" name="PA12"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA13"/>
+        <pin position="50" name="PA14"/>
+        <pin position="51" name="PA15"/>
+        <pin position="52" name="PC10"/>
+        <pin position="53" name="PC11"/>
+        <pin position="54" name="PC12"/>
+        <pin position="55" name="PD2"/>
+        <pin position="56" name="PB3"/>
+        <pin position="57" name="PB4"/>
+        <pin position="58" name="PB5"/>
+        <pin position="59" name="PB6"/>
+        <pin position="60" name="PB7"/>
+        <pin position="61" name="PB8-BOOT0"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="m" name="LQFP80">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PE7"/>
+        <pin position="31" name="PE8"/>
+        <pin position="32" name="PE9"/>
+        <pin position="33" name="PE10"/>
+        <pin position="34" name="PE11"/>
+        <pin position="35" name="PE12"/>
+        <pin position="36" name="PE13"/>
+        <pin position="37" name="PE14"/>
+        <pin position="38" name="PE15"/>
+        <pin position="39" name="PB10"/>
+        <pin position="40" name="VSS" type="power"/>
+        <pin position="41" name="VDD" type="power"/>
+        <pin position="42" name="PB11"/>
+        <pin position="43" name="PB12"/>
+        <pin position="44" name="PB13"/>
+        <pin position="45" name="PB14"/>
+        <pin position="46" name="PB15"/>
+        <pin position="47" name="PD8"/>
+        <pin position="48" name="PD9"/>
+        <pin position="49" name="PD10"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="VDD" type="power"/>
+        <pin position="52" name="PC6"/>
+        <pin position="53" name="PC7"/>
+        <pin position="54" name="PC8"/>
+        <pin position="55" name="PC9"/>
+        <pin position="56" name="PA8"/>
+        <pin position="57" name="PA9"/>
+        <pin position="58" name="PA10"/>
+        <pin position="59" name="PA11"/>
+        <pin position="60" name="PA12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PA13"/>
+        <pin position="64" name="PA14"/>
+        <pin position="65" name="PA15"/>
+        <pin position="66" name="PC10"/>
+        <pin position="67" name="PC11"/>
+        <pin position="68" name="PC12"/>
+        <pin position="69" name="PD0"/>
+        <pin position="70" name="PD1"/>
+        <pin position="71" name="PD2"/>
+        <pin position="72" name="PB3"/>
+        <pin position="73" name="PB4"/>
+        <pin position="74" name="PB5"/>
+        <pin position="75" name="PB6"/>
+        <pin position="76" name="PB7"/>
+        <pin position="77" name="PB8-BOOT0"/>
+        <pin position="78" name="PB9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+      </package>
+      <package device-package="i" name="UFBGA64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PC12"/>
+        <pin position="A7" name="PA15"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="PC13"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PB8-BOOT0"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PC1"/>
+        <pin position="C4" name="PB4"/>
+        <pin position="C5" name="PC10"/>
+        <pin position="C6" name="PA14"/>
+        <pin position="C7" name="PA13"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="PG10-NRST"/>
+        <pin position="D3" name="PC2"/>
+        <pin position="D4" name="PA4"/>
+        <pin position="D5" name="PC4"/>
+        <pin position="D6" name="PA10"/>
+        <pin position="D7" name="PA9"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="PF0-OSC_IN"/>
+        <pin position="E2" name="PC0"/>
+        <pin position="E3" name="PA1"/>
+        <pin position="E4" name="PA5"/>
+        <pin position="E5" name="PB0"/>
+        <pin position="E6" name="PA8"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC6"/>
+        <pin position="F1" name="PF1-OSC_OUT"/>
+        <pin position="F2" name="PA0"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PC5"/>
+        <pin position="F5" name="PB1"/>
+        <pin position="F6" name="PC8"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PA6"/>
+        <pin position="G4" name="VSSA" type="power"/>
+        <pin position="G5" name="VREF+" type="monoio"/>
+        <pin position="G6" name="PB13"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="PB12"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="PA3"/>
+        <pin position="H3" name="PA7"/>
+        <pin position="H4" name="PB2"/>
+        <pin position="H5" name="VDDA" type="power"/>
+        <pin position="H6" name="PB10"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="PG10-NRST"/>
+        <pin position="5" name="PA0"/>
+        <pin position="6" name="PA1"/>
+        <pin position="7" name="PA2"/>
+        <pin position="8" name="PA3"/>
+        <pin position="9" name="PA4"/>
+        <pin position="10" name="PA5"/>
+        <pin position="11" name="PA6"/>
+        <pin position="12" name="PA7"/>
+        <pin position="13" name="PB0"/>
+        <pin position="14" name="VSSA" type="power"/>
+        <pin position="15" name="VDDA" type="power"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB8-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PC4"/>
+        <pin position="17" name="PB0"/>
+        <pin position="18" name="PB1"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PB11"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PC6"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA13"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PC10"/>
+        <pin position="40" name="PC11"/>
+        <pin position="41" name="PB3"/>
+        <pin position="42" name="PB4"/>
+        <pin position="43" name="PB5"/>
+        <pin position="44" name="PB6"/>
+        <pin position="45" name="PB7"/>
+        <pin position="46" name="PB8-BOOT0"/>
+        <pin position="47" name="PB9"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin position="A1" name="PA15"/>
+        <pin position="A2" name="PC11"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PA14"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB8-BOOT0"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA9"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PC13"/>
+        <pin position="C6" name="PG10-NRST"/>
+        <pin position="C7" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PC6"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PB14"/>
+        <pin position="D4" name="PC4"/>
+        <pin position="D5" name="PA7"/>
+        <pin position="D6" name="PA1"/>
+        <pin position="D7" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PB13"/>
+        <pin position="E3" name="PB11"/>
+        <pin position="E4" name="PB1"/>
+        <pin position="E5" name="PA4"/>
+        <pin position="E6" name="PF1-OSC_OUT"/>
+        <pin position="E7" name="PF0-OSC_IN"/>
+        <pin position="F1" name="PB12"/>
+        <pin position="F2" name="PB10"/>
+        <pin position="F3" name="VREF+" type="monoio"/>
+        <pin position="F4" name="PB2"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA2"/>
+        <pin position="F7" name="PA0"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDDA" type="power"/>
+        <pin position="G4" name="VSSA" type="power"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA6"/>
+        <pin position="G7" name="PA3"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g4-71_91_a1.xml
+++ b/devices/stm32/stm32g4-71_91_a1.xml
@@ -1613,6 +1613,939 @@
       <gpio port="g" pin="10">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="PG10-NRST"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="PA0"/>
+        <pin position="21" name="PA1"/>
+        <pin position="22" name="PA2"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="PA4"/>
+        <pin position="27" name="PA5"/>
+        <pin position="28" name="PA6"/>
+        <pin position="29" name="PA7"/>
+        <pin position="30" name="PC4"/>
+        <pin position="31" name="PC5"/>
+        <pin position="32" name="PB0"/>
+        <pin position="33" name="PB1"/>
+        <pin position="34" name="PB2"/>
+        <pin position="35" name="VSSA" type="power"/>
+        <pin position="36" name="VREF+" type="monoio"/>
+        <pin position="37" name="VDDA" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PB11"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PC6"/>
+        <pin position="66" name="PC7"/>
+        <pin position="67" name="PC8"/>
+        <pin position="68" name="PC9"/>
+        <pin position="69" name="PA8"/>
+        <pin position="70" name="PA9"/>
+        <pin position="71" name="PA10"/>
+        <pin position="72" name="PA11"/>
+        <pin position="73" name="PA12"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA13"/>
+        <pin position="77" name="PA14"/>
+        <pin position="78" name="PA15"/>
+        <pin position="79" name="PC10"/>
+        <pin position="80" name="PC11"/>
+        <pin position="81" name="PC12"/>
+        <pin position="82" name="PD0"/>
+        <pin position="83" name="PD1"/>
+        <pin position="84" name="PD2"/>
+        <pin position="85" name="PD3"/>
+        <pin position="86" name="PD4"/>
+        <pin position="87" name="PD5"/>
+        <pin position="88" name="PD6"/>
+        <pin position="89" name="PD7"/>
+        <pin position="90" name="PB3"/>
+        <pin position="91" name="PB4"/>
+        <pin position="92" name="PB5"/>
+        <pin position="93" name="PB6"/>
+        <pin position="94" name="PB7"/>
+        <pin position="95" name="PB8-BOOT0"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="LQFP128">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF3"/>
+        <pin position="11" name="PF4"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="PF5"/>
+        <pin position="15" name="PF7"/>
+        <pin position="16" name="PF8"/>
+        <pin position="17" name="PF9"/>
+        <pin position="18" name="PF10"/>
+        <pin position="19" name="PF0-OSC_IN"/>
+        <pin position="20" name="PF1-OSC_OUT"/>
+        <pin position="21" name="PG10-NRST"/>
+        <pin position="22" name="PC0"/>
+        <pin position="23" name="PC1"/>
+        <pin position="24" name="PC2"/>
+        <pin position="25" name="PC3"/>
+        <pin position="26" name="PF2"/>
+        <pin position="27" name="PA0"/>
+        <pin position="28" name="PA1"/>
+        <pin position="29" name="PA2"/>
+        <pin position="30" name="VSS" type="power"/>
+        <pin position="31" name="VDD" type="power"/>
+        <pin position="32" name="PA3"/>
+        <pin position="33" name="PA4"/>
+        <pin position="34" name="PA5"/>
+        <pin position="35" name="PA6"/>
+        <pin position="36" name="PA7"/>
+        <pin position="37" name="PC4"/>
+        <pin position="38" name="PC5"/>
+        <pin position="39" name="PB0"/>
+        <pin position="40" name="PB1"/>
+        <pin position="41" name="PB2"/>
+        <pin position="42" name="VSSA" type="power"/>
+        <pin position="43" name="VREF+" type="monoio"/>
+        <pin position="44" name="VREF_+" type="monoio"/>
+        <pin position="45" name="VDDA" type="power"/>
+        <pin position="46" name="VSS" type="power"/>
+        <pin position="47" name="VDD" type="power"/>
+        <pin position="48" name="PF11"/>
+        <pin position="49" name="PF12"/>
+        <pin position="50" name="PF13"/>
+        <pin position="51" name="PF14"/>
+        <pin position="52" name="PF15"/>
+        <pin position="53" name="PE7"/>
+        <pin position="54" name="PE8"/>
+        <pin position="55" name="PE9"/>
+        <pin position="56" name="PE10"/>
+        <pin position="57" name="PE11"/>
+        <pin position="58" name="PE12"/>
+        <pin position="59" name="PE13"/>
+        <pin position="60" name="PE14"/>
+        <pin position="61" name="PE15"/>
+        <pin position="62" name="PB10"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PB11"/>
+        <pin position="66" name="PB12"/>
+        <pin position="67" name="PB13"/>
+        <pin position="68" name="PB14"/>
+        <pin position="69" name="PB15"/>
+        <pin position="70" name="PD8"/>
+        <pin position="71" name="PD9"/>
+        <pin position="72" name="PD10"/>
+        <pin position="73" name="PD11"/>
+        <pin position="74" name="PD12"/>
+        <pin position="75" name="PD13"/>
+        <pin position="76" name="PD14"/>
+        <pin position="77" name="PD15"/>
+        <pin position="78" name="VSS" type="power"/>
+        <pin position="79" name="VDD" type="power"/>
+        <pin position="80" name="PC6"/>
+        <pin position="81" name="PC7"/>
+        <pin position="82" name="PG0"/>
+        <pin position="83" name="PG1"/>
+        <pin position="84" name="PG2"/>
+        <pin position="85" name="PG3"/>
+        <pin position="86" name="PG4"/>
+        <pin position="87" name="PC8"/>
+        <pin position="88" name="PC9"/>
+        <pin position="89" name="PA8"/>
+        <pin position="90" name="PA9"/>
+        <pin position="91" name="PA10"/>
+        <pin position="92" name="PA11"/>
+        <pin position="93" name="PA12"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PA13"/>
+        <pin position="97" name="PF6"/>
+        <pin position="98" name="PA14"/>
+        <pin position="99" name="PA15"/>
+        <pin position="100" name="PC10"/>
+        <pin position="101" name="PC11"/>
+        <pin position="102" name="PC12"/>
+        <pin position="103" name="PG5"/>
+        <pin position="104" name="PG6"/>
+        <pin position="105" name="PG7"/>
+        <pin position="106" name="PG8"/>
+        <pin position="107" name="PG9"/>
+        <pin position="108" name="PD0"/>
+        <pin position="109" name="PD1"/>
+        <pin position="110" name="VSS" type="power"/>
+        <pin position="111" name="VDD" type="power"/>
+        <pin position="112" name="PD2"/>
+        <pin position="113" name="PD3"/>
+        <pin position="114" name="PD4"/>
+        <pin position="115" name="PD5"/>
+        <pin position="116" name="PD6"/>
+        <pin position="117" name="PD7"/>
+        <pin position="118" name="PB3"/>
+        <pin position="119" name="PB4"/>
+        <pin position="120" name="PB5"/>
+        <pin position="121" name="PB6"/>
+        <pin position="122" name="PB7"/>
+        <pin position="123" name="PB8-BOOT0"/>
+        <pin position="124" name="PB9"/>
+        <pin position="125" name="PE0"/>
+        <pin position="126" name="PE1"/>
+        <pin position="127" name="VSS" type="power"/>
+        <pin position="128" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PB0"/>
+        <pin position="17" name="PB1"/>
+        <pin position="18" name="PB2"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB11"/>
+        <pin position="26" name="PB12"/>
+        <pin position="27" name="PB13"/>
+        <pin position="28" name="PB14"/>
+        <pin position="29" name="PB15"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA13"/>
+        <pin position="38" name="PA14"/>
+        <pin position="39" name="PA15"/>
+        <pin position="40" name="PB3"/>
+        <pin position="41" name="PB4"/>
+        <pin position="42" name="PB5"/>
+        <pin position="43" name="PB6"/>
+        <pin position="44" name="PB7"/>
+        <pin position="45" name="PB8-BOOT0"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB11"/>
+        <pin position="34" name="PB12"/>
+        <pin position="35" name="PB13"/>
+        <pin position="36" name="PB14"/>
+        <pin position="37" name="PB15"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PC8"/>
+        <pin position="41" name="PC9"/>
+        <pin position="42" name="PA8"/>
+        <pin position="43" name="PA9"/>
+        <pin position="44" name="PA10"/>
+        <pin position="45" name="PA11"/>
+        <pin position="46" name="PA12"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA13"/>
+        <pin position="50" name="PA14"/>
+        <pin position="51" name="PA15"/>
+        <pin position="52" name="PC10"/>
+        <pin position="53" name="PC11"/>
+        <pin position="54" name="PC12"/>
+        <pin position="55" name="PD2"/>
+        <pin position="56" name="PB3"/>
+        <pin position="57" name="PB4"/>
+        <pin position="58" name="PB5"/>
+        <pin position="59" name="PB6"/>
+        <pin position="60" name="PB7"/>
+        <pin position="61" name="PB8-BOOT0"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="m" device-package="s|t" name="LQFP80">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PE7"/>
+        <pin position="31" name="PE8"/>
+        <pin position="32" name="PE9"/>
+        <pin position="33" name="PE10"/>
+        <pin position="34" name="PE11"/>
+        <pin position="35" name="PE12"/>
+        <pin position="36" name="PE13"/>
+        <pin position="37" name="PE14"/>
+        <pin position="38" name="PE15"/>
+        <pin position="39" name="PB10"/>
+        <pin position="40" name="VSS" type="power"/>
+        <pin position="41" name="VDD" type="power"/>
+        <pin position="42" name="PB11"/>
+        <pin position="43" name="PB12"/>
+        <pin position="44" name="PB13"/>
+        <pin position="45" name="PB14"/>
+        <pin position="46" name="PB15"/>
+        <pin position="47" name="PD8"/>
+        <pin position="48" name="PD9"/>
+        <pin position="49" name="PD10"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="VDD" type="power"/>
+        <pin position="52" name="PC6"/>
+        <pin position="53" name="PC7"/>
+        <pin position="54" name="PC8"/>
+        <pin position="55" name="PC9"/>
+        <pin position="56" name="PA8"/>
+        <pin position="57" name="PA9"/>
+        <pin position="58" name="PA10"/>
+        <pin position="59" name="PA11"/>
+        <pin position="60" name="PA12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PA13"/>
+        <pin position="64" name="PA14"/>
+        <pin position="65" name="PA15"/>
+        <pin position="66" name="PC10"/>
+        <pin position="67" name="PC11"/>
+        <pin position="68" name="PC12"/>
+        <pin position="69" name="PD0"/>
+        <pin position="70" name="PD1"/>
+        <pin position="71" name="PD2"/>
+        <pin position="72" name="PB3"/>
+        <pin position="73" name="PB4"/>
+        <pin position="74" name="PB5"/>
+        <pin position="75" name="PB6"/>
+        <pin position="76" name="PB7"/>
+        <pin position="77" name="PB8-BOOT0"/>
+        <pin position="78" name="PB9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA100">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB8-BOOT0"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PD6"/>
+        <pin position="A7" name="PD5"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD1"/>
+        <pin position="A10" name="PC12"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PD7"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PA15"/>
+        <pin position="B10" name="PA14"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB4"/>
+        <pin position="C6" name="PD3"/>
+        <pin position="C7" name="PC11"/>
+        <pin position="C8" name="PC10"/>
+        <pin position="C9" name="PA12"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VBAT" type="power"/>
+        <pin position="D4" name="PC13"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="VDD" type="power"/>
+        <pin position="D8" name="PA13"/>
+        <pin position="D9" name="PA10"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="E1" name="PF0-OSC_IN"/>
+        <pin position="E2" name="PF1-OSC_OUT"/>
+        <pin position="E3" name="PF9"/>
+        <pin position="E4" name="PF10"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PA8"/>
+        <pin position="F1" name="PC2"/>
+        <pin position="F2" name="PC0"/>
+        <pin position="F3" name="PG10-NRST"/>
+        <pin position="F4" name="PC1"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="PD14"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA1"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="PA0"/>
+        <pin position="G5" name="PE7"/>
+        <pin position="G6" name="PE12"/>
+        <pin position="G7" name="PD10"/>
+        <pin position="G8" name="PD9"/>
+        <pin position="G9" name="PD13"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="PA2"/>
+        <pin position="H2" name="PA4"/>
+        <pin position="H3" name="PA3"/>
+        <pin position="H4" name="PB0"/>
+        <pin position="H5" name="PE8"/>
+        <pin position="H6" name="PE9"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PB14"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="J1" name="PA5"/>
+        <pin position="J2" name="PA6"/>
+        <pin position="J3" name="PC5"/>
+        <pin position="J4" name="PB2"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="PE11"/>
+        <pin position="J7" name="PE14"/>
+        <pin position="J8" name="PB10"/>
+        <pin position="J9" name="PB13"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="K1" name="PA7"/>
+        <pin position="K2" name="PC4"/>
+        <pin position="K3" name="PB1"/>
+        <pin position="K4" name="VSSA" type="power"/>
+        <pin position="K5" name="VREF+" type="monoio"/>
+        <pin position="K6" name="PE10"/>
+        <pin position="K7" name="PE13"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PB15"/>
+        <pin position="K10" name="PD8"/>
+      </package>
+      <package device-name="71" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE2"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="PB4"/>
+        <pin position="A6" name="PD7"/>
+        <pin position="A7" name="PD6"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB8-BOOT0"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB3"/>
+        <pin position="B7" name="PD5"/>
+        <pin position="B8" name="PD2"/>
+        <pin position="B9" name="PD0"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PA15"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="C1" name="PE6"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="VSS" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VSS" type="power"/>
+        <pin position="C10" name="PA13"/>
+        <pin position="C11" name="PA10"/>
+        <pin position="C12" name="PA12"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="VBAT" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D10" name="PC8"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA11"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="PF9"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E10" name="PC6"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF10"/>
+        <pin position="F11" name="PC7"/>
+        <pin position="F12" name="PD14"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PG10-NRST"/>
+        <pin position="G11" name="PD15"/>
+        <pin position="G12" name="PD13"/>
+        <pin position="H1" name="PC2"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H10" name="VDD" type="power"/>
+        <pin position="H11" name="PD11"/>
+        <pin position="H12" name="PD12"/>
+        <pin position="J1" name="PC3"/>
+        <pin position="J2" name="PF2"/>
+        <pin position="J3" name="VDD" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="PD9"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PA0"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K8" name="PE8"/>
+        <pin position="K9" name="PE11"/>
+        <pin position="K10" name="PB11"/>
+        <pin position="K11" name="PB13"/>
+        <pin position="K12" name="PD8"/>
+        <pin position="L1" name="PA3"/>
+        <pin position="L2" name="PA4"/>
+        <pin position="L3" name="PC4"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="VSSA" type="power"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE13"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB12"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="PA5"/>
+        <pin position="M2" name="PA6"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="VREF+" type="monoio"/>
+        <pin position="M6" name="VDDA" type="power"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE12"/>
+        <pin position="M10" name="PE14"/>
+        <pin position="M11" name="PE15"/>
+        <pin position="M12" name="PB14"/>
+      </package>
+      <package device-name="91|a1" device-package="i" name="UFBGA64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PC12"/>
+        <pin position="A7" name="PA15"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="PC13"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PB8-BOOT0"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PC1"/>
+        <pin position="C4" name="PB4"/>
+        <pin position="C5" name="PC10"/>
+        <pin position="C6" name="PA14"/>
+        <pin position="C7" name="PA13"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="PG10-NRST"/>
+        <pin position="D3" name="PC2"/>
+        <pin position="D4" name="PA4"/>
+        <pin position="D5" name="PC4"/>
+        <pin position="D6" name="PA10"/>
+        <pin position="D7" name="PA9"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="PF0-OSC_IN"/>
+        <pin position="E2" name="PC0"/>
+        <pin position="E3" name="PA1"/>
+        <pin position="E4" name="PA5"/>
+        <pin position="E5" name="PB0"/>
+        <pin position="E6" name="PA8"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC6"/>
+        <pin position="F1" name="PF1-OSC_OUT"/>
+        <pin position="F2" name="PA0"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PC5"/>
+        <pin position="F5" name="PB1"/>
+        <pin position="F6" name="PC8"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PA6"/>
+        <pin position="G4" name="VSSA" type="power"/>
+        <pin position="G5" name="VREF+" type="monoio"/>
+        <pin position="G6" name="PB13"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="PB12"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="PA3"/>
+        <pin position="H3" name="PA7"/>
+        <pin position="H4" name="PB2"/>
+        <pin position="H5" name="VDDA" type="power"/>
+        <pin position="H6" name="PB10"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PF0-OSC_IN"/>
+        <pin position="3" name="PF1-OSC_OUT"/>
+        <pin position="4" name="PG10-NRST"/>
+        <pin position="5" name="PA0"/>
+        <pin position="6" name="PA1"/>
+        <pin position="7" name="PA2"/>
+        <pin position="8" name="PA3"/>
+        <pin position="9" name="PA4"/>
+        <pin position="10" name="PA5"/>
+        <pin position="11" name="PA6"/>
+        <pin position="12" name="PA7"/>
+        <pin position="13" name="PB0"/>
+        <pin position="14" name="VSSA" type="power"/>
+        <pin position="15" name="VDDA" type="power"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB8-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PC4"/>
+        <pin position="17" name="PB0"/>
+        <pin position="18" name="PB1"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PB11"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PC6"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA13"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PC10"/>
+        <pin position="40" name="PC11"/>
+        <pin position="41" name="PB3"/>
+        <pin position="42" name="PB4"/>
+        <pin position="43" name="PB5"/>
+        <pin position="44" name="PB6"/>
+        <pin position="45" name="PB7"/>
+        <pin position="46" name="PB8-BOOT0"/>
+        <pin position="47" name="PB9"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-name="91|a1" device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC11"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PA15"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB8-BOOT0"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA13"/>
+        <pin position="C4" name="PA14"/>
+        <pin position="C5" name="PB4"/>
+        <pin position="C6" name="PC13"/>
+        <pin position="C7" name="PC1"/>
+        <pin position="C8" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PA8"/>
+        <pin position="D3" name="PC9"/>
+        <pin position="D4" name="PB3"/>
+        <pin position="D5" name="PA2"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="PG10-NRST"/>
+        <pin position="D8" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC8"/>
+        <pin position="E3" name="PC6"/>
+        <pin position="E4" name="PA5"/>
+        <pin position="E5" name="PA4"/>
+        <pin position="E6" name="PC3"/>
+        <pin position="E7" name="PF1-OSC_OUT"/>
+        <pin position="E8" name="PF0-OSC_IN"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB14"/>
+        <pin position="F3" name="PB0"/>
+        <pin position="F4" name="PC5"/>
+        <pin position="F5" name="PA7"/>
+        <pin position="F6" name="PA3"/>
+        <pin position="F7" name="PA1"/>
+        <pin position="F8" name="PC0"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PB2"/>
+        <pin position="G5" name="VSSA" type="power"/>
+        <pin position="G6" name="PC4"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="PA0"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="PB10"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="VDDA" type="power"/>
+        <pin position="H5" name="VREF+" type="monoio"/>
+        <pin position="H6" name="PB1"/>
+        <pin position="H7" name="PA6"/>
+        <pin position="H8" name="VDD" type="power"/>
+      </package>
+      <package device-name="71" device-package="y" name="WLCSP81">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD1"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PD0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PB8-BOOT0"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA14"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PC8"/>
+        <pin position="C6" name="PB4"/>
+        <pin position="C7" name="PB7"/>
+        <pin position="C8" name="PC1"/>
+        <pin position="C9" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PC7"/>
+        <pin position="D6" name="PA4"/>
+        <pin position="D7" name="PA0"/>
+        <pin position="D8" name="PG10-NRST"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PD11"/>
+        <pin position="E3" name="PC6"/>
+        <pin position="E4" name="PB15"/>
+        <pin position="E5" name="PE12"/>
+        <pin position="E6" name="PC4"/>
+        <pin position="E7" name="PA1"/>
+        <pin position="E8" name="PC0"/>
+        <pin position="E9" name="PF0-OSC_IN"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PD10"/>
+        <pin position="F3" name="PD9"/>
+        <pin position="F4" name="PE15"/>
+        <pin position="F5" name="PE9"/>
+        <pin position="F6" name="PB0"/>
+        <pin position="F7" name="PA5"/>
+        <pin position="F8" name="PC2"/>
+        <pin position="F9" name="PF1-OSC_OUT"/>
+        <pin position="G1" name="PD8"/>
+        <pin position="G2" name="PB14"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PE13"/>
+        <pin position="G5" name="PE8"/>
+        <pin position="G6" name="PB1"/>
+        <pin position="G7" name="PA6"/>
+        <pin position="G8" name="PA2"/>
+        <pin position="G9" name="PC3"/>
+        <pin position="H1" name="PB13"/>
+        <pin position="H2" name="PB11"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PE11"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="VSSA" type="power"/>
+        <pin position="H7" name="PC5"/>
+        <pin position="H8" name="PA3"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PE14"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="VREF+" type="monoio"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA7"/>
+        <pin position="J9" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g4-73_83.xml
+++ b/devices/stm32/stm32g4-73_83.xml
@@ -1830,6 +1830,896 @@
       <gpio port="g" pin="10">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="PG10-NRST"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="PA0"/>
+        <pin position="21" name="PA1"/>
+        <pin position="22" name="PA2"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="PA4"/>
+        <pin position="27" name="PA5"/>
+        <pin position="28" name="PA6"/>
+        <pin position="29" name="PA7"/>
+        <pin position="30" name="PC4"/>
+        <pin position="31" name="PC5"/>
+        <pin position="32" name="PB0"/>
+        <pin position="33" name="PB1"/>
+        <pin position="34" name="PB2"/>
+        <pin position="35" name="VSSA" type="power"/>
+        <pin position="36" name="VREF+" type="monoio"/>
+        <pin position="37" name="VDDA" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PB11"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PC6"/>
+        <pin position="66" name="PC7"/>
+        <pin position="67" name="PC8"/>
+        <pin position="68" name="PC9"/>
+        <pin position="69" name="PA8"/>
+        <pin position="70" name="PA9"/>
+        <pin position="71" name="PA10"/>
+        <pin position="72" name="PA11"/>
+        <pin position="73" name="PA12"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA13"/>
+        <pin position="77" name="PA14"/>
+        <pin position="78" name="PA15"/>
+        <pin position="79" name="PC10"/>
+        <pin position="80" name="PC11"/>
+        <pin position="81" name="PC12"/>
+        <pin position="82" name="PD0"/>
+        <pin position="83" name="PD1"/>
+        <pin position="84" name="PD2"/>
+        <pin position="85" name="PD3"/>
+        <pin position="86" name="PD4"/>
+        <pin position="87" name="PD5"/>
+        <pin position="88" name="PD6"/>
+        <pin position="89" name="PD7"/>
+        <pin position="90" name="PB3"/>
+        <pin position="91" name="PB4"/>
+        <pin position="92" name="PB5"/>
+        <pin position="93" name="PB6"/>
+        <pin position="94" name="PB7"/>
+        <pin position="95" name="PB8-BOOT0"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="LQFP128">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF3"/>
+        <pin position="11" name="PF4"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="PF5"/>
+        <pin position="15" name="PF7"/>
+        <pin position="16" name="PF8"/>
+        <pin position="17" name="PF9"/>
+        <pin position="18" name="PF10"/>
+        <pin position="19" name="PF0-OSC_IN"/>
+        <pin position="20" name="PF1-OSC_OUT"/>
+        <pin position="21" name="PG10-NRST"/>
+        <pin position="22" name="PC0"/>
+        <pin position="23" name="PC1"/>
+        <pin position="24" name="PC2"/>
+        <pin position="25" name="PC3"/>
+        <pin position="26" name="PF2"/>
+        <pin position="27" name="PA0"/>
+        <pin position="28" name="PA1"/>
+        <pin position="29" name="PA2"/>
+        <pin position="30" name="VSS" type="power"/>
+        <pin position="31" name="VDD" type="power"/>
+        <pin position="32" name="PA3"/>
+        <pin position="33" name="PA4"/>
+        <pin position="34" name="PA5"/>
+        <pin position="35" name="PA6"/>
+        <pin position="36" name="PA7"/>
+        <pin position="37" name="PC4"/>
+        <pin position="38" name="PC5"/>
+        <pin position="39" name="PB0"/>
+        <pin position="40" name="PB1"/>
+        <pin position="41" name="PB2"/>
+        <pin position="42" name="VSSA" type="power"/>
+        <pin position="43" name="VREF+" type="monoio"/>
+        <pin position="44" name="VREF_+" type="monoio"/>
+        <pin position="45" name="VDDA" type="power"/>
+        <pin position="46" name="VSS" type="power"/>
+        <pin position="47" name="VDD" type="power"/>
+        <pin position="48" name="PF11"/>
+        <pin position="49" name="PF12"/>
+        <pin position="50" name="PF13"/>
+        <pin position="51" name="PF14"/>
+        <pin position="52" name="PF15"/>
+        <pin position="53" name="PE7"/>
+        <pin position="54" name="PE8"/>
+        <pin position="55" name="PE9"/>
+        <pin position="56" name="PE10"/>
+        <pin position="57" name="PE11"/>
+        <pin position="58" name="PE12"/>
+        <pin position="59" name="PE13"/>
+        <pin position="60" name="PE14"/>
+        <pin position="61" name="PE15"/>
+        <pin position="62" name="PB10"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PB11"/>
+        <pin position="66" name="PB12"/>
+        <pin position="67" name="PB13"/>
+        <pin position="68" name="PB14"/>
+        <pin position="69" name="PB15"/>
+        <pin position="70" name="PD8"/>
+        <pin position="71" name="PD9"/>
+        <pin position="72" name="PD10"/>
+        <pin position="73" name="PD11"/>
+        <pin position="74" name="PD12"/>
+        <pin position="75" name="PD13"/>
+        <pin position="76" name="PD14"/>
+        <pin position="77" name="PD15"/>
+        <pin position="78" name="VSS" type="power"/>
+        <pin position="79" name="VDD" type="power"/>
+        <pin position="80" name="PC6"/>
+        <pin position="81" name="PC7"/>
+        <pin position="82" name="PG0"/>
+        <pin position="83" name="PG1"/>
+        <pin position="84" name="PG2"/>
+        <pin position="85" name="PG3"/>
+        <pin position="86" name="PG4"/>
+        <pin position="87" name="PC8"/>
+        <pin position="88" name="PC9"/>
+        <pin position="89" name="PA8"/>
+        <pin position="90" name="PA9"/>
+        <pin position="91" name="PA10"/>
+        <pin position="92" name="PA11"/>
+        <pin position="93" name="PA12"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PA13"/>
+        <pin position="97" name="PF6"/>
+        <pin position="98" name="PA14"/>
+        <pin position="99" name="PA15"/>
+        <pin position="100" name="PC10"/>
+        <pin position="101" name="PC11"/>
+        <pin position="102" name="PC12"/>
+        <pin position="103" name="PG5"/>
+        <pin position="104" name="PG6"/>
+        <pin position="105" name="PG7"/>
+        <pin position="106" name="PG8"/>
+        <pin position="107" name="PG9"/>
+        <pin position="108" name="PD0"/>
+        <pin position="109" name="PD1"/>
+        <pin position="110" name="VSS" type="power"/>
+        <pin position="111" name="VDD" type="power"/>
+        <pin position="112" name="PD2"/>
+        <pin position="113" name="PD3"/>
+        <pin position="114" name="PD4"/>
+        <pin position="115" name="PD5"/>
+        <pin position="116" name="PD6"/>
+        <pin position="117" name="PD7"/>
+        <pin position="118" name="PB3"/>
+        <pin position="119" name="PB4"/>
+        <pin position="120" name="PB5"/>
+        <pin position="121" name="PB6"/>
+        <pin position="122" name="PB7"/>
+        <pin position="123" name="PB8-BOOT0"/>
+        <pin position="124" name="PB9"/>
+        <pin position="125" name="PE0"/>
+        <pin position="126" name="PE1"/>
+        <pin position="127" name="VSS" type="power"/>
+        <pin position="128" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PB0"/>
+        <pin position="17" name="PB1"/>
+        <pin position="18" name="PB2"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB11"/>
+        <pin position="26" name="PB12"/>
+        <pin position="27" name="PB13"/>
+        <pin position="28" name="PB14"/>
+        <pin position="29" name="PB15"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA13"/>
+        <pin position="38" name="PA14"/>
+        <pin position="39" name="PA15"/>
+        <pin position="40" name="PB3"/>
+        <pin position="41" name="PB4"/>
+        <pin position="42" name="PB5"/>
+        <pin position="43" name="PB6"/>
+        <pin position="44" name="PB7"/>
+        <pin position="45" name="PB8-BOOT0"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB11"/>
+        <pin position="34" name="PB12"/>
+        <pin position="35" name="PB13"/>
+        <pin position="36" name="PB14"/>
+        <pin position="37" name="PB15"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PC8"/>
+        <pin position="41" name="PC9"/>
+        <pin position="42" name="PA8"/>
+        <pin position="43" name="PA9"/>
+        <pin position="44" name="PA10"/>
+        <pin position="45" name="PA11"/>
+        <pin position="46" name="PA12"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA13"/>
+        <pin position="50" name="PA14"/>
+        <pin position="51" name="PA15"/>
+        <pin position="52" name="PC10"/>
+        <pin position="53" name="PC11"/>
+        <pin position="54" name="PC12"/>
+        <pin position="55" name="PD2"/>
+        <pin position="56" name="PB3"/>
+        <pin position="57" name="PB4"/>
+        <pin position="58" name="PB5"/>
+        <pin position="59" name="PB6"/>
+        <pin position="60" name="PB7"/>
+        <pin position="61" name="PB8-BOOT0"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="m" device-package="t" name="LQFP80">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PE7"/>
+        <pin position="31" name="PE8"/>
+        <pin position="32" name="PE9"/>
+        <pin position="33" name="PE10"/>
+        <pin position="34" name="PE11"/>
+        <pin position="35" name="PE12"/>
+        <pin position="36" name="PE13"/>
+        <pin position="37" name="PE14"/>
+        <pin position="38" name="PE15"/>
+        <pin position="39" name="PB10"/>
+        <pin position="40" name="VSS" type="power"/>
+        <pin position="41" name="VDD" type="power"/>
+        <pin position="42" name="PB11"/>
+        <pin position="43" name="PB12"/>
+        <pin position="44" name="PB13"/>
+        <pin position="45" name="PB14"/>
+        <pin position="46" name="PB15"/>
+        <pin position="47" name="PD8"/>
+        <pin position="48" name="PD9"/>
+        <pin position="49" name="PD10"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="VDD" type="power"/>
+        <pin position="52" name="PC6"/>
+        <pin position="53" name="PC7"/>
+        <pin position="54" name="PC8"/>
+        <pin position="55" name="PC9"/>
+        <pin position="56" name="PA8"/>
+        <pin position="57" name="PA9"/>
+        <pin position="58" name="PA10"/>
+        <pin position="59" name="PA11"/>
+        <pin position="60" name="PA12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PA13"/>
+        <pin position="64" name="PA14"/>
+        <pin position="65" name="PA15"/>
+        <pin position="66" name="PC10"/>
+        <pin position="67" name="PC11"/>
+        <pin position="68" name="PC12"/>
+        <pin position="69" name="PD0"/>
+        <pin position="70" name="PD1"/>
+        <pin position="71" name="PD2"/>
+        <pin position="72" name="PB3"/>
+        <pin position="73" name="PB4"/>
+        <pin position="74" name="PB5"/>
+        <pin position="75" name="PB6"/>
+        <pin position="76" name="PB7"/>
+        <pin position="77" name="PB8-BOOT0"/>
+        <pin position="78" name="PB9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA100">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB8-BOOT0"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PD6"/>
+        <pin position="A7" name="PD5"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD1"/>
+        <pin position="A10" name="PC12"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PD7"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PA15"/>
+        <pin position="B10" name="PA14"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB4"/>
+        <pin position="C6" name="PD3"/>
+        <pin position="C7" name="PC11"/>
+        <pin position="C8" name="PC10"/>
+        <pin position="C9" name="PA12"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VBAT" type="power"/>
+        <pin position="D4" name="PC13"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="VDD" type="power"/>
+        <pin position="D8" name="PA13"/>
+        <pin position="D9" name="PA10"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="E1" name="PF0-OSC_IN"/>
+        <pin position="E2" name="PF1-OSC_OUT"/>
+        <pin position="E3" name="PF9"/>
+        <pin position="E4" name="PF10"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PA8"/>
+        <pin position="F1" name="PC2"/>
+        <pin position="F2" name="PC0"/>
+        <pin position="F3" name="PG10-NRST"/>
+        <pin position="F4" name="PC1"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="PD14"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA1"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="PA0"/>
+        <pin position="G5" name="PE7"/>
+        <pin position="G6" name="PE12"/>
+        <pin position="G7" name="PD10"/>
+        <pin position="G8" name="PD9"/>
+        <pin position="G9" name="PD13"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="PA2"/>
+        <pin position="H2" name="PA4"/>
+        <pin position="H3" name="PA3"/>
+        <pin position="H4" name="PB0"/>
+        <pin position="H5" name="PE8"/>
+        <pin position="H6" name="PE9"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PB14"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="J1" name="PA5"/>
+        <pin position="J2" name="PA6"/>
+        <pin position="J3" name="PC5"/>
+        <pin position="J4" name="PB2"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="PE11"/>
+        <pin position="J7" name="PE14"/>
+        <pin position="J8" name="PB10"/>
+        <pin position="J9" name="PB13"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="K1" name="PA7"/>
+        <pin position="K2" name="PC4"/>
+        <pin position="K3" name="PB1"/>
+        <pin position="K4" name="VSSA" type="power"/>
+        <pin position="K5" name="VREF+" type="monoio"/>
+        <pin position="K6" name="PE10"/>
+        <pin position="K7" name="PE13"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PB15"/>
+        <pin position="K10" name="PD8"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE2"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="PB4"/>
+        <pin position="A6" name="PD7"/>
+        <pin position="A7" name="PD6"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB8-BOOT0"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB3"/>
+        <pin position="B7" name="PD5"/>
+        <pin position="B8" name="PD2"/>
+        <pin position="B9" name="PD0"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PA15"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="C1" name="PE6"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="VSS" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VSS" type="power"/>
+        <pin position="C10" name="PA13"/>
+        <pin position="C11" name="PA10"/>
+        <pin position="C12" name="PA12"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="VBAT" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D10" name="PC8"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA11"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="PF9"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E10" name="PC6"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF10"/>
+        <pin position="F11" name="PC7"/>
+        <pin position="F12" name="PD14"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PG10-NRST"/>
+        <pin position="G11" name="PD15"/>
+        <pin position="G12" name="PD13"/>
+        <pin position="H1" name="PC2"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H10" name="VDD" type="power"/>
+        <pin position="H11" name="PD11"/>
+        <pin position="H12" name="PD12"/>
+        <pin position="J1" name="PC3"/>
+        <pin position="J2" name="PF2"/>
+        <pin position="J3" name="VDD" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="PD9"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PA0"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K8" name="PE8"/>
+        <pin position="K9" name="PE11"/>
+        <pin position="K10" name="PB11"/>
+        <pin position="K11" name="PB13"/>
+        <pin position="K12" name="PD8"/>
+        <pin position="L1" name="PA3"/>
+        <pin position="L2" name="PA4"/>
+        <pin position="L3" name="PC4"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="VSSA" type="power"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE13"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB12"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="PA5"/>
+        <pin position="M2" name="PA6"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="VREF+" type="monoio"/>
+        <pin position="M6" name="VDDA" type="power"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE12"/>
+        <pin position="M10" name="PE14"/>
+        <pin position="M11" name="PE15"/>
+        <pin position="M12" name="PB14"/>
+      </package>
+      <package device-pin="p" name="UFBGA121">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3"/>
+        <pin position="A7" name="PD4"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PD1"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PF6"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PD7"/>
+        <pin position="B7" name="PD3"/>
+        <pin position="B8" name="VSS" type="power"/>
+        <pin position="B9" name="PD0"/>
+        <pin position="B10" name="PA14"/>
+        <pin position="B11" name="PA13"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PE6"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB4"/>
+        <pin position="C7" name="PD2"/>
+        <pin position="C8" name="PC11"/>
+        <pin position="C9" name="PC10"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="VDD" type="power"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PC15-OSC32_OUT"/>
+        <pin position="D3" name="PF3"/>
+        <pin position="D4" name="PF4"/>
+        <pin position="D5" name="PB8-BOOT0"/>
+        <pin position="D6" name="PD6"/>
+        <pin position="D7" name="PC12"/>
+        <pin position="D8" name="PA9"/>
+        <pin position="D9" name="PA10"/>
+        <pin position="D10" name="PA12"/>
+        <pin position="D11" name="PA11"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="VSS" type="power"/>
+        <pin position="E3" name="PF5"/>
+        <pin position="E4" name="PF7"/>
+        <pin position="E5" name="PF8"/>
+        <pin position="E6" name="PD5"/>
+        <pin position="E7" name="PA8"/>
+        <pin position="E8" name="PC9"/>
+        <pin position="E9" name="PC8"/>
+        <pin position="E10" name="PG4"/>
+        <pin position="E11" name="PG3"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF1-OSC_OUT"/>
+        <pin position="F3" name="PF9"/>
+        <pin position="F4" name="PF10"/>
+        <pin position="F5" name="PG10-NRST"/>
+        <pin position="F6" name="PD15"/>
+        <pin position="F7" name="PG2"/>
+        <pin position="F8" name="PG1"/>
+        <pin position="F9" name="PG0"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="F11" name="PC7"/>
+        <pin position="G1" name="PC1"/>
+        <pin position="G2" name="PC0"/>
+        <pin position="G3" name="PC2"/>
+        <pin position="G4" name="PA0"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PF15"/>
+        <pin position="G7" name="PD11"/>
+        <pin position="G8" name="PD12"/>
+        <pin position="G9" name="PD13"/>
+        <pin position="G10" name="PD14"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="H1" name="PC3"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PA1"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PF12"/>
+        <pin position="H6" name="PF14"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PB15"/>
+        <pin position="H9" name="PD8"/>
+        <pin position="H10" name="PD9"/>
+        <pin position="H11" name="PD10"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PA2"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PF11"/>
+        <pin position="J6" name="PF13"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE13"/>
+        <pin position="J9" name="PB12"/>
+        <pin position="J10" name="PB14"/>
+        <pin position="J11" name="PB13"/>
+        <pin position="K1" name="PA3"/>
+        <pin position="K2" name="PA5"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB2"/>
+        <pin position="K5" name="VSSA" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE12"/>
+        <pin position="K9" name="PE14"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="L1" name="PA4"/>
+        <pin position="L2" name="PA6"/>
+        <pin position="L3" name="PC4"/>
+        <pin position="L4" name="VREF+" type="monoio"/>
+        <pin position="L5" name="VDDA" type="power"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE11"/>
+        <pin position="L9" name="PE15"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PC4"/>
+        <pin position="17" name="PB0"/>
+        <pin position="18" name="PB1"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PB11"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PC6"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA13"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PC10"/>
+        <pin position="40" name="PC11"/>
+        <pin position="41" name="PB3"/>
+        <pin position="42" name="PB4"/>
+        <pin position="43" name="PB5"/>
+        <pin position="44" name="PB6"/>
+        <pin position="45" name="PB7"/>
+        <pin position="46" name="PB8-BOOT0"/>
+        <pin position="47" name="PB9"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP81">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD1"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PD0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PB8-BOOT0"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA14"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PC8"/>
+        <pin position="C6" name="PB4"/>
+        <pin position="C7" name="PB7"/>
+        <pin position="C8" name="PC1"/>
+        <pin position="C9" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PC7"/>
+        <pin position="D6" name="PA4"/>
+        <pin position="D7" name="PA0"/>
+        <pin position="D8" name="PG10-NRST"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PD11"/>
+        <pin position="E3" name="PC6"/>
+        <pin position="E4" name="PB15"/>
+        <pin position="E5" name="PE12"/>
+        <pin position="E6" name="PC4"/>
+        <pin position="E7" name="PA1"/>
+        <pin position="E8" name="PC0"/>
+        <pin position="E9" name="PF0-OSC_IN"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PD10"/>
+        <pin position="F3" name="PD9"/>
+        <pin position="F4" name="PE15"/>
+        <pin position="F5" name="PE9"/>
+        <pin position="F6" name="PB0"/>
+        <pin position="F7" name="PA5"/>
+        <pin position="F8" name="PC2"/>
+        <pin position="F9" name="PF1-OSC_OUT"/>
+        <pin position="G1" name="PD8"/>
+        <pin position="G2" name="PB14"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PE13"/>
+        <pin position="G5" name="PE8"/>
+        <pin position="G6" name="PB1"/>
+        <pin position="G7" name="PA6"/>
+        <pin position="G8" name="PA2"/>
+        <pin position="G9" name="PC3"/>
+        <pin position="H1" name="PB13"/>
+        <pin position="H2" name="PB11"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PE11"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="VSSA" type="power"/>
+        <pin position="H7" name="PC5"/>
+        <pin position="H8" name="PA3"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PE14"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="VREF+" type="monoio"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA7"/>
+        <pin position="J9" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32g4-74_84.xml
+++ b/devices/stm32/stm32g4-74_84.xml
@@ -1924,6 +1924,896 @@
       <gpio port="g" pin="10">
         <signal af="0" driver="rcc" name="mco"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF9"/>
+        <pin position="11" name="PF10"/>
+        <pin position="12" name="PF0-OSC_IN"/>
+        <pin position="13" name="PF1-OSC_OUT"/>
+        <pin position="14" name="PG10-NRST"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="PF2"/>
+        <pin position="20" name="PA0"/>
+        <pin position="21" name="PA1"/>
+        <pin position="22" name="PA2"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="PA4"/>
+        <pin position="27" name="PA5"/>
+        <pin position="28" name="PA6"/>
+        <pin position="29" name="PA7"/>
+        <pin position="30" name="PC4"/>
+        <pin position="31" name="PC5"/>
+        <pin position="32" name="PB0"/>
+        <pin position="33" name="PB1"/>
+        <pin position="34" name="PB2"/>
+        <pin position="35" name="VSSA" type="power"/>
+        <pin position="36" name="VREF+" type="monoio"/>
+        <pin position="37" name="VDDA" type="power"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PB11"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PC6"/>
+        <pin position="66" name="PC7"/>
+        <pin position="67" name="PC8"/>
+        <pin position="68" name="PC9"/>
+        <pin position="69" name="PA8"/>
+        <pin position="70" name="PA9"/>
+        <pin position="71" name="PA10"/>
+        <pin position="72" name="PA11"/>
+        <pin position="73" name="PA12"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA13"/>
+        <pin position="77" name="PA14"/>
+        <pin position="78" name="PA15"/>
+        <pin position="79" name="PC10"/>
+        <pin position="80" name="PC11"/>
+        <pin position="81" name="PC12"/>
+        <pin position="82" name="PD0"/>
+        <pin position="83" name="PD1"/>
+        <pin position="84" name="PD2"/>
+        <pin position="85" name="PD3"/>
+        <pin position="86" name="PD4"/>
+        <pin position="87" name="PD5"/>
+        <pin position="88" name="PD6"/>
+        <pin position="89" name="PD7"/>
+        <pin position="90" name="PB3"/>
+        <pin position="91" name="PB4"/>
+        <pin position="92" name="PB5"/>
+        <pin position="93" name="PB6"/>
+        <pin position="94" name="PB7"/>
+        <pin position="95" name="PB8-BOOT0"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="LQFP128">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF3"/>
+        <pin position="11" name="PF4"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="PF5"/>
+        <pin position="15" name="PF7"/>
+        <pin position="16" name="PF8"/>
+        <pin position="17" name="PF9"/>
+        <pin position="18" name="PF10"/>
+        <pin position="19" name="PF0-OSC_IN"/>
+        <pin position="20" name="PF1-OSC_OUT"/>
+        <pin position="21" name="PG10-NRST"/>
+        <pin position="22" name="PC0"/>
+        <pin position="23" name="PC1"/>
+        <pin position="24" name="PC2"/>
+        <pin position="25" name="PC3"/>
+        <pin position="26" name="PF2"/>
+        <pin position="27" name="PA0"/>
+        <pin position="28" name="PA1"/>
+        <pin position="29" name="PA2"/>
+        <pin position="30" name="VSS" type="power"/>
+        <pin position="31" name="VDD" type="power"/>
+        <pin position="32" name="PA3"/>
+        <pin position="33" name="PA4"/>
+        <pin position="34" name="PA5"/>
+        <pin position="35" name="PA6"/>
+        <pin position="36" name="PA7"/>
+        <pin position="37" name="PC4"/>
+        <pin position="38" name="PC5"/>
+        <pin position="39" name="PB0"/>
+        <pin position="40" name="PB1"/>
+        <pin position="41" name="PB2"/>
+        <pin position="42" name="VSSA" type="power"/>
+        <pin position="43" name="VREF+" type="monoio"/>
+        <pin position="44" name="VREF_+" type="monoio"/>
+        <pin position="45" name="VDDA" type="power"/>
+        <pin position="46" name="VSS" type="power"/>
+        <pin position="47" name="VDD" type="power"/>
+        <pin position="48" name="PF11"/>
+        <pin position="49" name="PF12"/>
+        <pin position="50" name="PF13"/>
+        <pin position="51" name="PF14"/>
+        <pin position="52" name="PF15"/>
+        <pin position="53" name="PE7"/>
+        <pin position="54" name="PE8"/>
+        <pin position="55" name="PE9"/>
+        <pin position="56" name="PE10"/>
+        <pin position="57" name="PE11"/>
+        <pin position="58" name="PE12"/>
+        <pin position="59" name="PE13"/>
+        <pin position="60" name="PE14"/>
+        <pin position="61" name="PE15"/>
+        <pin position="62" name="PB10"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+        <pin position="65" name="PB11"/>
+        <pin position="66" name="PB12"/>
+        <pin position="67" name="PB13"/>
+        <pin position="68" name="PB14"/>
+        <pin position="69" name="PB15"/>
+        <pin position="70" name="PD8"/>
+        <pin position="71" name="PD9"/>
+        <pin position="72" name="PD10"/>
+        <pin position="73" name="PD11"/>
+        <pin position="74" name="PD12"/>
+        <pin position="75" name="PD13"/>
+        <pin position="76" name="PD14"/>
+        <pin position="77" name="PD15"/>
+        <pin position="78" name="VSS" type="power"/>
+        <pin position="79" name="VDD" type="power"/>
+        <pin position="80" name="PC6"/>
+        <pin position="81" name="PC7"/>
+        <pin position="82" name="PG0"/>
+        <pin position="83" name="PG1"/>
+        <pin position="84" name="PG2"/>
+        <pin position="85" name="PG3"/>
+        <pin position="86" name="PG4"/>
+        <pin position="87" name="PC8"/>
+        <pin position="88" name="PC9"/>
+        <pin position="89" name="PA8"/>
+        <pin position="90" name="PA9"/>
+        <pin position="91" name="PA10"/>
+        <pin position="92" name="PA11"/>
+        <pin position="93" name="PA12"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PA13"/>
+        <pin position="97" name="PF6"/>
+        <pin position="98" name="PA14"/>
+        <pin position="99" name="PA15"/>
+        <pin position="100" name="PC10"/>
+        <pin position="101" name="PC11"/>
+        <pin position="102" name="PC12"/>
+        <pin position="103" name="PG5"/>
+        <pin position="104" name="PG6"/>
+        <pin position="105" name="PG7"/>
+        <pin position="106" name="PG8"/>
+        <pin position="107" name="PG9"/>
+        <pin position="108" name="PD0"/>
+        <pin position="109" name="PD1"/>
+        <pin position="110" name="VSS" type="power"/>
+        <pin position="111" name="VDD" type="power"/>
+        <pin position="112" name="PD2"/>
+        <pin position="113" name="PD3"/>
+        <pin position="114" name="PD4"/>
+        <pin position="115" name="PD5"/>
+        <pin position="116" name="PD6"/>
+        <pin position="117" name="PD7"/>
+        <pin position="118" name="PB3"/>
+        <pin position="119" name="PB4"/>
+        <pin position="120" name="PB5"/>
+        <pin position="121" name="PB6"/>
+        <pin position="122" name="PB7"/>
+        <pin position="123" name="PB8-BOOT0"/>
+        <pin position="124" name="PB9"/>
+        <pin position="125" name="PE0"/>
+        <pin position="126" name="PE1"/>
+        <pin position="127" name="VSS" type="power"/>
+        <pin position="128" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PB0"/>
+        <pin position="17" name="PB1"/>
+        <pin position="18" name="PB2"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB11"/>
+        <pin position="26" name="PB12"/>
+        <pin position="27" name="PB13"/>
+        <pin position="28" name="PB14"/>
+        <pin position="29" name="PB15"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA13"/>
+        <pin position="38" name="PA14"/>
+        <pin position="39" name="PA15"/>
+        <pin position="40" name="PB3"/>
+        <pin position="41" name="PB4"/>
+        <pin position="42" name="PB5"/>
+        <pin position="43" name="PB6"/>
+        <pin position="44" name="PB7"/>
+        <pin position="45" name="PB8-BOOT0"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PB10"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB11"/>
+        <pin position="34" name="PB12"/>
+        <pin position="35" name="PB13"/>
+        <pin position="36" name="PB14"/>
+        <pin position="37" name="PB15"/>
+        <pin position="38" name="PC6"/>
+        <pin position="39" name="PC7"/>
+        <pin position="40" name="PC8"/>
+        <pin position="41" name="PC9"/>
+        <pin position="42" name="PA8"/>
+        <pin position="43" name="PA9"/>
+        <pin position="44" name="PA10"/>
+        <pin position="45" name="PA11"/>
+        <pin position="46" name="PA12"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA13"/>
+        <pin position="50" name="PA14"/>
+        <pin position="51" name="PA15"/>
+        <pin position="52" name="PC10"/>
+        <pin position="53" name="PC11"/>
+        <pin position="54" name="PC12"/>
+        <pin position="55" name="PD2"/>
+        <pin position="56" name="PB3"/>
+        <pin position="57" name="PB4"/>
+        <pin position="58" name="PB5"/>
+        <pin position="59" name="PB6"/>
+        <pin position="60" name="PB7"/>
+        <pin position="61" name="PB8-BOOT0"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="m" device-package="t" name="LQFP80">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="PA0"/>
+        <pin position="13" name="PA1"/>
+        <pin position="14" name="PA2"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="PA4"/>
+        <pin position="19" name="PA5"/>
+        <pin position="20" name="PA6"/>
+        <pin position="21" name="PA7"/>
+        <pin position="22" name="PC4"/>
+        <pin position="23" name="PC5"/>
+        <pin position="24" name="PB0"/>
+        <pin position="25" name="PB1"/>
+        <pin position="26" name="PB2"/>
+        <pin position="27" name="VSSA" type="power"/>
+        <pin position="28" name="VREF+" type="monoio"/>
+        <pin position="29" name="VDDA" type="power"/>
+        <pin position="30" name="PE7"/>
+        <pin position="31" name="PE8"/>
+        <pin position="32" name="PE9"/>
+        <pin position="33" name="PE10"/>
+        <pin position="34" name="PE11"/>
+        <pin position="35" name="PE12"/>
+        <pin position="36" name="PE13"/>
+        <pin position="37" name="PE14"/>
+        <pin position="38" name="PE15"/>
+        <pin position="39" name="PB10"/>
+        <pin position="40" name="VSS" type="power"/>
+        <pin position="41" name="VDD" type="power"/>
+        <pin position="42" name="PB11"/>
+        <pin position="43" name="PB12"/>
+        <pin position="44" name="PB13"/>
+        <pin position="45" name="PB14"/>
+        <pin position="46" name="PB15"/>
+        <pin position="47" name="PD8"/>
+        <pin position="48" name="PD9"/>
+        <pin position="49" name="PD10"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="VDD" type="power"/>
+        <pin position="52" name="PC6"/>
+        <pin position="53" name="PC7"/>
+        <pin position="54" name="PC8"/>
+        <pin position="55" name="PC9"/>
+        <pin position="56" name="PA8"/>
+        <pin position="57" name="PA9"/>
+        <pin position="58" name="PA10"/>
+        <pin position="59" name="PA11"/>
+        <pin position="60" name="PA12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PA13"/>
+        <pin position="64" name="PA14"/>
+        <pin position="65" name="PA15"/>
+        <pin position="66" name="PC10"/>
+        <pin position="67" name="PC11"/>
+        <pin position="68" name="PC12"/>
+        <pin position="69" name="PD0"/>
+        <pin position="70" name="PD1"/>
+        <pin position="71" name="PD2"/>
+        <pin position="72" name="PB3"/>
+        <pin position="73" name="PB4"/>
+        <pin position="74" name="PB5"/>
+        <pin position="75" name="PB6"/>
+        <pin position="76" name="PB7"/>
+        <pin position="77" name="PB8-BOOT0"/>
+        <pin position="78" name="PB9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA100">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB8-BOOT0"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PD6"/>
+        <pin position="A7" name="PD5"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD1"/>
+        <pin position="A10" name="PC12"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PD7"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PA15"/>
+        <pin position="B10" name="PA14"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB4"/>
+        <pin position="C6" name="PD3"/>
+        <pin position="C7" name="PC11"/>
+        <pin position="C8" name="PC10"/>
+        <pin position="C9" name="PA12"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VBAT" type="power"/>
+        <pin position="D4" name="PC13"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="VDD" type="power"/>
+        <pin position="D8" name="PA13"/>
+        <pin position="D9" name="PA10"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="E1" name="PF0-OSC_IN"/>
+        <pin position="E2" name="PF1-OSC_OUT"/>
+        <pin position="E3" name="PF9"/>
+        <pin position="E4" name="PF10"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PA8"/>
+        <pin position="F1" name="PC2"/>
+        <pin position="F2" name="PC0"/>
+        <pin position="F3" name="PG10-NRST"/>
+        <pin position="F4" name="PC1"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="PD14"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA1"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="PA0"/>
+        <pin position="G5" name="PE7"/>
+        <pin position="G6" name="PE12"/>
+        <pin position="G7" name="PD10"/>
+        <pin position="G8" name="PD9"/>
+        <pin position="G9" name="PD13"/>
+        <pin position="G10" name="PD15"/>
+        <pin position="H1" name="PA2"/>
+        <pin position="H2" name="PA4"/>
+        <pin position="H3" name="PA3"/>
+        <pin position="H4" name="PB0"/>
+        <pin position="H5" name="PE8"/>
+        <pin position="H6" name="PE9"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PB14"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="J1" name="PA5"/>
+        <pin position="J2" name="PA6"/>
+        <pin position="J3" name="PC5"/>
+        <pin position="J4" name="PB2"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="PE11"/>
+        <pin position="J7" name="PE14"/>
+        <pin position="J8" name="PB10"/>
+        <pin position="J9" name="PB13"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="K1" name="PA7"/>
+        <pin position="K2" name="PC4"/>
+        <pin position="K3" name="PB1"/>
+        <pin position="K4" name="VSSA" type="power"/>
+        <pin position="K5" name="VREF+" type="monoio"/>
+        <pin position="K6" name="PE10"/>
+        <pin position="K7" name="PE13"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PB15"/>
+        <pin position="K10" name="PD8"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE2"/>
+        <pin position="A2" name="PB9"/>
+        <pin position="A3" name="PB7"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="PB4"/>
+        <pin position="A6" name="PD7"/>
+        <pin position="A7" name="PD6"/>
+        <pin position="A8" name="PD4"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PE1"/>
+        <pin position="B4" name="PB8-BOOT0"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB3"/>
+        <pin position="B7" name="PD5"/>
+        <pin position="B8" name="PD2"/>
+        <pin position="B9" name="PD0"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PA15"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="C1" name="PE6"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="VSS" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VSS" type="power"/>
+        <pin position="C10" name="PA13"/>
+        <pin position="C11" name="PA10"/>
+        <pin position="C12" name="PA12"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="VBAT" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D10" name="PC8"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA11"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="PF9"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E10" name="PC6"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF10"/>
+        <pin position="F11" name="PC7"/>
+        <pin position="F12" name="PD14"/>
+        <pin position="G1" name="PF1-OSC_OUT"/>
+        <pin position="G2" name="PG10-NRST"/>
+        <pin position="G11" name="PD15"/>
+        <pin position="G12" name="PD13"/>
+        <pin position="H1" name="PC2"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="VSS" type="power"/>
+        <pin position="H10" name="VDD" type="power"/>
+        <pin position="H11" name="PD11"/>
+        <pin position="H12" name="PD12"/>
+        <pin position="J1" name="PC3"/>
+        <pin position="J2" name="PF2"/>
+        <pin position="J3" name="VDD" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="PD9"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PA0"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K8" name="PE8"/>
+        <pin position="K9" name="PE11"/>
+        <pin position="K10" name="PB11"/>
+        <pin position="K11" name="PB13"/>
+        <pin position="K12" name="PD8"/>
+        <pin position="L1" name="PA3"/>
+        <pin position="L2" name="PA4"/>
+        <pin position="L3" name="PC4"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="VSSA" type="power"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE13"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB12"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="PA5"/>
+        <pin position="M2" name="PA6"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="VREF+" type="monoio"/>
+        <pin position="M6" name="VDDA" type="power"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE12"/>
+        <pin position="M10" name="PE14"/>
+        <pin position="M11" name="PE15"/>
+        <pin position="M12" name="PB14"/>
+      </package>
+      <package device-pin="p" name="UFBGA121">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3"/>
+        <pin position="A7" name="PD4"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PD1"/>
+        <pin position="A10" name="PA15"/>
+        <pin position="A11" name="PF6"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PD7"/>
+        <pin position="B7" name="PD3"/>
+        <pin position="B8" name="VSS" type="power"/>
+        <pin position="B9" name="PD0"/>
+        <pin position="B10" name="PA14"/>
+        <pin position="B11" name="PA13"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PE6"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB4"/>
+        <pin position="C7" name="PD2"/>
+        <pin position="C8" name="PC11"/>
+        <pin position="C9" name="PC10"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="VDD" type="power"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PC15-OSC32_OUT"/>
+        <pin position="D3" name="PF3"/>
+        <pin position="D4" name="PF4"/>
+        <pin position="D5" name="PB8-BOOT0"/>
+        <pin position="D6" name="PD6"/>
+        <pin position="D7" name="PC12"/>
+        <pin position="D8" name="PA9"/>
+        <pin position="D9" name="PA10"/>
+        <pin position="D10" name="PA12"/>
+        <pin position="D11" name="PA11"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="VSS" type="power"/>
+        <pin position="E3" name="PF5"/>
+        <pin position="E4" name="PF7"/>
+        <pin position="E5" name="PF8"/>
+        <pin position="E6" name="PD5"/>
+        <pin position="E7" name="PA8"/>
+        <pin position="E8" name="PC9"/>
+        <pin position="E9" name="PC8"/>
+        <pin position="E10" name="PG4"/>
+        <pin position="E11" name="PG3"/>
+        <pin position="F1" name="PF0-OSC_IN"/>
+        <pin position="F2" name="PF1-OSC_OUT"/>
+        <pin position="F3" name="PF9"/>
+        <pin position="F4" name="PF10"/>
+        <pin position="F5" name="PG10-NRST"/>
+        <pin position="F6" name="PD15"/>
+        <pin position="F7" name="PG2"/>
+        <pin position="F8" name="PG1"/>
+        <pin position="F9" name="PG0"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="F11" name="PC7"/>
+        <pin position="G1" name="PC1"/>
+        <pin position="G2" name="PC0"/>
+        <pin position="G3" name="PC2"/>
+        <pin position="G4" name="PA0"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PF15"/>
+        <pin position="G7" name="PD11"/>
+        <pin position="G8" name="PD12"/>
+        <pin position="G9" name="PD13"/>
+        <pin position="G10" name="PD14"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="H1" name="PC3"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PA1"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PF12"/>
+        <pin position="H6" name="PF14"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PB15"/>
+        <pin position="H9" name="PD8"/>
+        <pin position="H10" name="PD9"/>
+        <pin position="H11" name="PD10"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PA2"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PF11"/>
+        <pin position="J6" name="PF13"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE13"/>
+        <pin position="J9" name="PB12"/>
+        <pin position="J10" name="PB14"/>
+        <pin position="J11" name="PB13"/>
+        <pin position="K1" name="PA3"/>
+        <pin position="K2" name="PA5"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB2"/>
+        <pin position="K5" name="VSSA" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE12"/>
+        <pin position="K9" name="PE14"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="L1" name="PA4"/>
+        <pin position="L2" name="PA6"/>
+        <pin position="L3" name="PC4"/>
+        <pin position="L4" name="VREF+" type="monoio"/>
+        <pin position="L5" name="VDDA" type="power"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE11"/>
+        <pin position="L9" name="PE15"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PF0-OSC_IN"/>
+        <pin position="6" name="PF1-OSC_OUT"/>
+        <pin position="7" name="PG10-NRST"/>
+        <pin position="8" name="PA0"/>
+        <pin position="9" name="PA1"/>
+        <pin position="10" name="PA2"/>
+        <pin position="11" name="PA3"/>
+        <pin position="12" name="PA4"/>
+        <pin position="13" name="PA5"/>
+        <pin position="14" name="PA6"/>
+        <pin position="15" name="PA7"/>
+        <pin position="16" name="PC4"/>
+        <pin position="17" name="PB0"/>
+        <pin position="18" name="PB1"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PB10"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PB11"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PC6"/>
+        <pin position="30" name="PA8"/>
+        <pin position="31" name="PA9"/>
+        <pin position="32" name="PA10"/>
+        <pin position="33" name="PA11"/>
+        <pin position="34" name="PA12"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA13"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PC10"/>
+        <pin position="40" name="PC11"/>
+        <pin position="41" name="PB3"/>
+        <pin position="42" name="PB4"/>
+        <pin position="43" name="PB5"/>
+        <pin position="44" name="PB6"/>
+        <pin position="45" name="PB7"/>
+        <pin position="46" name="PB8-BOOT0"/>
+        <pin position="47" name="PB9"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP81">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD1"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PB9"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PD0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PB8-BOOT0"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PA14"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PC8"/>
+        <pin position="C6" name="PB4"/>
+        <pin position="C7" name="PB7"/>
+        <pin position="C8" name="PC1"/>
+        <pin position="C9" name="PC14-OSC32_IN"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PC7"/>
+        <pin position="D6" name="PA4"/>
+        <pin position="D7" name="PA0"/>
+        <pin position="D8" name="PG10-NRST"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin position="E2" name="PD11"/>
+        <pin position="E3" name="PC6"/>
+        <pin position="E4" name="PB15"/>
+        <pin position="E5" name="PE12"/>
+        <pin position="E6" name="PC4"/>
+        <pin position="E7" name="PA1"/>
+        <pin position="E8" name="PC0"/>
+        <pin position="E9" name="PF0-OSC_IN"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin position="F2" name="PD10"/>
+        <pin position="F3" name="PD9"/>
+        <pin position="F4" name="PE15"/>
+        <pin position="F5" name="PE9"/>
+        <pin position="F6" name="PB0"/>
+        <pin position="F7" name="PA5"/>
+        <pin position="F8" name="PC2"/>
+        <pin position="F9" name="PF1-OSC_OUT"/>
+        <pin position="G1" name="PD8"/>
+        <pin position="G2" name="PB14"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PE13"/>
+        <pin position="G5" name="PE8"/>
+        <pin position="G6" name="PB1"/>
+        <pin position="G7" name="PA6"/>
+        <pin position="G8" name="PA2"/>
+        <pin position="G9" name="PC3"/>
+        <pin position="H1" name="PB13"/>
+        <pin position="H2" name="PB11"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PE11"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="VSSA" type="power"/>
+        <pin position="H7" name="PC5"/>
+        <pin position="H8" name="PA3"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PE14"/>
+        <pin position="J4" name="PE10"/>
+        <pin position="J5" name="VDDA" type="power"/>
+        <pin position="J6" name="VREF+" type="monoio"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA7"/>
+        <pin position="J9" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-23_33.xml
+++ b/devices/stm32/stm32h7-23_33.xml
@@ -2078,6 +2078,502 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13(JTMS/SWDIO)"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14(JTCK/SWCLK)"/>
+        <pin position="77" name="PA15(JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4(NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13(JTMS/SWDIO)"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14(JTCK/SWCLK)"/>
+        <pin position="110" name="PA15(JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4(NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4(NJTRST)"/>
+        <pin position="A7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A8" name="PA15(JTDI)"/>
+        <pin position="A9" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A10" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2_C"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VCAP" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3_C"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD33USB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="power"/>
+        <pin position="F8" name="VCAP" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-package="i" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4(NJTRST)"/>
+        <pin position="A7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15(JTDI)"/>
+        <pin position="A11" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A12" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDD33USB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0-OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1-OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-25_35.xml
+++ b/devices/stm32/stm32h7-25_35.xml
@@ -2376,6 +2376,993 @@
         <signal af="11" driver="tim" instance="1" name="bkin_comp2"/>
         <signal af="14" driver="ltdc" name="g7"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE4"/>
+        <pin position="3" name="PE5"/>
+        <pin position="4" name="VDD" type="power"/>
+        <pin position="5" name="VBAT" type="power"/>
+        <pin position="6" name="PC13"/>
+        <pin position="7" name="PC14-OSC32_IN"/>
+        <pin position="8" name="PC15-OSC32_OUT"/>
+        <pin position="9" name="VSSSMPS" type="power"/>
+        <pin position="10" name="VLXSMPS" type="power"/>
+        <pin position="11" name="VDDSMPS" type="power"/>
+        <pin position="12" name="VFBSMPS" type="power"/>
+        <pin position="13" name="PH0-OSC_IN"/>
+        <pin position="14" name="PH1-OSC_OUT"/>
+        <pin position="15" name="NRST" type="reset"/>
+        <pin position="16" name="PC0"/>
+        <pin position="17" name="PC1"/>
+        <pin position="18" name="PC2_C"/>
+        <pin position="19" name="PC3_C"/>
+        <pin position="20" name="VDD" type="power"/>
+        <pin position="21" name="VSS" type="power"/>
+        <pin position="22" name="VSSA" type="power"/>
+        <pin position="23" name="VREF+" type="monoio"/>
+        <pin position="24" name="VDDA" type="power"/>
+        <pin position="25" name="PA0"/>
+        <pin position="26" name="PA1"/>
+        <pin position="27" name="PA2"/>
+        <pin position="28" name="PA3"/>
+        <pin position="29" name="VSS" type="power"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="PA4"/>
+        <pin position="32" name="PA5"/>
+        <pin position="33" name="PA6"/>
+        <pin position="34" name="PA7"/>
+        <pin position="35" name="PC4"/>
+        <pin position="36" name="PC5"/>
+        <pin position="37" name="PB0"/>
+        <pin position="38" name="PB1"/>
+        <pin position="39" name="PB2"/>
+        <pin position="40" name="PE7"/>
+        <pin position="41" name="PE8"/>
+        <pin position="42" name="PB10"/>
+        <pin position="43" name="PB11"/>
+        <pin position="44" name="VCAP" type="power"/>
+        <pin position="45" name="VSS" type="power"/>
+        <pin position="46" name="VDDLDO" type="power"/>
+        <pin position="47" name="VDD" type="power"/>
+        <pin position="48" name="PB12"/>
+        <pin position="49" name="PB13"/>
+        <pin position="50" name="PB14"/>
+        <pin position="51" name="PB15"/>
+        <pin position="52" name="PD8"/>
+        <pin position="53" name="PD9"/>
+        <pin position="54" name="PD10"/>
+        <pin position="55" name="PD11"/>
+        <pin position="56" name="PD12"/>
+        <pin position="57" name="PD13"/>
+        <pin position="58" name="VSS" type="power"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="PD14"/>
+        <pin position="61" name="PD15"/>
+        <pin position="62" name="PC6"/>
+        <pin position="63" name="PC7"/>
+        <pin position="64" name="PC8"/>
+        <pin position="65" name="PC9"/>
+        <pin position="66" name="PA8"/>
+        <pin position="67" name="PA9"/>
+        <pin position="68" name="PA10"/>
+        <pin position="69" name="PA11"/>
+        <pin position="70" name="PA12"/>
+        <pin position="71" name="PA13(JTMS/SWDIO)"/>
+        <pin position="72" name="VCAP" type="power"/>
+        <pin position="73" name="VSS" type="power"/>
+        <pin position="74" name="VDDLDO" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="VDD33USB" type="power"/>
+        <pin position="77" name="PA14(JTCK/SWCLK)"/>
+        <pin position="78" name="PA15(JTDI)"/>
+        <pin position="79" name="PC10"/>
+        <pin position="80" name="PC11"/>
+        <pin position="81" name="PC12"/>
+        <pin position="82" name="PD0"/>
+        <pin position="83" name="PD1"/>
+        <pin position="84" name="PD2"/>
+        <pin position="85" name="PD3"/>
+        <pin position="86" name="PD4"/>
+        <pin position="87" name="PD5"/>
+        <pin position="88" name="VDD" type="power"/>
+        <pin position="89" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4(NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="VCAP" type="power"/>
+        <pin position="98" name="VSS" type="power"/>
+        <pin position="99" name="VDDLDO" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN"/>
+        <pin position="11" name="PC15-OSC32_OUT"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PF6"/>
+        <pin position="21" name="PF7"/>
+        <pin position="22" name="PF8"/>
+        <pin position="23" name="PF9"/>
+        <pin position="24" name="PF10"/>
+        <pin position="25" name="PH0-OSC_IN"/>
+        <pin position="26" name="PH1-OSC_OUT"/>
+        <pin position="27" name="NRST" type="reset"/>
+        <pin position="28" name="PC0"/>
+        <pin position="29" name="PC1"/>
+        <pin position="30" name="PC2_C"/>
+        <pin position="31" name="PC3_C"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="VSS" type="power"/>
+        <pin position="34" name="VSSA" type="power"/>
+        <pin position="35" name="VREF+" type="monoio"/>
+        <pin position="36" name="VDDA" type="power"/>
+        <pin position="37" name="PA0"/>
+        <pin position="38" name="PA1"/>
+        <pin position="39" name="PA2"/>
+        <pin position="40" name="PA3"/>
+        <pin position="41" name="VSS" type="power"/>
+        <pin position="42" name="VDD" type="power"/>
+        <pin position="43" name="PA4"/>
+        <pin position="44" name="PA5"/>
+        <pin position="45" name="PA6"/>
+        <pin position="46" name="PA7"/>
+        <pin position="47" name="PC4"/>
+        <pin position="48" name="PC5"/>
+        <pin position="49" name="PB0"/>
+        <pin position="50" name="PB1"/>
+        <pin position="51" name="PB2"/>
+        <pin position="52" name="PF11"/>
+        <pin position="53" name="PF14"/>
+        <pin position="54" name="PF15"/>
+        <pin position="55" name="VSS" type="power"/>
+        <pin position="56" name="VDD" type="power"/>
+        <pin position="57" name="PE7"/>
+        <pin position="58" name="PE8"/>
+        <pin position="59" name="PE9"/>
+        <pin position="60" name="PE10"/>
+        <pin position="61" name="PE11"/>
+        <pin position="62" name="PE12"/>
+        <pin position="63" name="PE13"/>
+        <pin position="64" name="PE14"/>
+        <pin position="65" name="PE15"/>
+        <pin position="66" name="PB10"/>
+        <pin position="67" name="PB11"/>
+        <pin position="68" name="VCAP" type="power"/>
+        <pin position="69" name="VSS" type="power"/>
+        <pin position="70" name="VDDLDO" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PB12"/>
+        <pin position="73" name="PB13"/>
+        <pin position="74" name="PB14"/>
+        <pin position="75" name="PB15"/>
+        <pin position="76" name="PD8"/>
+        <pin position="77" name="PD9"/>
+        <pin position="78" name="PD10"/>
+        <pin position="79" name="VDD" type="power"/>
+        <pin position="80" name="VSS" type="power"/>
+        <pin position="81" name="PD11"/>
+        <pin position="82" name="PD12"/>
+        <pin position="83" name="PD13"/>
+        <pin position="84" name="PD14"/>
+        <pin position="85" name="PD15"/>
+        <pin position="86" name="PG6"/>
+        <pin position="87" name="PG7"/>
+        <pin position="88" name="PG8"/>
+        <pin position="89" name="VSS" type="power"/>
+        <pin position="90" name="VDD50USB" type="power"/>
+        <pin position="91" name="VDD33USB" type="power"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="PC6"/>
+        <pin position="94" name="PC7"/>
+        <pin position="95" name="PC8"/>
+        <pin position="96" name="PC9"/>
+        <pin position="97" name="PA8"/>
+        <pin position="98" name="PA9"/>
+        <pin position="99" name="PA10"/>
+        <pin position="100" name="PA11"/>
+        <pin position="101" name="PA12"/>
+        <pin position="102" name="PA13(JTMS/SWDIO)"/>
+        <pin position="103" name="VCAP" type="power"/>
+        <pin position="104" name="VSS" type="power"/>
+        <pin position="105" name="VDDLDO" type="power"/>
+        <pin position="106" name="VDD" type="power"/>
+        <pin position="107" name="PA14(JTCK/SWCLK)"/>
+        <pin position="108" name="PA15(JTDI)"/>
+        <pin position="109" name="PC10"/>
+        <pin position="110" name="PC11"/>
+        <pin position="111" name="PC12"/>
+        <pin position="112" name="PD0"/>
+        <pin position="113" name="PD1"/>
+        <pin position="114" name="PD2"/>
+        <pin position="115" name="PD3"/>
+        <pin position="116" name="PD4"/>
+        <pin position="117" name="PD5"/>
+        <pin position="118" name="VSS" type="power"/>
+        <pin position="119" name="VDD" type="power"/>
+        <pin position="120" name="PD6"/>
+        <pin position="121" name="PD7"/>
+        <pin position="122" name="PG9"/>
+        <pin position="123" name="PG10"/>
+        <pin position="124" name="PG11"/>
+        <pin position="125" name="PG12"/>
+        <pin position="126" name="PG13"/>
+        <pin position="127" name="PG14"/>
+        <pin position="128" name="VSS" type="power"/>
+        <pin position="129" name="VDD" type="power"/>
+        <pin position="130" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="131" name="PB4(NJTRST)"/>
+        <pin position="132" name="PB5"/>
+        <pin position="133" name="PB6"/>
+        <pin position="134" name="PB7"/>
+        <pin position="135" name="BOOT0" type="boot"/>
+        <pin position="136" name="PB8"/>
+        <pin position="137" name="PB9"/>
+        <pin position="138" name="PE0"/>
+        <pin position="139" name="PE1"/>
+        <pin position="140" name="VCAP" type="power"/>
+        <pin position="141" name="VSS" type="power"/>
+        <pin position="142" name="PDR_ON" type="power"/>
+        <pin position="143" name="VDDLDO" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN"/>
+        <pin position="11" name="PC15-OSC32_OUT"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="PF0"/>
+        <pin position="19" name="PF1"/>
+        <pin position="20" name="PF2"/>
+        <pin position="21" name="PF3"/>
+        <pin position="22" name="PF4"/>
+        <pin position="23" name="PF5"/>
+        <pin position="24" name="VSS" type="power"/>
+        <pin position="25" name="VDD" type="power"/>
+        <pin position="26" name="PF6"/>
+        <pin position="27" name="PF7"/>
+        <pin position="28" name="PF8"/>
+        <pin position="29" name="PF9"/>
+        <pin position="30" name="PF10"/>
+        <pin position="31" name="PH0-OSC_IN"/>
+        <pin position="32" name="PH1-OSC_OUT"/>
+        <pin position="33" name="NRST" type="reset"/>
+        <pin position="34" name="PC0"/>
+        <pin position="35" name="PC1"/>
+        <pin position="36" name="PC2_C"/>
+        <pin position="37" name="PC3_C"/>
+        <pin position="38" name="VSSA" type="power"/>
+        <pin position="39" name="VREF+" type="monoio"/>
+        <pin position="40" name="VDDA" type="power"/>
+        <pin position="41" name="PA0"/>
+        <pin position="42" name="PA1"/>
+        <pin position="43" name="PA2"/>
+        <pin position="44" name="VDD" type="power"/>
+        <pin position="45" name="VSS" type="power"/>
+        <pin position="46" name="PA3"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA4"/>
+        <pin position="50" name="PA5"/>
+        <pin position="51" name="PA6"/>
+        <pin position="52" name="PA7"/>
+        <pin position="53" name="PC4"/>
+        <pin position="54" name="PC5"/>
+        <pin position="55" name="PB0"/>
+        <pin position="56" name="PB1"/>
+        <pin position="57" name="PB2"/>
+        <pin position="58" name="PF11"/>
+        <pin position="59" name="PF12"/>
+        <pin position="60" name="PF13"/>
+        <pin position="61" name="PF14"/>
+        <pin position="62" name="PF15"/>
+        <pin position="63" name="PG0"/>
+        <pin position="64" name="VSS" type="power"/>
+        <pin position="65" name="VDD" type="power"/>
+        <pin position="66" name="PG1"/>
+        <pin position="67" name="PE7"/>
+        <pin position="68" name="PE8"/>
+        <pin position="69" name="PE9"/>
+        <pin position="70" name="VSS" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PE10"/>
+        <pin position="73" name="PE11"/>
+        <pin position="74" name="PE12"/>
+        <pin position="75" name="PE13"/>
+        <pin position="76" name="PE14"/>
+        <pin position="77" name="PE15"/>
+        <pin position="78" name="PB10"/>
+        <pin position="79" name="PB11"/>
+        <pin position="80" name="VCAP" type="power"/>
+        <pin position="81" name="VSS" type="power"/>
+        <pin position="82" name="VDDLDO" type="power"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PB12"/>
+        <pin position="86" name="PB13"/>
+        <pin position="87" name="PB14"/>
+        <pin position="88" name="PB15"/>
+        <pin position="89" name="PD8"/>
+        <pin position="90" name="PD9"/>
+        <pin position="91" name="PD10"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="PD11"/>
+        <pin position="95" name="PD12"/>
+        <pin position="96" name="PD13"/>
+        <pin position="97" name="PD14"/>
+        <pin position="98" name="PD15"/>
+        <pin position="99" name="VDD" type="power"/>
+        <pin position="100" name="VSS" type="power"/>
+        <pin position="101" name="PJ8"/>
+        <pin position="102" name="PJ9"/>
+        <pin position="103" name="PJ10"/>
+        <pin position="104" name="PJ11"/>
+        <pin position="105" name="VDD" type="power"/>
+        <pin position="106" name="VSS" type="power"/>
+        <pin position="107" name="PK0"/>
+        <pin position="108" name="PK1"/>
+        <pin position="109" name="PK2"/>
+        <pin position="110" name="PG2"/>
+        <pin position="111" name="PG3"/>
+        <pin position="112" name="VSS" type="power"/>
+        <pin position="113" name="VDD" type="power"/>
+        <pin position="114" name="PG4"/>
+        <pin position="115" name="PG5"/>
+        <pin position="116" name="PG6"/>
+        <pin position="117" name="PG7"/>
+        <pin position="118" name="PG8"/>
+        <pin position="119" name="VSS" type="power"/>
+        <pin position="120" name="VDD50USB" type="power"/>
+        <pin position="121" name="VDD33USB" type="power"/>
+        <pin position="122" name="PC6"/>
+        <pin position="123" name="PC7"/>
+        <pin position="124" name="PC8"/>
+        <pin position="125" name="PC9"/>
+        <pin position="126" name="VDD" type="power"/>
+        <pin position="127" name="PA8"/>
+        <pin position="128" name="PA9"/>
+        <pin position="129" name="PA10"/>
+        <pin position="130" name="PA11"/>
+        <pin position="131" name="PA12"/>
+        <pin position="132" name="PA13(JTMS/SWDIO)"/>
+        <pin position="133" name="VCAP" type="power"/>
+        <pin position="134" name="VSS" type="power"/>
+        <pin position="135" name="VDDLDO" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="VSS" type="power"/>
+        <pin position="138" name="PA14(JTCK/SWCLK)"/>
+        <pin position="139" name="PA15(JTDI)"/>
+        <pin position="140" name="PC10"/>
+        <pin position="141" name="PC11"/>
+        <pin position="142" name="PC12"/>
+        <pin position="143" name="PD0"/>
+        <pin position="144" name="PD1"/>
+        <pin position="145" name="PD2"/>
+        <pin position="146" name="PD3"/>
+        <pin position="147" name="PD4"/>
+        <pin position="148" name="PD5"/>
+        <pin position="149" name="PD6"/>
+        <pin position="150" name="PD7"/>
+        <pin position="151" name="VSS" type="power"/>
+        <pin position="152" name="VDD" type="power"/>
+        <pin position="153" name="PG9"/>
+        <pin position="154" name="PG10"/>
+        <pin position="155" name="PG11"/>
+        <pin position="156" name="PG12"/>
+        <pin position="157" name="PG13"/>
+        <pin position="158" name="PG14"/>
+        <pin position="159" name="VSS" type="power"/>
+        <pin position="160" name="VDD" type="power"/>
+        <pin position="161" name="PG15"/>
+        <pin position="162" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="163" name="PB4(NJTRST)"/>
+        <pin position="164" name="PB5"/>
+        <pin position="165" name="PB6"/>
+        <pin position="166" name="PB7"/>
+        <pin position="167" name="BOOT0" type="boot"/>
+        <pin position="168" name="PB8"/>
+        <pin position="169" name="PB9"/>
+        <pin position="170" name="PE0"/>
+        <pin position="171" name="PE1"/>
+        <pin position="172" name="VCAP" type="power"/>
+        <pin position="173" name="VSS" type="power"/>
+        <pin position="174" name="PDR_ON" type="power"/>
+        <pin position="175" name="VDDLDO" type="power"/>
+        <pin position="176" name="VDD" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4(NJTRST)"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14(JTCK/SWCLK)"/>
+        <pin position="B13" name="PH13"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="power"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15(JTDI)"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13(JTMS/SWDIO)"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VSSSMPS" type="power"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50USB" type="power"/>
+        <pin position="G13" name="VDD33USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN"/>
+        <pin position="H2" name="PH1-OSC_OUT"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PC2"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PA0_C"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PA1_C"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PB8"/>
+        <pin position="A3" name="VDDLDO" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A7" name="PG11"/>
+        <pin position="A8" name="PG9"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PA15(JTDI)"/>
+        <pin position="A12" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A13" name="VDDLDO" type="power"/>
+        <pin position="A14" name="VCAP" type="power"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB4(NJTRST)"/>
+        <pin position="B7" name="PG13"/>
+        <pin position="B8" name="PD7"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PD2"/>
+        <pin position="B11" name="PC12"/>
+        <pin position="B12" name="PH14"/>
+        <pin position="B13" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B14" name="PA8"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD0"/>
+        <pin position="C11" name="PC11"/>
+        <pin position="C12" name="PC10"/>
+        <pin position="C13" name="PH13"/>
+        <pin position="C14" name="PA10"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="PC14-OSC32_IN"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PDR_ON" type="power"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PG15"/>
+        <pin position="D8" name="PG12"/>
+        <pin position="D9" name="PD6"/>
+        <pin position="D10" name="VSS" type="power"/>
+        <pin position="D11" name="VDD" type="power"/>
+        <pin position="D12" name="PH15"/>
+        <pin position="D13" name="PA9"/>
+        <pin position="D14" name="PC8"/>
+        <pin position="D15" name="PC7"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E12" name="VDD" type="power"/>
+        <pin position="E13" name="PC9"/>
+        <pin position="E14" name="PC6"/>
+        <pin position="E15" name="VDD50USB" type="power"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PF1"/>
+        <pin position="F4" name="PF0"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VDD33USB" type="power"/>
+        <pin position="F14" name="PG6"/>
+        <pin position="F15" name="PG5"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="PG8"/>
+        <pin position="G13" name="PG7"/>
+        <pin position="G14" name="PG4"/>
+        <pin position="G15" name="PG2"/>
+        <pin position="H1" name="PF6"/>
+        <pin position="H2" name="PF4"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VDD" type="power"/>
+        <pin position="H13" name="PG3"/>
+        <pin position="H14" name="PD14"/>
+        <pin position="H15" name="PD13"/>
+        <pin position="J1" name="PH0-OSC_IN"/>
+        <pin position="J2" name="PF8"/>
+        <pin position="J3" name="PF7"/>
+        <pin position="J4" name="PF9"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD11"/>
+        <pin position="J14" name="VSS" type="power"/>
+        <pin position="J15" name="PD12"/>
+        <pin position="K1" name="PH1-OSC_OUT"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PF10"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="VSS" type="power"/>
+        <pin position="K13" name="PD9"/>
+        <pin position="K14" name="PB15"/>
+        <pin position="K15" name="PB14"/>
+        <pin position="L1" name="NRST" type="reset"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PC1"/>
+        <pin position="L4" name="VREF-" type="power"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD8"/>
+        <pin position="L15" name="PB13"/>
+        <pin position="M1" name="PC2"/>
+        <pin position="M2" name="PC3"/>
+        <pin position="M3" name="VREF+" type="monoio"/>
+        <pin position="M4" name="VDDA" type="power"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M6" name="VSS" type="power"/>
+        <pin position="M7" name="PC5"/>
+        <pin position="M8" name="PB1"/>
+        <pin position="M9" name="VDD" type="power"/>
+        <pin position="M10" name="VSS" type="power"/>
+        <pin position="M11" name="PH7"/>
+        <pin position="M12" name="PE14"/>
+        <pin position="M13" name="PH11"/>
+        <pin position="M14" name="PH9"/>
+        <pin position="M15" name="PB12"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="VSSA" type="power"/>
+        <pin position="N4" name="PH2"/>
+        <pin position="N5" name="PA3"/>
+        <pin position="N6" name="PA7"/>
+        <pin position="N7" name="PF11"/>
+        <pin position="N8" name="PE8"/>
+        <pin position="N9" name="PG1"/>
+        <pin position="N10" name="PF15"/>
+        <pin position="N11" name="PF13"/>
+        <pin position="N12" name="PB10"/>
+        <pin position="N13" name="PH8"/>
+        <pin position="N14" name="PH10"/>
+        <pin position="N15" name="PH12"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA1_C"/>
+        <pin position="P4" name="PH4"/>
+        <pin position="P5" name="PA4"/>
+        <pin position="P6" name="PA5"/>
+        <pin position="P7" name="PB2"/>
+        <pin position="P8" name="PG0"/>
+        <pin position="P9" name="PE7"/>
+        <pin position="P10" name="PB11"/>
+        <pin position="P11" name="PF12"/>
+        <pin position="P12" name="PE12"/>
+        <pin position="P13" name="PE13"/>
+        <pin position="P14" name="PE15"/>
+        <pin position="P15" name="PH6"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA0_C"/>
+        <pin position="R4" name="PH3"/>
+        <pin position="R5" name="PH5"/>
+        <pin position="R6" name="PC4"/>
+        <pin position="R7" name="PA6"/>
+        <pin position="R8" name="PB0"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PF14"/>
+        <pin position="R11" name="PE9"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="VCAP" type="power"/>
+        <pin position="R14" name="VDDLDO" type="power"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
+      <package device-pin="r" name="VFQFPN68">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="VSSSMPS" type="power"/>
+        <pin position="5" name="VLXSMPS" type="power"/>
+        <pin position="6" name="VDDSMPS" type="power"/>
+        <pin position="7" name="VFBSMPS" type="power"/>
+        <pin position="8" name="VSS" type="power"/>
+        <pin position="9" name="VDD" type="power"/>
+        <pin position="10" name="PH0-OSC_IN"/>
+        <pin position="11" name="PH1-OSC_OUT"/>
+        <pin position="12" name="NRST" type="reset"/>
+        <pin position="13" name="PC0"/>
+        <pin position="14" name="PC1"/>
+        <pin position="15" name="VSSA" type="power"/>
+        <pin position="16" name="VDDA" type="power"/>
+        <pin position="17" name="PA0"/>
+        <pin position="18" name="PA1"/>
+        <pin position="19" name="PA2"/>
+        <pin position="20" name="PA3"/>
+        <pin position="21" name="VSS" type="power"/>
+        <pin position="22" name="VDD" type="power"/>
+        <pin position="23" name="PA4"/>
+        <pin position="24" name="PA5"/>
+        <pin position="25" name="PA6"/>
+        <pin position="26" name="PA7"/>
+        <pin position="27" name="PC4"/>
+        <pin position="28" name="PC5"/>
+        <pin position="29" name="PB0"/>
+        <pin position="30" name="PB1"/>
+        <pin position="31" name="PB2"/>
+        <pin position="32" name="PB10"/>
+        <pin position="33" name="VCAP" type="power"/>
+        <pin position="34" name="VSS" type="power"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PB12"/>
+        <pin position="37" name="PB13"/>
+        <pin position="38" name="PB14"/>
+        <pin position="39" name="PB15"/>
+        <pin position="40" name="PC6"/>
+        <pin position="41" name="PC7"/>
+        <pin position="42" name="PC9"/>
+        <pin position="43" name="PA8"/>
+        <pin position="44" name="PA9"/>
+        <pin position="45" name="PA10"/>
+        <pin position="46" name="PA11"/>
+        <pin position="47" name="PA12"/>
+        <pin position="48" name="PA13(JTMS/SWDIO)"/>
+        <pin position="49" name="VCAP" type="power"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="VDD" type="power"/>
+        <pin position="52" name="PA14(JTCK/SWCLK)"/>
+        <pin position="53" name="PA15(JTDI)"/>
+        <pin position="54" name="PC10"/>
+        <pin position="55" name="PC11"/>
+        <pin position="56" name="PC12"/>
+        <pin position="57" name="PD2"/>
+        <pin position="58" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="59" name="PB4(NJTRST)"/>
+        <pin position="60" name="PB5"/>
+        <pin position="61" name="PB6"/>
+        <pin position="62" name="PB7"/>
+        <pin position="63" name="BOOT0" type="boot"/>
+        <pin position="64" name="PB8"/>
+        <pin position="65" name="PB9"/>
+        <pin position="66" name="VCAP" type="power"/>
+        <pin position="67" name="VSS" type="power"/>
+        <pin position="68" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP115">
+        <pin position="A2" name="VDD" type="power"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A10" name="VSS" type="power"/>
+        <pin position="AA2" name="VSS" type="power"/>
+        <pin position="AA4" name="VDD" type="power"/>
+        <pin position="AA6" name="PB2"/>
+        <pin position="AA8" name="PC5"/>
+        <pin position="AA10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B3" name="VDD" type="power"/>
+        <pin position="B5" name="PD3"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B9" name="VCAP" type="power"/>
+        <pin position="B11" name="PE2"/>
+        <pin position="C2" name="VDDLDO" type="power"/>
+        <pin position="C4" name="VSS" type="power"/>
+        <pin position="C6" name="VSS" type="power"/>
+        <pin position="C8" name="BOOT0" type="boot"/>
+        <pin position="C10" name="VDD" type="power"/>
+        <pin position="D1" name="VCAP" type="power"/>
+        <pin position="D3" name="PA14(JTCK/SWCLK)"/>
+        <pin position="D5" name="PD1"/>
+        <pin position="D7" name="PB5"/>
+        <pin position="D9" name="VDDLDO" type="power"/>
+        <pin position="D11" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PA11"/>
+        <pin position="E4" name="PC10"/>
+        <pin position="E6" name="PD5"/>
+        <pin position="E8" name="PB8"/>
+        <pin position="E10" name="PC15-OSC32_OUT"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin position="F3" name="PA12"/>
+        <pin position="F5" name="PC12"/>
+        <pin position="F7" name="PB4(NJTRST)"/>
+        <pin position="F9" name="PE4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G4" name="PA13(JTMS/SWDIO)"/>
+        <pin position="G6" name="PD4"/>
+        <pin position="G8" name="PB9"/>
+        <pin position="G10" name="VDD" type="power"/>
+        <pin position="H1" name="PC6"/>
+        <pin position="H3" name="PA8"/>
+        <pin position="H5" name="PA15(JTDI)"/>
+        <pin position="H7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="H9" name="PC13"/>
+        <pin position="H11" name="VSSSMPS" type="power"/>
+        <pin position="J2" name="VDD33USB" type="power"/>
+        <pin position="J4" name="PA9"/>
+        <pin position="J6" name="PD0"/>
+        <pin position="J8" name="PE0"/>
+        <pin position="J10" name="VLXSMPS" type="power"/>
+        <pin position="K1" name="VDD50USB" type="power"/>
+        <pin position="K3" name="PC7"/>
+        <pin position="K5" name="PA10"/>
+        <pin position="K7" name="PB6"/>
+        <pin position="K9" name="VBAT" type="power"/>
+        <pin position="K11" name="VDDSMPS" type="power"/>
+        <pin position="L2" name="PD14"/>
+        <pin position="L4" name="PC8"/>
+        <pin position="L6" name="PC11"/>
+        <pin position="L8" name="PDR_ON" type="power"/>
+        <pin position="L10" name="VFBSMPS" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M3" name="PD13"/>
+        <pin position="M5" name="PC9"/>
+        <pin position="M7" name="PB7"/>
+        <pin position="M9" name="PC0"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="N2" name="PD15"/>
+        <pin position="N4" name="PD9"/>
+        <pin position="N6" name="PE7"/>
+        <pin position="N8" name="PA0"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="P1" name="VSS" type="power"/>
+        <pin position="P3" name="PD10"/>
+        <pin position="P5" name="PB13"/>
+        <pin position="P7" name="PA3"/>
+        <pin position="P9" name="PC1"/>
+        <pin position="P11" name="PH0-OSC_IN"/>
+        <pin position="R2" name="PD11"/>
+        <pin position="R4" name="PB14"/>
+        <pin position="R6" name="PA7"/>
+        <pin position="R8" name="PA1"/>
+        <pin position="R10" name="NRST" type="reset"/>
+        <pin position="T1" name="PD12"/>
+        <pin position="T3" name="PD8"/>
+        <pin position="T5" name="PB10"/>
+        <pin position="T7" name="PA6"/>
+        <pin position="T9" name="VSSA" type="power"/>
+        <pin position="T11" name="PH1-OSC_OUT"/>
+        <pin position="U2" name="VSS" type="power"/>
+        <pin position="U4" name="PB12"/>
+        <pin position="U6" name="PB0"/>
+        <pin position="U8" name="PA5"/>
+        <pin position="U10" name="VSS" type="power"/>
+        <pin position="V1" name="VDD" type="power"/>
+        <pin position="V3" name="PB15"/>
+        <pin position="V5" name="PE8"/>
+        <pin position="V7" name="VSS" type="power"/>
+        <pin position="V9" name="PA2"/>
+        <pin position="V11" name="VDD" type="power"/>
+        <pin position="W2" name="VDDLDO" type="power"/>
+        <pin position="W4" name="PB11"/>
+        <pin position="W6" name="PB1"/>
+        <pin position="W8" name="PC4"/>
+        <pin position="W10" name="VREF+" type="monoio"/>
+        <pin position="Y1" name="VDD" type="power"/>
+        <pin position="Y3" name="VCAP" type="power"/>
+        <pin position="Y5" name="VSS" type="power"/>
+        <pin position="Y7" name="VDD" type="power"/>
+        <pin position="Y9" name="PA4"/>
+        <pin position="Y11" name="VDDA" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-30.xml
+++ b/devices/stm32/stm32h7-30.xml
@@ -2305,6 +2305,1054 @@
         <signal af="11" driver="tim" instance="1" name="bkin_comp2"/>
         <signal af="14" driver="ltdc" name="g7"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13(JTMS/SWDIO)"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14(JTCK/SWCLK)"/>
+        <pin position="77" name="PA15(JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4(NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13(JTMS/SWDIO)"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14(JTCK/SWCLK)"/>
+        <pin position="110" name="PA15(JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4(NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN"/>
+        <pin position="11" name="PC15-OSC32_OUT"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="PF0"/>
+        <pin position="19" name="PF1"/>
+        <pin position="20" name="PF2"/>
+        <pin position="21" name="PF3"/>
+        <pin position="22" name="PF4"/>
+        <pin position="23" name="PF5"/>
+        <pin position="24" name="VSS" type="power"/>
+        <pin position="25" name="VDD" type="power"/>
+        <pin position="26" name="PF6"/>
+        <pin position="27" name="PF7"/>
+        <pin position="28" name="PF8"/>
+        <pin position="29" name="PF9"/>
+        <pin position="30" name="PF10"/>
+        <pin position="31" name="PH0-OSC_IN"/>
+        <pin position="32" name="PH1-OSC_OUT"/>
+        <pin position="33" name="NRST" type="reset"/>
+        <pin position="34" name="PC0"/>
+        <pin position="35" name="PC1"/>
+        <pin position="36" name="PC2_C"/>
+        <pin position="37" name="PC3_C"/>
+        <pin position="38" name="VSSA" type="power"/>
+        <pin position="39" name="VREF+" type="monoio"/>
+        <pin position="40" name="VDDA" type="power"/>
+        <pin position="41" name="PA0"/>
+        <pin position="42" name="PA1"/>
+        <pin position="43" name="PA2"/>
+        <pin position="44" name="VDD" type="power"/>
+        <pin position="45" name="VSS" type="power"/>
+        <pin position="46" name="PA3"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA4"/>
+        <pin position="50" name="PA5"/>
+        <pin position="51" name="PA6"/>
+        <pin position="52" name="PA7"/>
+        <pin position="53" name="PC4"/>
+        <pin position="54" name="PC5"/>
+        <pin position="55" name="PB0"/>
+        <pin position="56" name="PB1"/>
+        <pin position="57" name="PB2"/>
+        <pin position="58" name="PF11"/>
+        <pin position="59" name="PF12"/>
+        <pin position="60" name="PF13"/>
+        <pin position="61" name="PF14"/>
+        <pin position="62" name="PF15"/>
+        <pin position="63" name="PG0"/>
+        <pin position="64" name="VSS" type="power"/>
+        <pin position="65" name="VDD" type="power"/>
+        <pin position="66" name="PG1"/>
+        <pin position="67" name="PE7"/>
+        <pin position="68" name="PE8"/>
+        <pin position="69" name="PE9"/>
+        <pin position="70" name="VSS" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PE10"/>
+        <pin position="73" name="PE11"/>
+        <pin position="74" name="PE12"/>
+        <pin position="75" name="PE13"/>
+        <pin position="76" name="PE14"/>
+        <pin position="77" name="PE15"/>
+        <pin position="78" name="PB10"/>
+        <pin position="79" name="PB11"/>
+        <pin position="80" name="VCAP" type="power"/>
+        <pin position="81" name="VSS" type="power"/>
+        <pin position="82" name="VDDLDO" type="power"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PB12"/>
+        <pin position="86" name="PB13"/>
+        <pin position="87" name="PB14"/>
+        <pin position="88" name="PB15"/>
+        <pin position="89" name="PD8"/>
+        <pin position="90" name="PD9"/>
+        <pin position="91" name="PD10"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="PD11"/>
+        <pin position="95" name="PD12"/>
+        <pin position="96" name="PD13"/>
+        <pin position="97" name="PD14"/>
+        <pin position="98" name="PD15"/>
+        <pin position="99" name="VDD" type="power"/>
+        <pin position="100" name="VSS" type="power"/>
+        <pin position="101" name="PJ8"/>
+        <pin position="102" name="PJ9"/>
+        <pin position="103" name="PJ10"/>
+        <pin position="104" name="PJ11"/>
+        <pin position="105" name="VDD" type="power"/>
+        <pin position="106" name="VSS" type="power"/>
+        <pin position="107" name="PK0"/>
+        <pin position="108" name="PK1"/>
+        <pin position="109" name="PK2"/>
+        <pin position="110" name="PG2"/>
+        <pin position="111" name="PG3"/>
+        <pin position="112" name="VSS" type="power"/>
+        <pin position="113" name="VDD" type="power"/>
+        <pin position="114" name="PG4"/>
+        <pin position="115" name="PG5"/>
+        <pin position="116" name="PG6"/>
+        <pin position="117" name="PG7"/>
+        <pin position="118" name="PG8"/>
+        <pin position="119" name="VSS" type="power"/>
+        <pin position="120" name="VDD50USB" type="power"/>
+        <pin position="121" name="VDD33USB" type="power"/>
+        <pin position="122" name="PC6"/>
+        <pin position="123" name="PC7"/>
+        <pin position="124" name="PC8"/>
+        <pin position="125" name="PC9"/>
+        <pin position="126" name="VDD" type="power"/>
+        <pin position="127" name="PA8"/>
+        <pin position="128" name="PA9"/>
+        <pin position="129" name="PA10"/>
+        <pin position="130" name="PA11"/>
+        <pin position="131" name="PA12"/>
+        <pin position="132" name="PA13(JTMS/SWDIO)"/>
+        <pin position="133" name="VCAP" type="power"/>
+        <pin position="134" name="VSS" type="power"/>
+        <pin position="135" name="VDDLDO" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="VSS" type="power"/>
+        <pin position="138" name="PA14(JTCK/SWCLK)"/>
+        <pin position="139" name="PA15(JTDI)"/>
+        <pin position="140" name="PC10"/>
+        <pin position="141" name="PC11"/>
+        <pin position="142" name="PC12"/>
+        <pin position="143" name="PD0"/>
+        <pin position="144" name="PD1"/>
+        <pin position="145" name="PD2"/>
+        <pin position="146" name="PD3"/>
+        <pin position="147" name="PD4"/>
+        <pin position="148" name="PD5"/>
+        <pin position="149" name="PD6"/>
+        <pin position="150" name="PD7"/>
+        <pin position="151" name="VSS" type="power"/>
+        <pin position="152" name="VDD" type="power"/>
+        <pin position="153" name="PG9"/>
+        <pin position="154" name="PG10"/>
+        <pin position="155" name="PG11"/>
+        <pin position="156" name="PG12"/>
+        <pin position="157" name="PG13"/>
+        <pin position="158" name="PG14"/>
+        <pin position="159" name="VSS" type="power"/>
+        <pin position="160" name="VDD" type="power"/>
+        <pin position="161" name="PG15"/>
+        <pin position="162" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="163" name="PB4(NJTRST)"/>
+        <pin position="164" name="PB5"/>
+        <pin position="165" name="PB6"/>
+        <pin position="166" name="PB7"/>
+        <pin position="167" name="BOOT0" type="boot"/>
+        <pin position="168" name="PB8"/>
+        <pin position="169" name="PB9"/>
+        <pin position="170" name="PE0"/>
+        <pin position="171" name="PE1"/>
+        <pin position="172" name="VCAP" type="power"/>
+        <pin position="173" name="VSS" type="power"/>
+        <pin position="174" name="PDR_ON" type="power"/>
+        <pin position="175" name="VDDLDO" type="power"/>
+        <pin position="176" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4(NJTRST)"/>
+        <pin position="A7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A8" name="PA15(JTDI)"/>
+        <pin position="A9" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A10" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2_C"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VCAP" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3_C"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD33USB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="power"/>
+        <pin position="F8" name="VCAP" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="z" device-package="i" name="UFBGA144">
+        <pin position="A1" name="PC13"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PE1"/>
+        <pin position="A5" name="PE0"/>
+        <pin position="A6" name="PB4(NJTRST)"/>
+        <pin position="A7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A8" name="PD6"/>
+        <pin position="A9" name="PD7"/>
+        <pin position="A10" name="PA15(JTDI)"/>
+        <pin position="A11" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A12" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B1" name="PC14-OSC32_IN"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE5"/>
+        <pin position="B4" name="PE6"/>
+        <pin position="B5" name="PB9"/>
+        <pin position="B6" name="PB5"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PC11"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA12"/>
+        <pin position="C1" name="PC15-OSC32_OUT"/>
+        <pin position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PF0"/>
+        <pin position="C4" name="PF1"/>
+        <pin position="C5" name="PB8"/>
+        <pin position="C6" name="PB6"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG11"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PC12"/>
+        <pin position="C11" name="VDD33USB" type="power"/>
+        <pin position="C12" name="PA11"/>
+        <pin position="D1" name="PH0-OSC_IN"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="VDD" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD1"/>
+        <pin position="D11" name="PA10"/>
+        <pin position="D12" name="PA9"/>
+        <pin position="E1" name="PH1-OSC_OUT"/>
+        <pin position="E2" name="PF3"/>
+        <pin position="E3" name="PF4"/>
+        <pin position="E4" name="PF5"/>
+        <pin position="E5" name="PDR_ON" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E8" name="PG9"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PD0"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="F1" name="NRST" type="reset"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF6"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VDD" type="power"/>
+        <pin position="F11" name="PC8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PF10"/>
+        <pin position="G2" name="PF9"/>
+        <pin position="G3" name="PF8"/>
+        <pin position="G4" name="VSS" type="power"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VCAP" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="PC6"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="PC1"/>
+        <pin position="H3" name="PC2"/>
+        <pin position="H4" name="PC3"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VCAP" type="power"/>
+        <pin position="H8" name="PE11"/>
+        <pin position="H9" name="PD11"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PG6"/>
+        <pin position="H12" name="PG5"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PA0"/>
+        <pin position="J3" name="PA4"/>
+        <pin position="J4" name="PC4"/>
+        <pin position="J5" name="PB2"/>
+        <pin position="J6" name="PG1"/>
+        <pin position="J7" name="PE10"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD10"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PA1"/>
+        <pin position="K3" name="PA5"/>
+        <pin position="K4" name="PC5"/>
+        <pin position="K5" name="PF13"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PD9"/>
+        <pin position="K10" name="PD13"/>
+        <pin position="K11" name="PD14"/>
+        <pin position="K12" name="PD15"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA6"/>
+        <pin position="L4" name="PB0"/>
+        <pin position="L5" name="PF12"/>
+        <pin position="L6" name="PF15"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE14"/>
+        <pin position="L9" name="PD8"/>
+        <pin position="L10" name="PD12"/>
+        <pin position="L11" name="PB14"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA7"/>
+        <pin position="M4" name="PB1"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF14"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE15"/>
+        <pin position="M9" name="PB10"/>
+        <pin position="M10" name="PB11"/>
+        <pin position="M11" name="PB12"/>
+        <pin position="M12" name="PB13"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4(NJTRST)"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14(JTCK/SWCLK)"/>
+        <pin position="B13" name="PH13"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="power"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15(JTDI)"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13(JTMS/SWDIO)"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VSSSMPS" type="power"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50USB" type="power"/>
+        <pin position="G13" name="VDD33USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN"/>
+        <pin position="H2" name="PH1-OSC_OUT"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PC2"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PA0_C"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PA1_C"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PB8"/>
+        <pin position="A3" name="VDDLDO" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3(JTDO/TRACESWO)"/>
+        <pin position="A7" name="PG11"/>
+        <pin position="A8" name="PG9"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PA15(JTDI)"/>
+        <pin position="A12" name="PA14(JTCK/SWCLK)"/>
+        <pin position="A13" name="VDDLDO" type="power"/>
+        <pin position="A14" name="VCAP" type="power"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB4(NJTRST)"/>
+        <pin position="B7" name="PG13"/>
+        <pin position="B8" name="PD7"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PD2"/>
+        <pin position="B11" name="PC12"/>
+        <pin position="B12" name="PH14"/>
+        <pin position="B13" name="PA13(JTMS/SWDIO)"/>
+        <pin position="B14" name="PA8"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD0"/>
+        <pin position="C11" name="PC11"/>
+        <pin position="C12" name="PC10"/>
+        <pin position="C13" name="PH13"/>
+        <pin position="C14" name="PA10"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="PC14-OSC32_IN"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PDR_ON" type="power"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PG15"/>
+        <pin position="D8" name="PG12"/>
+        <pin position="D9" name="PD6"/>
+        <pin position="D10" name="VSS" type="power"/>
+        <pin position="D11" name="VDD" type="power"/>
+        <pin position="D12" name="PH15"/>
+        <pin position="D13" name="PA9"/>
+        <pin position="D14" name="PC8"/>
+        <pin position="D15" name="PC7"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E12" name="VDD" type="power"/>
+        <pin position="E13" name="PC9"/>
+        <pin position="E14" name="PC6"/>
+        <pin position="E15" name="VDD50USB" type="power"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PF1"/>
+        <pin position="F4" name="PF0"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VDD33USB" type="power"/>
+        <pin position="F14" name="PG6"/>
+        <pin position="F15" name="PG5"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="PG8"/>
+        <pin position="G13" name="PG7"/>
+        <pin position="G14" name="PG4"/>
+        <pin position="G15" name="PG2"/>
+        <pin position="H1" name="PF6"/>
+        <pin position="H2" name="PF4"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VDD" type="power"/>
+        <pin position="H13" name="PG3"/>
+        <pin position="H14" name="PD14"/>
+        <pin position="H15" name="PD13"/>
+        <pin position="J1" name="PH0-OSC_IN"/>
+        <pin position="J2" name="PF8"/>
+        <pin position="J3" name="PF7"/>
+        <pin position="J4" name="PF9"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD11"/>
+        <pin position="J14" name="VSS" type="power"/>
+        <pin position="J15" name="PD12"/>
+        <pin position="K1" name="PH1-OSC_OUT"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PF10"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="VSS" type="power"/>
+        <pin position="K13" name="PD9"/>
+        <pin position="K14" name="PB15"/>
+        <pin position="K15" name="PB14"/>
+        <pin position="L1" name="NRST" type="reset"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PC1"/>
+        <pin position="L4" name="VREF-" type="power"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD8"/>
+        <pin position="L15" name="PB13"/>
+        <pin position="M1" name="PC2"/>
+        <pin position="M2" name="PC3"/>
+        <pin position="M3" name="VREF+" type="monoio"/>
+        <pin position="M4" name="VDDA" type="power"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M6" name="VSS" type="power"/>
+        <pin position="M7" name="PC5"/>
+        <pin position="M8" name="PB1"/>
+        <pin position="M9" name="VDD" type="power"/>
+        <pin position="M10" name="VSS" type="power"/>
+        <pin position="M11" name="PH7"/>
+        <pin position="M12" name="PE14"/>
+        <pin position="M13" name="PH11"/>
+        <pin position="M14" name="PH9"/>
+        <pin position="M15" name="PB12"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="VSSA" type="power"/>
+        <pin position="N4" name="PH2"/>
+        <pin position="N5" name="PA3"/>
+        <pin position="N6" name="PA7"/>
+        <pin position="N7" name="PF11"/>
+        <pin position="N8" name="PE8"/>
+        <pin position="N9" name="PG1"/>
+        <pin position="N10" name="PF15"/>
+        <pin position="N11" name="PF13"/>
+        <pin position="N12" name="PB10"/>
+        <pin position="N13" name="PH8"/>
+        <pin position="N14" name="PH10"/>
+        <pin position="N15" name="PH12"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA1_C"/>
+        <pin position="P4" name="PH4"/>
+        <pin position="P5" name="PA4"/>
+        <pin position="P6" name="PA5"/>
+        <pin position="P7" name="PB2"/>
+        <pin position="P8" name="PG0"/>
+        <pin position="P9" name="PE7"/>
+        <pin position="P10" name="PB11"/>
+        <pin position="P11" name="PF12"/>
+        <pin position="P12" name="PE12"/>
+        <pin position="P13" name="PE13"/>
+        <pin position="P14" name="PE15"/>
+        <pin position="P15" name="PH6"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA0_C"/>
+        <pin position="R4" name="PH3"/>
+        <pin position="R5" name="PH5"/>
+        <pin position="R6" name="PC4"/>
+        <pin position="R7" name="PA6"/>
+        <pin position="R8" name="PB0"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PF14"/>
+        <pin position="R11" name="PE9"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="VCAP" type="power"/>
+        <pin position="R14" name="VDDLDO" type="power"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-42.xml
+++ b/devices/stm32/stm32h7-42.xml
@@ -2022,6 +2022,1384 @@
       <gpio device-pin="b|x" port="k" pin="5"/>
       <gpio device-pin="b|x" port="k" pin="6"/>
       <gpio device-pin="b|x" port="k" pin="7"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33_USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="10" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN (PH0)"/>
+        <pin position="30" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2_C"/>
+        <pin position="35" name="PC3_C"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="monoio"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD33_USB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="125" name="VCAP" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="138" name="PA15 (JTDI)"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="162" name="PB4 (NJTRST)"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="10" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0-OSC_IN (PH0)"/>
+        <pin position="33" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2_C"/>
+        <pin position="38" name="PC3_C"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="monoio"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin position="118" name="PJ6"/>
+        <pin position="119" name="PJ7"/>
+        <pin position="120" name="PJ8"/>
+        <pin position="121" name="PJ9"/>
+        <pin position="122" name="PJ10"/>
+        <pin position="123" name="PJ11"/>
+        <pin position="124" name="VDD" type="power"/>
+        <pin position="125" name="VSS" type="power"/>
+        <pin position="126" name="PK0"/>
+        <pin position="127" name="PK1"/>
+        <pin position="128" name="PK2"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDD33_USB" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="148" name="VCAP" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="160" name="PA15 (JTDI)"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDD" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="193" name="PB4 (NJTRST)"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4 (NJTRST)"/>
+        <pin position="A7" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A8" name="PA15 (JTDI)"/>
+        <pin position="A9" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A10" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2_C"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VCAP" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3_C"/>
+        <pin position="F4" name="VDDLDO" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD33_USB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="reset"/>
+        <pin position="F8" name="VCAP" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="x" name="TFBGA240">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PI4"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="VDDLDO" type="power"/>
+        <pin position="A7" name="VCAP" type="power"/>
+        <pin position="A8" name="PK5"/>
+        <pin position="A9" name="PG10"/>
+        <pin position="A10" name="PG9"/>
+        <pin position="A11" name="PD5"/>
+        <pin position="A12" name="PD4"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PA15 (JTDI)"/>
+        <pin position="A15" name="PI1"/>
+        <pin position="A16" name="PI0"/>
+        <pin position="A17" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PI7"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B7" name="PB4 (NJTRST)"/>
+        <pin position="B8" name="PK4"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PJ15"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD3"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B15" name="PI2"/>
+        <pin position="B16" name="PH15"/>
+        <pin position="B17" name="PH14"/>
+        <pin position="C1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PK6"/>
+        <pin position="C8" name="PK3"/>
+        <pin position="C9" name="PG12"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PD7"/>
+        <pin position="C12" name="PC12"/>
+        <pin position="C13" name="VSS" type="power"/>
+        <pin position="C14" name="PI3"/>
+        <pin position="C15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C16" name="VSS" type="power"/>
+        <pin position="C17" name="VDDLDO" type="power"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE4"/>
+        <pin position="D3" name="PE3"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PG15"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG14"/>
+        <pin position="D9" name="PG13"/>
+        <pin position="D10" name="PJ14"/>
+        <pin position="D11" name="PJ12"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PD0"/>
+        <pin position="D14" name="PA10"/>
+        <pin position="D15" name="PA9"/>
+        <pin position="D16" name="PH13"/>
+        <pin position="D17" name="VCAP" type="power"/>
+        <pin position="E1" name="NC" type="nc"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PI8"/>
+        <pin position="E5" name="PE6"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="BOOT0" type="boot"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PJ13"/>
+        <pin position="E11" name="VDD" type="power"/>
+        <pin position="E12" name="PD1"/>
+        <pin position="E13" name="PC8"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PA8"/>
+        <pin position="E16" name="PA12"/>
+        <pin position="E17" name="PA11"/>
+        <pin position="F1" name="NC" type="nc"/>
+        <pin position="F2" name="NC" type="nc"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PI11"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F13" name="PC7"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="F16" name="PG7"/>
+        <pin position="F17" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF2"/>
+        <pin position="G2" name="NC" type="nc"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG6"/>
+        <pin position="G16" name="VSS" type="power"/>
+        <pin position="G17" name="VDD50_USB" type="power"/>
+        <pin position="H1" name="PI12"/>
+        <pin position="H2" name="PI13"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG4"/>
+        <pin position="H15" name="PG3"/>
+        <pin position="H16" name="PG2"/>
+        <pin position="H17" name="PK2"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="VSS" type="power"/>
+        <pin position="J4" name="PF5"/>
+        <pin position="J5" name="PF4"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PK0"/>
+        <pin position="J15" name="PK1"/>
+        <pin position="J16" name="VSS" type="power"/>
+        <pin position="J17" name="VSS" type="power"/>
+        <pin position="K1" name="NRST" type="reset"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF7"/>
+        <pin position="K4" name="PF8"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K13" name="VDD" type="power"/>
+        <pin position="K14" name="PJ11"/>
+        <pin position="K15" name="VSS" type="power"/>
+        <pin position="K16" name="NC" type="nc"/>
+        <pin position="K17" name="NC" type="nc"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PF10"/>
+        <pin position="L4" name="PF9"/>
+        <pin position="L5" name="VDD" type="power"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="VSS" type="power"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VSS" type="power"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="L14" name="PJ10"/>
+        <pin position="L15" name="VSS" type="power"/>
+        <pin position="L16" name="NC" type="nc"/>
+        <pin position="L17" name="NC" type="nc"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PC2"/>
+        <pin position="M4" name="PC3"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M13" name="VDD" type="power"/>
+        <pin position="M14" name="PJ9"/>
+        <pin position="M15" name="VSS" type="power"/>
+        <pin position="M16" name="NC" type="nc"/>
+        <pin position="M17" name="NC" type="nc"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA2"/>
+        <pin position="N4" name="PA1"/>
+        <pin position="N5" name="PA0"/>
+        <pin position="N6" name="PJ0"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="PE10"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="VDD" type="power"/>
+        <pin position="N13" name="PJ8"/>
+        <pin position="N14" name="PJ7"/>
+        <pin position="N15" name="PJ6"/>
+        <pin position="N16" name="VSS" type="power"/>
+        <pin position="N17" name="NC" type="nc"/>
+        <pin position="P1" name="VSSA" type="power"/>
+        <pin position="P2" name="PH3"/>
+        <pin position="P3" name="PH4"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PI15"/>
+        <pin position="P6" name="PJ1"/>
+        <pin position="P7" name="PF13"/>
+        <pin position="P8" name="PF14"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PB10"/>
+        <pin position="P12" name="PB11"/>
+        <pin position="P13" name="PH10"/>
+        <pin position="P14" name="PH11"/>
+        <pin position="P15" name="PD15"/>
+        <pin position="P16" name="PD14"/>
+        <pin position="P17" name="VDD" type="power"/>
+        <pin position="R1" name="PC2_C"/>
+        <pin position="R2" name="PC3_C"/>
+        <pin position="R3" name="PA6"/>
+        <pin position="R4" name="VSS" type="power"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PF12"/>
+        <pin position="R8" name="VSS" type="power"/>
+        <pin position="R9" name="PF15"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PJ5"/>
+        <pin position="R13" name="PH9"/>
+        <pin position="R14" name="PH12"/>
+        <pin position="R15" name="PD11"/>
+        <pin position="R16" name="PD12"/>
+        <pin position="R17" name="PD13"/>
+        <pin position="T1" name="PA0_C"/>
+        <pin position="T2" name="PA1_C"/>
+        <pin position="T3" name="PA5"/>
+        <pin position="T4" name="PC4"/>
+        <pin position="T5" name="PB1"/>
+        <pin position="T6" name="PJ2"/>
+        <pin position="T7" name="PF11"/>
+        <pin position="T8" name="PG0"/>
+        <pin position="T9" name="PE8"/>
+        <pin position="T10" name="PE13"/>
+        <pin position="T11" name="PH6"/>
+        <pin position="T12" name="VSS" type="power"/>
+        <pin position="T13" name="PH8"/>
+        <pin position="T14" name="PB12"/>
+        <pin position="T15" name="PB15"/>
+        <pin position="T16" name="PD10"/>
+        <pin position="T17" name="PD9"/>
+        <pin position="U1" name="VSS" type="power"/>
+        <pin position="U2" name="PA3"/>
+        <pin position="U3" name="PA4"/>
+        <pin position="U4" name="PC5"/>
+        <pin position="U5" name="PB0"/>
+        <pin position="U6" name="PJ3"/>
+        <pin position="U7" name="PJ4"/>
+        <pin position="U8" name="PG1"/>
+        <pin position="U9" name="PE7"/>
+        <pin position="U10" name="PE14"/>
+        <pin position="U11" name="VCAP" type="power"/>
+        <pin position="U12" name="VDDLDO" type="power"/>
+        <pin position="U13" name="PH7"/>
+        <pin position="U14" name="PB13"/>
+        <pin position="U15" name="PB14"/>
+        <pin position="U16" name="PD8"/>
+        <pin position="U17" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PI6"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PI2"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PI0"/>
+        <pin position="B1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4 (NJTRST)"/>
+        <pin position="B7" name="PI3"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B13" name="PI1"/>
+        <pin position="C1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="reset"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15 (JTDI)"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="PI11"/>
+        <pin position="E2" name="PI7"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="PI13"/>
+        <pin position="F2" name="PI12"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50_USB" type="power"/>
+        <pin position="G13" name="VDD33_USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PJ1"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PJ0"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PH4"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PH5"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4 (NJTRST)"/>
+        <pin position="A10" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15 (JTDI)"/>
+        <pin position="A14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD33_USB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="VSS" type="power"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2_C"/>
+        <pin position="M5" name="PC3_C"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="monoio"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-43_53.xml
+++ b/devices/stm32/stm32h7-43_53.xml
@@ -2171,6 +2171,1385 @@
       <gpio device-pin="b|x" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33_USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="10" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN (PH0)"/>
+        <pin position="30" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2_C"/>
+        <pin position="35" name="PC3_C"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="monoio"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD33_USB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="125" name="VCAP" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="138" name="PA15 (JTDI)"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="162" name="PB4 (NJTRST)"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="10" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PI12"/>
+        <pin position="20" name="PI13"/>
+        <pin position="21" name="PI14"/>
+        <pin position="22" name="PF3"/>
+        <pin position="23" name="PF4"/>
+        <pin position="24" name="PF5"/>
+        <pin position="25" name="VSS" type="power"/>
+        <pin position="26" name="VDD" type="power"/>
+        <pin position="27" name="PF6"/>
+        <pin position="28" name="PF7"/>
+        <pin position="29" name="PF8"/>
+        <pin position="30" name="PF9"/>
+        <pin position="31" name="PF10"/>
+        <pin position="32" name="PH0-OSC_IN (PH0)"/>
+        <pin position="33" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="34" name="NRST" type="reset"/>
+        <pin position="35" name="PC0"/>
+        <pin position="36" name="PC1"/>
+        <pin position="37" name="PC2_C"/>
+        <pin position="38" name="PC3_C"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="VSSA" type="power"/>
+        <pin position="41" name="VREF+" type="monoio"/>
+        <pin position="42" name="VDDA" type="power"/>
+        <pin position="43" name="PA0"/>
+        <pin position="44" name="PA1"/>
+        <pin position="45" name="PA2"/>
+        <pin position="46" name="PH2"/>
+        <pin position="47" name="PH3"/>
+        <pin position="48" name="PH4"/>
+        <pin position="49" name="PH5"/>
+        <pin position="50" name="PA3"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PA4"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA6"/>
+        <pin position="56" name="PA7"/>
+        <pin position="57" name="PC4"/>
+        <pin position="58" name="PC5"/>
+        <pin position="59" name="VDD" type="power"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PB0"/>
+        <pin position="62" name="PB1"/>
+        <pin position="63" name="PB2"/>
+        <pin position="64" name="PI15"/>
+        <pin position="65" name="PJ0"/>
+        <pin position="66" name="PJ1"/>
+        <pin position="67" name="PJ2"/>
+        <pin position="68" name="PJ3"/>
+        <pin position="69" name="PJ4"/>
+        <pin position="70" name="PF11"/>
+        <pin position="71" name="PF12"/>
+        <pin position="72" name="VSS" type="power"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="PF13"/>
+        <pin position="75" name="PF14"/>
+        <pin position="76" name="PF15"/>
+        <pin position="77" name="PG0"/>
+        <pin position="78" name="PG1"/>
+        <pin position="79" name="PE7"/>
+        <pin position="80" name="PE8"/>
+        <pin position="81" name="PE9"/>
+        <pin position="82" name="VSS" type="power"/>
+        <pin position="83" name="VDD" type="power"/>
+        <pin position="84" name="PE10"/>
+        <pin position="85" name="PE11"/>
+        <pin position="86" name="PE12"/>
+        <pin position="87" name="PE13"/>
+        <pin position="88" name="PE14"/>
+        <pin position="89" name="PE15"/>
+        <pin position="90" name="PB10"/>
+        <pin position="91" name="PB11"/>
+        <pin position="92" name="VCAP" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="VDD" type="power"/>
+        <pin position="95" name="PJ5"/>
+        <pin position="96" name="PH6"/>
+        <pin position="97" name="PH7"/>
+        <pin position="98" name="PH8"/>
+        <pin position="99" name="PH9"/>
+        <pin position="100" name="PH10"/>
+        <pin position="101" name="PH11"/>
+        <pin position="102" name="PH12"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PB12"/>
+        <pin position="105" name="PB13"/>
+        <pin position="106" name="PB14"/>
+        <pin position="107" name="PB15"/>
+        <pin position="108" name="PD8"/>
+        <pin position="109" name="PD9"/>
+        <pin position="110" name="PD10"/>
+        <pin position="111" name="PD11"/>
+        <pin position="112" name="PD12"/>
+        <pin position="113" name="PD13"/>
+        <pin position="114" name="VSS" type="power"/>
+        <pin position="115" name="VDD" type="power"/>
+        <pin position="116" name="PD14"/>
+        <pin position="117" name="PD15"/>
+        <pin position="118" name="PJ6"/>
+        <pin position="119" name="PJ7"/>
+        <pin position="120" name="PJ8"/>
+        <pin position="121" name="PJ9"/>
+        <pin position="122" name="PJ10"/>
+        <pin position="123" name="PJ11"/>
+        <pin position="124" name="VDD" type="power"/>
+        <pin position="125" name="VSS" type="power"/>
+        <pin position="126" name="PK0"/>
+        <pin position="127" name="PK1"/>
+        <pin position="128" name="PK2"/>
+        <pin position="129" name="PG2"/>
+        <pin position="130" name="PG3"/>
+        <pin position="131" name="PG4"/>
+        <pin position="132" name="PG5"/>
+        <pin position="133" name="PG6"/>
+        <pin position="134" name="PG7"/>
+        <pin position="135" name="PG8"/>
+        <pin position="136" name="VSS" type="power"/>
+        <pin position="137" name="VDD33_USB" type="power"/>
+        <pin position="138" name="PC6"/>
+        <pin position="139" name="PC7"/>
+        <pin position="140" name="PC8"/>
+        <pin position="141" name="PC9"/>
+        <pin position="142" name="PA8"/>
+        <pin position="143" name="PA9"/>
+        <pin position="144" name="PA10"/>
+        <pin position="145" name="PA11"/>
+        <pin position="146" name="PA12"/>
+        <pin position="147" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="148" name="VCAP" type="power"/>
+        <pin position="149" name="VSS" type="power"/>
+        <pin position="150" name="VDD" type="power"/>
+        <pin position="151" name="PH13"/>
+        <pin position="152" name="PH14"/>
+        <pin position="153" name="PH15"/>
+        <pin position="154" name="PI0"/>
+        <pin position="155" name="PI1"/>
+        <pin position="156" name="PI2"/>
+        <pin position="157" name="PI3"/>
+        <pin position="158" name="VDD" type="power"/>
+        <pin position="159" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="160" name="PA15 (JTDI)"/>
+        <pin position="161" name="PC10"/>
+        <pin position="162" name="PC11"/>
+        <pin position="163" name="PC12"/>
+        <pin position="164" name="PD0"/>
+        <pin position="165" name="PD1"/>
+        <pin position="166" name="PD2"/>
+        <pin position="167" name="PD3"/>
+        <pin position="168" name="PD4"/>
+        <pin position="169" name="PD5"/>
+        <pin position="170" name="VSS" type="power"/>
+        <pin position="171" name="VDD" type="power"/>
+        <pin position="172" name="PD6"/>
+        <pin position="173" name="PD7"/>
+        <pin position="174" name="PJ12"/>
+        <pin position="175" name="PJ13"/>
+        <pin position="176" name="PJ14"/>
+        <pin position="177" name="PJ15"/>
+        <pin position="178" name="PG9"/>
+        <pin position="179" name="PG10"/>
+        <pin position="180" name="PG11"/>
+        <pin position="181" name="PG12"/>
+        <pin position="182" name="PG13"/>
+        <pin position="183" name="PG14"/>
+        <pin position="184" name="VSS" type="power"/>
+        <pin position="185" name="VDD" type="power"/>
+        <pin position="186" name="PK3"/>
+        <pin position="187" name="PK4"/>
+        <pin position="188" name="PK5"/>
+        <pin position="189" name="PK6"/>
+        <pin position="190" name="PK7"/>
+        <pin position="191" name="PG15"/>
+        <pin position="192" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="193" name="PB4 (NJTRST)"/>
+        <pin position="194" name="PB5"/>
+        <pin position="195" name="PB6"/>
+        <pin position="196" name="PB7"/>
+        <pin position="197" name="BOOT0" type="boot"/>
+        <pin position="198" name="PB8"/>
+        <pin position="199" name="PB9"/>
+        <pin position="200" name="PE0"/>
+        <pin position="201" name="PE1"/>
+        <pin position="202" name="VSS" type="power"/>
+        <pin position="203" name="PDR_ON" type="reset"/>
+        <pin position="204" name="VDD" type="power"/>
+        <pin position="205" name="PI4"/>
+        <pin position="206" name="PI5"/>
+        <pin position="207" name="PI6"/>
+        <pin position="208" name="PI7"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin position="A1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PB9"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB4 (NJTRST)"/>
+        <pin position="A7" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A8" name="PA15 (JTDI)"/>
+        <pin position="A9" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A10" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD5"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="PC11"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PD3"/>
+        <pin position="C8" name="PC12"/>
+        <pin position="C9" name="PA9"/>
+        <pin position="C10" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="BOOT0" type="boot"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="PD4"/>
+        <pin position="D8" name="PD0"/>
+        <pin position="D9" name="PA8"/>
+        <pin position="D10" name="PA10"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC2_C"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VSS" type="power"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VSS" type="power"/>
+        <pin position="E7" name="VCAP" type="power"/>
+        <pin position="E8" name="PD1"/>
+        <pin position="E9" name="PC9"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="F1" name="PC0"/>
+        <pin position="F2" name="PC1"/>
+        <pin position="F3" name="PC3_C"/>
+        <pin position="F4" name="VDDLDO" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VDD33_USB" type="power"/>
+        <pin position="F7" name="PDR_ON" type="reset"/>
+        <pin position="F8" name="VCAP" type="power"/>
+        <pin position="F9" name="PC8"/>
+        <pin position="F10" name="PC6"/>
+        <pin position="G1" name="VSSA" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA4"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PB2"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin position="G9" name="PD11"/>
+        <pin position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA5"/>
+        <pin position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin position="H6" name="PE11"/>
+        <pin position="H7" name="PE15"/>
+        <pin position="H8" name="PD14"/>
+        <pin position="H9" name="PD10"/>
+        <pin position="H10" name="PB14"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin position="J4" name="PB0"/>
+        <pin position="J5" name="PE8"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin position="J9" name="PD9"/>
+        <pin position="J10" name="PD13"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin position="K4" name="PB1"/>
+        <pin position="K5" name="PE9"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PD12"/>
+      </package>
+      <package device-pin="x" name="TFBGA240">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PI4"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="VDDLDO" type="power"/>
+        <pin position="A7" name="VCAP" type="power"/>
+        <pin position="A8" name="PK5"/>
+        <pin position="A9" name="PG10"/>
+        <pin position="A10" name="PG9"/>
+        <pin position="A11" name="PD5"/>
+        <pin position="A12" name="PD4"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PA15 (JTDI)"/>
+        <pin position="A15" name="PI1"/>
+        <pin position="A16" name="PI0"/>
+        <pin position="A17" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PI7"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="NC" type="nc"/>
+        <pin position="B7" name="PB4 (NJTRST)"/>
+        <pin position="B8" name="PK4"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PJ15"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD3"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B15" name="PI2"/>
+        <pin position="B16" name="PH15"/>
+        <pin position="B17" name="PH14"/>
+        <pin position="C1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PK6"/>
+        <pin position="C8" name="PK3"/>
+        <pin position="C9" name="PG12"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PD7"/>
+        <pin position="C12" name="PC12"/>
+        <pin position="C13" name="VSS" type="power"/>
+        <pin position="C14" name="PI3"/>
+        <pin position="C15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C16" name="VSS" type="power"/>
+        <pin position="C17" name="VDDLDO" type="power"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE4"/>
+        <pin position="D3" name="PE3"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PG15"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG14"/>
+        <pin position="D9" name="PG13"/>
+        <pin position="D10" name="PJ14"/>
+        <pin position="D11" name="PJ12"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PD0"/>
+        <pin position="D14" name="PA10"/>
+        <pin position="D15" name="PA9"/>
+        <pin position="D16" name="PH13"/>
+        <pin position="D17" name="VCAP" type="power"/>
+        <pin position="E1" name="NC" type="nc"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PI8"/>
+        <pin position="E5" name="PE6"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="BOOT0" type="boot"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PJ13"/>
+        <pin position="E11" name="VDD" type="power"/>
+        <pin position="E12" name="PD1"/>
+        <pin position="E13" name="PC8"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PA8"/>
+        <pin position="E16" name="PA12"/>
+        <pin position="E17" name="PA11"/>
+        <pin position="F1" name="NC" type="nc"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PI11"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F13" name="PC7"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="F16" name="PG7"/>
+        <pin position="F17" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF2"/>
+        <pin position="G2" name="NC" type="nc"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG6"/>
+        <pin position="G16" name="VSS" type="power"/>
+        <pin position="G17" name="VDD50_USB" type="power"/>
+        <pin position="H1" name="PI12"/>
+        <pin position="H2" name="PI13"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG4"/>
+        <pin position="H15" name="PG3"/>
+        <pin position="H16" name="PG2"/>
+        <pin position="H17" name="PK2"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="VSS" type="power"/>
+        <pin position="J4" name="PF5"/>
+        <pin position="J5" name="PF4"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PK0"/>
+        <pin position="J15" name="PK1"/>
+        <pin position="J16" name="VSS" type="power"/>
+        <pin position="J17" name="VSS" type="power"/>
+        <pin position="K1" name="NRST" type="reset"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF7"/>
+        <pin position="K4" name="PF8"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K13" name="VDD" type="power"/>
+        <pin position="K14" name="PJ11"/>
+        <pin position="K15" name="VSS" type="power"/>
+        <pin position="K16" name="NC" type="nc"/>
+        <pin position="K17" name="NC" type="nc"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PF10"/>
+        <pin position="L4" name="PF9"/>
+        <pin position="L5" name="VDD" type="power"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="VSS" type="power"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VSS" type="power"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="L14" name="PJ10"/>
+        <pin position="L15" name="VSS" type="power"/>
+        <pin position="L16" name="NC" type="nc"/>
+        <pin position="L17" name="NC" type="nc"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PC2"/>
+        <pin position="M4" name="PC3"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M13" name="VDD" type="power"/>
+        <pin position="M14" name="PJ9"/>
+        <pin position="M15" name="VSS" type="power"/>
+        <pin position="M16" name="NC" type="nc"/>
+        <pin position="M17" name="NC" type="nc"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA2"/>
+        <pin position="N4" name="PA1"/>
+        <pin position="N5" name="PA0"/>
+        <pin position="N6" name="PJ0"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="PE10"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="VDD" type="power"/>
+        <pin position="N13" name="PJ8"/>
+        <pin position="N14" name="PJ7"/>
+        <pin position="N15" name="PJ6"/>
+        <pin position="N16" name="VSS" type="power"/>
+        <pin position="N17" name="NC" type="nc"/>
+        <pin position="P1" name="VSSA" type="power"/>
+        <pin position="P2" name="PH3"/>
+        <pin position="P3" name="PH4"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PI15"/>
+        <pin position="P6" name="PJ1"/>
+        <pin position="P7" name="PF13"/>
+        <pin position="P8" name="PF14"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PB10"/>
+        <pin position="P12" name="PB11"/>
+        <pin position="P13" name="PH10"/>
+        <pin position="P14" name="PH11"/>
+        <pin position="P15" name="PD15"/>
+        <pin position="P16" name="PD14"/>
+        <pin position="P17" name="VDD" type="power"/>
+        <pin position="R1" name="PC2_C"/>
+        <pin position="R2" name="PC3_C"/>
+        <pin position="R3" name="PA6"/>
+        <pin position="R4" name="VSS" type="power"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PF12"/>
+        <pin position="R8" name="VSS" type="power"/>
+        <pin position="R9" name="PF15"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PJ5"/>
+        <pin position="R13" name="PH9"/>
+        <pin position="R14" name="PH12"/>
+        <pin position="R15" name="PD11"/>
+        <pin position="R16" name="PD12"/>
+        <pin position="R17" name="PD13"/>
+        <pin position="T1" name="PA0_C"/>
+        <pin position="T2" name="PA1_C"/>
+        <pin position="T3" name="PA5"/>
+        <pin position="T4" name="PC4"/>
+        <pin position="T5" name="PB1"/>
+        <pin position="T6" name="PJ2"/>
+        <pin position="T7" name="PF11"/>
+        <pin position="T8" name="PG0"/>
+        <pin position="T9" name="PE8"/>
+        <pin position="T10" name="PE13"/>
+        <pin position="T11" name="PH6"/>
+        <pin position="T12" name="VSS" type="power"/>
+        <pin position="T13" name="PH8"/>
+        <pin position="T14" name="PB12"/>
+        <pin position="T15" name="PB15"/>
+        <pin position="T16" name="PD10"/>
+        <pin position="T17" name="PD9"/>
+        <pin position="U1" name="VSS" type="power"/>
+        <pin position="U2" name="PA3"/>
+        <pin position="U3" name="PA4"/>
+        <pin position="U4" name="PC5"/>
+        <pin position="U5" name="PB0"/>
+        <pin position="U6" name="PJ3"/>
+        <pin position="U7" name="PJ4"/>
+        <pin position="U8" name="PG1"/>
+        <pin position="U9" name="PE7"/>
+        <pin position="U10" name="PE14"/>
+        <pin position="U11" name="VCAP" type="power"/>
+        <pin position="U12" name="VDDLDO" type="power"/>
+        <pin position="U13" name="PH7"/>
+        <pin position="U14" name="PB13"/>
+        <pin position="U15" name="PB14"/>
+        <pin position="U16" name="PD8"/>
+        <pin position="U17" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PI6"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PI2"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PI0"/>
+        <pin position="B1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4 (NJTRST)"/>
+        <pin position="B7" name="PI3"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B13" name="PI1"/>
+        <pin position="C1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="reset"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15 (JTDI)"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="PI11"/>
+        <pin position="E2" name="PI7"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="PI13"/>
+        <pin position="F2" name="PI12"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50_USB" type="power"/>
+        <pin position="G13" name="VDD33_USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PJ1"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PJ0"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PH4"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PH5"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4 (NJTRST)"/>
+        <pin position="A10" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15 (JTDI)"/>
+        <pin position="A14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD33_USB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="VSS" type="power"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2_C"/>
+        <pin position="M5" name="PC3_C"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="monoio"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -2449,6 +2449,1010 @@
       <gpio device-pin="x" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="11" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PF6"/>
+        <pin position="21" name="PF7"/>
+        <pin position="22" name="PF8"/>
+        <pin position="23" name="PF9"/>
+        <pin position="24" name="PF10"/>
+        <pin position="25" name="PH0-OSC_IN (PH0)"/>
+        <pin position="26" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="27" name="NRST" type="reset"/>
+        <pin position="28" name="PC0"/>
+        <pin position="29" name="PC1"/>
+        <pin position="30" name="PC2_C"/>
+        <pin position="31" name="PC3_C"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="VSS" type="power"/>
+        <pin position="34" name="VSSA" type="power"/>
+        <pin position="35" name="VREF+" type="monoio"/>
+        <pin position="36" name="VDDA" type="power"/>
+        <pin position="37" name="PA0"/>
+        <pin position="38" name="PA1"/>
+        <pin position="39" name="PA2"/>
+        <pin position="40" name="PA3"/>
+        <pin position="41" name="VSS" type="power"/>
+        <pin position="42" name="VDD" type="power"/>
+        <pin position="43" name="PA4"/>
+        <pin position="44" name="PA5"/>
+        <pin position="45" name="PA6"/>
+        <pin position="46" name="PA7"/>
+        <pin position="47" name="PC4"/>
+        <pin position="48" name="PC5"/>
+        <pin position="49" name="PB0"/>
+        <pin position="50" name="PB1"/>
+        <pin position="51" name="PB2"/>
+        <pin position="52" name="PF11"/>
+        <pin position="53" name="PF14"/>
+        <pin position="54" name="PF15"/>
+        <pin position="55" name="VSS" type="power"/>
+        <pin position="56" name="VDD" type="power"/>
+        <pin position="57" name="PE7"/>
+        <pin position="58" name="PE8"/>
+        <pin position="59" name="PE9"/>
+        <pin position="60" name="PE10"/>
+        <pin position="61" name="PE11"/>
+        <pin position="62" name="PE12"/>
+        <pin position="63" name="PE13"/>
+        <pin position="64" name="PE14"/>
+        <pin position="65" name="PE15"/>
+        <pin position="66" name="PB10"/>
+        <pin position="67" name="PB11"/>
+        <pin position="68" name="VCAP" type="power"/>
+        <pin position="69" name="VSS" type="power"/>
+        <pin position="70" name="VDDLDO" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PB12"/>
+        <pin position="73" name="PB13"/>
+        <pin position="74" name="PB14"/>
+        <pin position="75" name="PB15"/>
+        <pin position="76" name="PD8"/>
+        <pin position="77" name="PD9"/>
+        <pin position="78" name="PD10"/>
+        <pin position="79" name="VDD" type="power"/>
+        <pin position="80" name="VSS" type="power"/>
+        <pin position="81" name="PD11"/>
+        <pin position="82" name="PD12"/>
+        <pin position="83" name="PD13"/>
+        <pin position="84" name="PD14"/>
+        <pin position="85" name="PD15"/>
+        <pin position="86" name="PG6"/>
+        <pin position="87" name="PG7"/>
+        <pin position="88" name="PG8"/>
+        <pin position="89" name="VSS" type="power"/>
+        <pin position="90" name="VDD50_USB" type="power"/>
+        <pin position="91" name="VDD33_USB" type="power"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="PC6"/>
+        <pin position="94" name="PC7"/>
+        <pin position="95" name="PC8"/>
+        <pin position="96" name="PC9"/>
+        <pin position="97" name="PA8"/>
+        <pin position="98" name="PA9"/>
+        <pin position="99" name="PA10"/>
+        <pin position="100" name="PA11"/>
+        <pin position="101" name="PA12"/>
+        <pin position="102" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="103" name="VCAP" type="power"/>
+        <pin position="104" name="VSS" type="power"/>
+        <pin position="105" name="VDDLDO" type="power"/>
+        <pin position="106" name="VDD" type="power"/>
+        <pin position="107" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="108" name="PA15 (JTDI)"/>
+        <pin position="109" name="PC10"/>
+        <pin position="110" name="PC11"/>
+        <pin position="111" name="PC12"/>
+        <pin position="112" name="PD0"/>
+        <pin position="113" name="PD1"/>
+        <pin position="114" name="PD2"/>
+        <pin position="115" name="PD3"/>
+        <pin position="116" name="PD4"/>
+        <pin position="117" name="PD5"/>
+        <pin position="118" name="VSS" type="power"/>
+        <pin position="119" name="VDD" type="power"/>
+        <pin position="120" name="PD6"/>
+        <pin position="121" name="PD7"/>
+        <pin position="122" name="PG9"/>
+        <pin position="123" name="PG10"/>
+        <pin position="124" name="PG11"/>
+        <pin position="125" name="PG12"/>
+        <pin position="126" name="PG13"/>
+        <pin position="127" name="PG14"/>
+        <pin position="128" name="VSS" type="power"/>
+        <pin position="129" name="VDD" type="power"/>
+        <pin position="130" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="131" name="PB4 (NJTRST)"/>
+        <pin position="132" name="PB5"/>
+        <pin position="133" name="PB6"/>
+        <pin position="134" name="PB7"/>
+        <pin position="135" name="BOOT0" type="boot"/>
+        <pin position="136" name="PB8"/>
+        <pin position="137" name="PB9"/>
+        <pin position="138" name="PE0"/>
+        <pin position="139" name="PE1"/>
+        <pin position="140" name="VCAP" type="power"/>
+        <pin position="141" name="VSS" type="power"/>
+        <pin position="142" name="PDR_ON" type="reset"/>
+        <pin position="143" name="VDDLDO" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="11" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="PF0"/>
+        <pin position="19" name="PF1"/>
+        <pin position="20" name="PF2"/>
+        <pin position="21" name="PF3"/>
+        <pin position="22" name="PF4"/>
+        <pin position="23" name="PF5"/>
+        <pin position="24" name="VSS" type="power"/>
+        <pin position="25" name="VDD" type="power"/>
+        <pin position="26" name="PF6"/>
+        <pin position="27" name="PF7"/>
+        <pin position="28" name="PF8"/>
+        <pin position="29" name="PF9"/>
+        <pin position="30" name="PF10"/>
+        <pin position="31" name="PH0-OSC_IN (PH0)"/>
+        <pin position="32" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="33" name="NRST" type="reset"/>
+        <pin position="34" name="PC0"/>
+        <pin position="35" name="PC1"/>
+        <pin position="36" name="PC2_C"/>
+        <pin position="37" name="PC3_C"/>
+        <pin position="38" name="VSSA" type="power"/>
+        <pin position="39" name="VREF+" type="monoio"/>
+        <pin position="40" name="VDDA" type="power"/>
+        <pin position="41" name="PA0"/>
+        <pin position="42" name="PA1"/>
+        <pin position="43" name="PA2"/>
+        <pin position="44" name="VDD" type="power"/>
+        <pin position="45" name="VSS" type="power"/>
+        <pin position="46" name="PA3"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA4"/>
+        <pin position="50" name="PA5"/>
+        <pin position="51" name="PA6"/>
+        <pin position="52" name="PA7"/>
+        <pin position="53" name="PC4"/>
+        <pin position="54" name="PC5"/>
+        <pin position="55" name="PB0"/>
+        <pin position="56" name="PB1"/>
+        <pin position="57" name="PB2"/>
+        <pin position="58" name="PF11"/>
+        <pin position="59" name="PF12"/>
+        <pin position="60" name="PF13"/>
+        <pin position="61" name="PF14"/>
+        <pin position="62" name="PF15"/>
+        <pin position="63" name="PG0"/>
+        <pin position="64" name="VSS" type="power"/>
+        <pin position="65" name="VDD" type="power"/>
+        <pin position="66" name="PG1"/>
+        <pin position="67" name="PE7"/>
+        <pin position="68" name="PE8"/>
+        <pin position="69" name="PE9"/>
+        <pin position="70" name="VSS" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PE10"/>
+        <pin position="73" name="PE11"/>
+        <pin position="74" name="PE12"/>
+        <pin position="75" name="PE13"/>
+        <pin position="76" name="PE14"/>
+        <pin position="77" name="PE15"/>
+        <pin position="78" name="PB10"/>
+        <pin position="79" name="PB11"/>
+        <pin position="80" name="VCAP" type="power"/>
+        <pin position="81" name="VSS" type="power"/>
+        <pin position="82" name="VDDLDO" type="power"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PB12"/>
+        <pin position="86" name="PB13"/>
+        <pin position="87" name="PB14"/>
+        <pin position="88" name="PB15"/>
+        <pin position="89" name="PD8"/>
+        <pin position="90" name="PD9"/>
+        <pin position="91" name="PD10"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="PD11"/>
+        <pin position="95" name="PD12"/>
+        <pin position="96" name="PD13"/>
+        <pin position="97" name="PD14"/>
+        <pin position="98" name="PD15"/>
+        <pin position="99" name="VDD" type="power"/>
+        <pin position="100" name="VSS" type="power"/>
+        <pin position="101" name="PJ8"/>
+        <pin position="102" name="PJ9"/>
+        <pin position="103" name="PJ10"/>
+        <pin position="104" name="PJ11"/>
+        <pin position="105" name="VDD" type="power"/>
+        <pin position="106" name="VSS" type="power"/>
+        <pin position="107" name="PK0"/>
+        <pin position="108" name="PK1"/>
+        <pin position="109" name="PK2"/>
+        <pin position="110" name="PG2"/>
+        <pin position="111" name="PG3"/>
+        <pin position="112" name="VSS" type="power"/>
+        <pin position="113" name="VDD" type="power"/>
+        <pin position="114" name="PG4"/>
+        <pin position="115" name="PG5"/>
+        <pin position="116" name="PG6"/>
+        <pin position="117" name="PG7"/>
+        <pin position="118" name="PG8"/>
+        <pin position="119" name="VSS" type="power"/>
+        <pin position="120" name="VDD50_USB" type="power"/>
+        <pin position="121" name="VDD33_USB" type="power"/>
+        <pin position="122" name="PC6"/>
+        <pin position="123" name="PC7"/>
+        <pin position="124" name="PC8"/>
+        <pin position="125" name="PC9"/>
+        <pin position="126" name="VDD" type="power"/>
+        <pin position="127" name="PA8"/>
+        <pin position="128" name="PA9"/>
+        <pin position="129" name="PA10"/>
+        <pin position="130" name="PA11"/>
+        <pin position="131" name="PA12"/>
+        <pin position="132" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="133" name="VCAP" type="power"/>
+        <pin position="134" name="VSS" type="power"/>
+        <pin position="135" name="VDDLDO" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="VSS" type="power"/>
+        <pin position="138" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="139" name="PA15 (JTDI)"/>
+        <pin position="140" name="PC10"/>
+        <pin position="141" name="PC11"/>
+        <pin position="142" name="PC12"/>
+        <pin position="143" name="PD0"/>
+        <pin position="144" name="PD1"/>
+        <pin position="145" name="PD2"/>
+        <pin position="146" name="PD3"/>
+        <pin position="147" name="PD4"/>
+        <pin position="148" name="PD5"/>
+        <pin position="149" name="PD6"/>
+        <pin position="150" name="PD7"/>
+        <pin position="151" name="VSS" type="power"/>
+        <pin position="152" name="VDD" type="power"/>
+        <pin position="153" name="PG9"/>
+        <pin position="154" name="PG10"/>
+        <pin position="155" name="PG11"/>
+        <pin position="156" name="PG12"/>
+        <pin position="157" name="PG13"/>
+        <pin position="158" name="PG14"/>
+        <pin position="159" name="VSS" type="power"/>
+        <pin position="160" name="VDD" type="power"/>
+        <pin position="161" name="PG15"/>
+        <pin position="162" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="163" name="PB4 (NJTRST)"/>
+        <pin position="164" name="PB5"/>
+        <pin position="165" name="PB6"/>
+        <pin position="166" name="PB7"/>
+        <pin position="167" name="BOOT0" type="boot"/>
+        <pin position="168" name="PB8"/>
+        <pin position="169" name="PB9"/>
+        <pin position="170" name="PE0"/>
+        <pin position="171" name="PE1"/>
+        <pin position="172" name="VCAP" type="power"/>
+        <pin position="173" name="VSS" type="power"/>
+        <pin position="174" name="PDR_ON" type="reset"/>
+        <pin position="175" name="VDDLDO" type="power"/>
+        <pin position="176" name="VDD" type="power"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PI8"/>
+        <pin position="10" name="PC13"/>
+        <pin position="11" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="12" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="13" name="PI9"/>
+        <pin position="14" name="PI10"/>
+        <pin position="15" name="PI11"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="VSSSMPS" type="power"/>
+        <pin position="19" name="VLXSMPS" type="power"/>
+        <pin position="20" name="VDDSMPS" type="power"/>
+        <pin position="21" name="VFBSMPS" type="power"/>
+        <pin position="22" name="PF0"/>
+        <pin position="23" name="PF1"/>
+        <pin position="24" name="PF2"/>
+        <pin position="25" name="PF3"/>
+        <pin position="26" name="PF4"/>
+        <pin position="27" name="PF5"/>
+        <pin position="28" name="VSS" type="power"/>
+        <pin position="29" name="VDD" type="power"/>
+        <pin position="30" name="PF6"/>
+        <pin position="31" name="PF7"/>
+        <pin position="32" name="PF8"/>
+        <pin position="33" name="PF9"/>
+        <pin position="34" name="PF10"/>
+        <pin position="35" name="PH0-OSC_IN (PH0)"/>
+        <pin position="36" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="37" name="NRST" type="reset"/>
+        <pin position="38" name="PC0"/>
+        <pin position="39" name="PC1"/>
+        <pin position="40" name="PC2_C"/>
+        <pin position="41" name="PC3_C"/>
+        <pin position="42" name="VSSA" type="power"/>
+        <pin position="43" name="VREF+" type="monoio"/>
+        <pin position="44" name="VDDA" type="power"/>
+        <pin position="45" name="PA0"/>
+        <pin position="46" name="PA1"/>
+        <pin position="47" name="PA2"/>
+        <pin position="48" name="PH2"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="PH3"/>
+        <pin position="52" name="PH4"/>
+        <pin position="53" name="PH5"/>
+        <pin position="54" name="PA3"/>
+        <pin position="55" name="VSS" type="power"/>
+        <pin position="56" name="VDD" type="power"/>
+        <pin position="57" name="PA4"/>
+        <pin position="58" name="PA5"/>
+        <pin position="59" name="PA6"/>
+        <pin position="60" name="PA7"/>
+        <pin position="61" name="PC4"/>
+        <pin position="62" name="PC5"/>
+        <pin position="63" name="PB0"/>
+        <pin position="64" name="PB1"/>
+        <pin position="65" name="PB2"/>
+        <pin position="66" name="PI15"/>
+        <pin position="67" name="PF11"/>
+        <pin position="68" name="PF12"/>
+        <pin position="69" name="PF13"/>
+        <pin position="70" name="PF14"/>
+        <pin position="71" name="PF15"/>
+        <pin position="72" name="PG0"/>
+        <pin position="73" name="VSS" type="power"/>
+        <pin position="74" name="VDD" type="power"/>
+        <pin position="75" name="PG1"/>
+        <pin position="76" name="PE7"/>
+        <pin position="77" name="PE8"/>
+        <pin position="78" name="PE9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+        <pin position="81" name="PE10"/>
+        <pin position="82" name="PE11"/>
+        <pin position="83" name="PE12"/>
+        <pin position="84" name="PE13"/>
+        <pin position="85" name="PE14"/>
+        <pin position="86" name="PE15"/>
+        <pin position="87" name="PB10"/>
+        <pin position="88" name="PB11"/>
+        <pin position="89" name="VCAP" type="power"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDDLDO" type="power"/>
+        <pin position="92" name="PH6"/>
+        <pin position="93" name="PH7"/>
+        <pin position="94" name="PH8"/>
+        <pin position="95" name="PH9"/>
+        <pin position="96" name="PH10"/>
+        <pin position="97" name="PH11"/>
+        <pin position="98" name="PH12"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+        <pin position="101" name="PB12"/>
+        <pin position="102" name="PB13"/>
+        <pin position="103" name="PB14"/>
+        <pin position="104" name="PB15"/>
+        <pin position="105" name="PD8"/>
+        <pin position="106" name="PD9"/>
+        <pin position="107" name="PD10"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="VSS" type="power"/>
+        <pin position="110" name="PD11"/>
+        <pin position="111" name="PD12"/>
+        <pin position="112" name="PD13"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD" type="power"/>
+        <pin position="115" name="PD14"/>
+        <pin position="116" name="PD15"/>
+        <pin position="117" name="PJ6"/>
+        <pin position="118" name="PJ7"/>
+        <pin position="119" name="VDD" type="power"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="PJ8"/>
+        <pin position="122" name="PJ9"/>
+        <pin position="123" name="PJ10"/>
+        <pin position="124" name="PJ11"/>
+        <pin position="125" name="VDD" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="PK0"/>
+        <pin position="128" name="PK1"/>
+        <pin position="129" name="PK2"/>
+        <pin position="130" name="PG2"/>
+        <pin position="131" name="PG3"/>
+        <pin position="132" name="VSS" type="power"/>
+        <pin position="133" name="VDD" type="power"/>
+        <pin position="134" name="PG4"/>
+        <pin position="135" name="PG5"/>
+        <pin position="136" name="PG6"/>
+        <pin position="137" name="PG7"/>
+        <pin position="138" name="PG8"/>
+        <pin position="139" name="VSS" type="power"/>
+        <pin position="140" name="VDD50_USB" type="power"/>
+        <pin position="141" name="VDD33_USB" type="power"/>
+        <pin position="142" name="PC6"/>
+        <pin position="143" name="PC7"/>
+        <pin position="144" name="PC8"/>
+        <pin position="145" name="PC9"/>
+        <pin position="146" name="PA8"/>
+        <pin position="147" name="PA9"/>
+        <pin position="148" name="PA10"/>
+        <pin position="149" name="PA11"/>
+        <pin position="150" name="PA12"/>
+        <pin position="151" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="152" name="VCAP" type="power"/>
+        <pin position="153" name="VSS" type="power"/>
+        <pin position="154" name="VDDLDO" type="power"/>
+        <pin position="155" name="VDD" type="power"/>
+        <pin position="156" name="PH13"/>
+        <pin position="157" name="PH14"/>
+        <pin position="158" name="PH15"/>
+        <pin position="159" name="PI0"/>
+        <pin position="160" name="VSS" type="power"/>
+        <pin position="161" name="VDD" type="power"/>
+        <pin position="162" name="PI1"/>
+        <pin position="163" name="PI2"/>
+        <pin position="164" name="PI3"/>
+        <pin position="165" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="166" name="PA15 (JTDI)"/>
+        <pin position="167" name="PC10"/>
+        <pin position="168" name="PC11"/>
+        <pin position="169" name="PC12"/>
+        <pin position="170" name="PD0"/>
+        <pin position="171" name="PD1"/>
+        <pin position="172" name="PD2"/>
+        <pin position="173" name="PD3"/>
+        <pin position="174" name="PD4"/>
+        <pin position="175" name="PD5"/>
+        <pin position="176" name="PD6"/>
+        <pin position="177" name="PD7"/>
+        <pin position="178" name="VSS" type="power"/>
+        <pin position="179" name="VDD" type="power"/>
+        <pin position="180" name="PG9"/>
+        <pin position="181" name="PG10"/>
+        <pin position="182" name="PG11"/>
+        <pin position="183" name="PG12"/>
+        <pin position="184" name="PG13"/>
+        <pin position="185" name="PG14"/>
+        <pin position="186" name="VSS" type="power"/>
+        <pin position="187" name="VDD" type="power"/>
+        <pin position="188" name="PG15"/>
+        <pin position="189" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="190" name="PB4 (NJTRST)"/>
+        <pin position="191" name="PB5"/>
+        <pin position="192" name="PB6"/>
+        <pin position="193" name="PB7"/>
+        <pin position="194" name="BOOT0" type="boot"/>
+        <pin position="195" name="PB8"/>
+        <pin position="196" name="PB9"/>
+        <pin position="197" name="PE0"/>
+        <pin position="198" name="PE1"/>
+        <pin position="199" name="VCAP" type="power"/>
+        <pin position="200" name="VSS" type="power"/>
+        <pin position="201" name="PDR_ON" type="reset"/>
+        <pin position="202" name="VDDLDO" type="power"/>
+        <pin position="203" name="PI4"/>
+        <pin position="204" name="PI5"/>
+        <pin position="205" name="PI6"/>
+        <pin position="206" name="PI7"/>
+        <pin position="207" name="VSS" type="power"/>
+        <pin position="208" name="VDD" type="power"/>
+      </package>
+      <package device-pin="x" name="TFBGA240">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PI4"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="VDDLDO" type="power"/>
+        <pin position="A7" name="VCAP" type="power"/>
+        <pin position="A8" name="PK5"/>
+        <pin position="A9" name="PG10"/>
+        <pin position="A10" name="PG9"/>
+        <pin position="A11" name="PD5"/>
+        <pin position="A12" name="PD4"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PA15 (JTDI)"/>
+        <pin position="A15" name="PI1"/>
+        <pin position="A16" name="PI0"/>
+        <pin position="A17" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PI7"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PB4 (NJTRST)"/>
+        <pin position="B8" name="PK4"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PJ15"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD3"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B15" name="PI2"/>
+        <pin position="B16" name="PH15"/>
+        <pin position="B17" name="PH14"/>
+        <pin position="C1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PK6"/>
+        <pin position="C8" name="PK3"/>
+        <pin position="C9" name="PG12"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PD7"/>
+        <pin position="C12" name="PC12"/>
+        <pin position="C13" name="VSS" type="power"/>
+        <pin position="C14" name="PI3"/>
+        <pin position="C15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C16" name="VSS" type="power"/>
+        <pin position="C17" name="VDDLDO" type="power"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE4"/>
+        <pin position="D3" name="PE3"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PG15"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG14"/>
+        <pin position="D9" name="PG13"/>
+        <pin position="D10" name="PJ14"/>
+        <pin position="D11" name="PJ12"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PD0"/>
+        <pin position="D14" name="PA10"/>
+        <pin position="D15" name="PA9"/>
+        <pin position="D16" name="PH13"/>
+        <pin position="D17" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PI8"/>
+        <pin position="E5" name="PE6"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="BOOT0" type="boot"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PJ13"/>
+        <pin position="E11" name="VDD" type="power"/>
+        <pin position="E12" name="PD1"/>
+        <pin position="E13" name="PC8"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PA8"/>
+        <pin position="E16" name="PA12"/>
+        <pin position="E17" name="PA11"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PI11"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F13" name="PC7"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="F16" name="PG7"/>
+        <pin position="F17" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF2"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG6"/>
+        <pin position="G16" name="VSS" type="power"/>
+        <pin position="G17" name="VDD50_USB" type="power"/>
+        <pin position="H1" name="PI12"/>
+        <pin position="H2" name="PI13"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG4"/>
+        <pin position="H15" name="PG3"/>
+        <pin position="H16" name="PG2"/>
+        <pin position="H17" name="PK2"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="VSS" type="power"/>
+        <pin position="J4" name="PF5"/>
+        <pin position="J5" name="PF4"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PK0"/>
+        <pin position="J15" name="PK1"/>
+        <pin position="J16" name="VSS" type="power"/>
+        <pin position="J17" name="VSS" type="power"/>
+        <pin position="K1" name="NRST" type="reset"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF7"/>
+        <pin position="K4" name="PF8"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K13" name="VDD" type="power"/>
+        <pin position="K14" name="PJ11"/>
+        <pin position="K15" name="VSS" type="power"/>
+        <pin position="K16" name="NC" type="nc"/>
+        <pin position="K17" name="NC" type="nc"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PF10"/>
+        <pin position="L4" name="PF9"/>
+        <pin position="L5" name="VDD" type="power"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="VSS" type="power"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VSS" type="power"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="L14" name="PJ10"/>
+        <pin position="L15" name="VSS" type="power"/>
+        <pin position="L16" name="NC" type="nc"/>
+        <pin position="L17" name="NC" type="nc"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PC2"/>
+        <pin position="M4" name="PC3"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M13" name="VDD" type="power"/>
+        <pin position="M14" name="PJ9"/>
+        <pin position="M15" name="VSS" type="power"/>
+        <pin position="M16" name="NC" type="nc"/>
+        <pin position="M17" name="NC" type="nc"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA2"/>
+        <pin position="N4" name="PA1"/>
+        <pin position="N5" name="PA0"/>
+        <pin position="N6" name="PJ0"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="PE10"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="VDD" type="power"/>
+        <pin position="N13" name="PJ8"/>
+        <pin position="N14" name="PJ7"/>
+        <pin position="N15" name="PJ6"/>
+        <pin position="N16" name="VSS" type="power"/>
+        <pin position="N17" name="NC" type="nc"/>
+        <pin position="P1" name="VSSA" type="power"/>
+        <pin position="P2" name="PH3"/>
+        <pin position="P3" name="PH4"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PI15"/>
+        <pin position="P6" name="PJ1"/>
+        <pin position="P7" name="PF13"/>
+        <pin position="P8" name="PF14"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PB10"/>
+        <pin position="P12" name="PB11"/>
+        <pin position="P13" name="PH10"/>
+        <pin position="P14" name="PH11"/>
+        <pin position="P15" name="PD15"/>
+        <pin position="P16" name="PD14"/>
+        <pin position="P17" name="VDD" type="power"/>
+        <pin position="R1" name="PC2_C"/>
+        <pin position="R2" name="PC3_C"/>
+        <pin position="R3" name="PA6"/>
+        <pin position="R4" name="VSS" type="power"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PF12"/>
+        <pin position="R8" name="VSS" type="power"/>
+        <pin position="R9" name="PF15"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PJ5"/>
+        <pin position="R13" name="PH9"/>
+        <pin position="R14" name="PH12"/>
+        <pin position="R15" name="PD11"/>
+        <pin position="R16" name="PD12"/>
+        <pin position="R17" name="PD13"/>
+        <pin position="T1" name="PA0_C"/>
+        <pin position="T2" name="PA1_C"/>
+        <pin position="T3" name="PA5"/>
+        <pin position="T4" name="PC4"/>
+        <pin position="T5" name="PB1"/>
+        <pin position="T6" name="PJ2"/>
+        <pin position="T7" name="PF11"/>
+        <pin position="T8" name="PG0"/>
+        <pin position="T9" name="PE8"/>
+        <pin position="T10" name="PE13"/>
+        <pin position="T11" name="PH6"/>
+        <pin position="T12" name="VSS" type="power"/>
+        <pin position="T13" name="PH8"/>
+        <pin position="T14" name="PB12"/>
+        <pin position="T15" name="PB15"/>
+        <pin position="T16" name="PD10"/>
+        <pin position="T17" name="PD9"/>
+        <pin position="U1" name="VSS" type="power"/>
+        <pin position="U2" name="PA3"/>
+        <pin position="U3" name="PA4"/>
+        <pin position="U4" name="PC5"/>
+        <pin position="U5" name="PB0"/>
+        <pin position="U6" name="PJ3"/>
+        <pin position="U7" name="PJ4"/>
+        <pin position="U8" name="PG1"/>
+        <pin position="U9" name="PE7"/>
+        <pin position="U10" name="PE14"/>
+        <pin position="U11" name="VCAP" type="power"/>
+        <pin position="U12" name="VDDLDO" type="power"/>
+        <pin position="U13" name="PH7"/>
+        <pin position="U14" name="PB13"/>
+        <pin position="U15" name="PB14"/>
+        <pin position="U16" name="PD8"/>
+        <pin position="U17" name="VSS" type="power"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PB8"/>
+        <pin position="A3" name="VDDLDO" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="PG11"/>
+        <pin position="A8" name="PG9"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PA15 (JTDI)"/>
+        <pin position="A12" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A13" name="VDDLDO" type="power"/>
+        <pin position="A14" name="VCAP" type="power"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB4 (NJTRST)"/>
+        <pin position="B7" name="PG13"/>
+        <pin position="B8" name="PD7"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PD2"/>
+        <pin position="B11" name="PC12"/>
+        <pin position="B12" name="PH14"/>
+        <pin position="B13" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B14" name="PA8"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD0"/>
+        <pin position="C11" name="PC11"/>
+        <pin position="C12" name="PC10"/>
+        <pin position="C13" name="PH13"/>
+        <pin position="C14" name="PA10"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="D2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PDR_ON" type="reset"/>
+        <pin position="D5" name="VDD" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PG15"/>
+        <pin position="D8" name="PG12"/>
+        <pin position="D9" name="PD6"/>
+        <pin position="D10" name="VSS" type="power"/>
+        <pin position="D11" name="VDD" type="power"/>
+        <pin position="D12" name="PH15"/>
+        <pin position="D13" name="PA9"/>
+        <pin position="D14" name="PC8"/>
+        <pin position="D15" name="PC7"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E12" name="VDD" type="power"/>
+        <pin position="E13" name="PC9"/>
+        <pin position="E14" name="PC6"/>
+        <pin position="E15" name="VDD50_USB" type="power"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PF1"/>
+        <pin position="F4" name="PF0"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VDD33_USB" type="power"/>
+        <pin position="F14" name="PG6"/>
+        <pin position="F15" name="PG5"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="PG8"/>
+        <pin position="G13" name="PG7"/>
+        <pin position="G14" name="PG4"/>
+        <pin position="G15" name="PG2"/>
+        <pin position="H1" name="PF6"/>
+        <pin position="H2" name="PF4"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VDD" type="power"/>
+        <pin position="H13" name="PG3"/>
+        <pin position="H14" name="PD14"/>
+        <pin position="H15" name="PD13"/>
+        <pin position="J1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J2" name="PF8"/>
+        <pin position="J3" name="PF7"/>
+        <pin position="J4" name="PF9"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD11"/>
+        <pin position="J14" name="VSS" type="power"/>
+        <pin position="J15" name="PD12"/>
+        <pin position="K1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PF10"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="VSS" type="power"/>
+        <pin position="K13" name="PD9"/>
+        <pin position="K14" name="PB15"/>
+        <pin position="K15" name="PB14"/>
+        <pin position="L1" name="NRST" type="reset"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PC1"/>
+        <pin position="L4" name="VREF-" type="power"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD8"/>
+        <pin position="L15" name="PB13"/>
+        <pin position="M1" name="PC2"/>
+        <pin position="M2" name="PC3"/>
+        <pin position="M3" name="VREF+" type="monoio"/>
+        <pin position="M4" name="VDDA" type="power"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M6" name="VSS" type="power"/>
+        <pin position="M7" name="PC5"/>
+        <pin position="M8" name="PB1"/>
+        <pin position="M9" name="VDD" type="power"/>
+        <pin position="M10" name="VSS" type="power"/>
+        <pin position="M11" name="PH7"/>
+        <pin position="M12" name="PE14"/>
+        <pin position="M13" name="PH11"/>
+        <pin position="M14" name="PH9"/>
+        <pin position="M15" name="PB12"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="VSSA" type="power"/>
+        <pin position="N4" name="PH2"/>
+        <pin position="N5" name="PA3"/>
+        <pin position="N6" name="PA7"/>
+        <pin position="N7" name="PF11"/>
+        <pin position="N8" name="PE8"/>
+        <pin position="N9" name="PG1"/>
+        <pin position="N10" name="PF15"/>
+        <pin position="N11" name="PF13"/>
+        <pin position="N12" name="PB10"/>
+        <pin position="N13" name="PH8"/>
+        <pin position="N14" name="PH10"/>
+        <pin position="N15" name="PH12"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA1_C"/>
+        <pin position="P4" name="PH4"/>
+        <pin position="P5" name="PA4"/>
+        <pin position="P6" name="PA5"/>
+        <pin position="P7" name="PB2"/>
+        <pin position="P8" name="PG0"/>
+        <pin position="P9" name="PE7"/>
+        <pin position="P10" name="PB11"/>
+        <pin position="P11" name="PF12"/>
+        <pin position="P12" name="PE12"/>
+        <pin position="P13" name="PE13"/>
+        <pin position="P14" name="PE15"/>
+        <pin position="P15" name="PH6"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA0_C"/>
+        <pin position="R4" name="PH3"/>
+        <pin position="R5" name="PH5"/>
+        <pin position="R6" name="PC4"/>
+        <pin position="R7" name="PA6"/>
+        <pin position="R8" name="PB0"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PF14"/>
+        <pin position="R11" name="PE9"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="VCAP" type="power"/>
+        <pin position="R14" name="VDDLDO" type="power"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -2180,6 +2180,990 @@
       <gpio device-pin="x" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="i" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PC13"/>
+        <pin position="10" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="11" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="VSSSMPS" type="power"/>
+        <pin position="15" name="VLXSMPS" type="power"/>
+        <pin position="16" name="VDDSMPS" type="power"/>
+        <pin position="17" name="VFBSMPS" type="power"/>
+        <pin position="18" name="PF0"/>
+        <pin position="19" name="PF1"/>
+        <pin position="20" name="PF2"/>
+        <pin position="21" name="PF3"/>
+        <pin position="22" name="PF4"/>
+        <pin position="23" name="PF5"/>
+        <pin position="24" name="VSS" type="power"/>
+        <pin position="25" name="VDD" type="power"/>
+        <pin position="26" name="PF6"/>
+        <pin position="27" name="PF7"/>
+        <pin position="28" name="PF8"/>
+        <pin position="29" name="PF9"/>
+        <pin position="30" name="PF10"/>
+        <pin position="31" name="PH0-OSC_IN (PH0)"/>
+        <pin position="32" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="33" name="NRST" type="reset"/>
+        <pin position="34" name="PC0"/>
+        <pin position="35" name="PC1"/>
+        <pin position="36" name="PC2_C"/>
+        <pin position="37" name="PC3_C"/>
+        <pin position="38" name="VSSA" type="power"/>
+        <pin position="39" name="VREF+" type="monoio"/>
+        <pin position="40" name="VDDA" type="power"/>
+        <pin position="41" name="PA0"/>
+        <pin position="42" name="PA1"/>
+        <pin position="43" name="PA2"/>
+        <pin position="44" name="VDD" type="power"/>
+        <pin position="45" name="VSS" type="power"/>
+        <pin position="46" name="PA3"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA4"/>
+        <pin position="50" name="PA5"/>
+        <pin position="51" name="PA6"/>
+        <pin position="52" name="PA7"/>
+        <pin position="53" name="PC4"/>
+        <pin position="54" name="PC5"/>
+        <pin position="55" name="PB0"/>
+        <pin position="56" name="PB1"/>
+        <pin position="57" name="PB2"/>
+        <pin position="58" name="PF11"/>
+        <pin position="59" name="PF12"/>
+        <pin position="60" name="PF13"/>
+        <pin position="61" name="PF14"/>
+        <pin position="62" name="PF15"/>
+        <pin position="63" name="PG0"/>
+        <pin position="64" name="VSS" type="power"/>
+        <pin position="65" name="VDD" type="power"/>
+        <pin position="66" name="PG1"/>
+        <pin position="67" name="PE7"/>
+        <pin position="68" name="PE8"/>
+        <pin position="69" name="PE9"/>
+        <pin position="70" name="VSS" type="power"/>
+        <pin position="71" name="VDD" type="power"/>
+        <pin position="72" name="PE10"/>
+        <pin position="73" name="PE11"/>
+        <pin position="74" name="PE12"/>
+        <pin position="75" name="PE13"/>
+        <pin position="76" name="PE14"/>
+        <pin position="77" name="PE15"/>
+        <pin position="78" name="PB10"/>
+        <pin position="79" name="PB11"/>
+        <pin position="80" name="VCAP" type="power"/>
+        <pin position="81" name="VSS" type="power"/>
+        <pin position="82" name="VDDLDO" type="power"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PB12"/>
+        <pin position="86" name="PB13"/>
+        <pin position="87" name="PB14"/>
+        <pin position="88" name="PB15"/>
+        <pin position="89" name="PD8"/>
+        <pin position="90" name="PD9"/>
+        <pin position="91" name="PD10"/>
+        <pin position="92" name="VDD" type="power"/>
+        <pin position="93" name="VSS" type="power"/>
+        <pin position="94" name="PD11"/>
+        <pin position="95" name="PD12"/>
+        <pin position="96" name="PD13"/>
+        <pin position="97" name="PD14"/>
+        <pin position="98" name="PD15"/>
+        <pin position="99" name="VDD" type="power"/>
+        <pin position="100" name="VSS" type="power"/>
+        <pin position="101" name="VCAPDSI" type="power"/>
+        <pin position="102" name="VDD12DSI" type="power"/>
+        <pin position="103" name="DSI_D0P" type="monoio"/>
+        <pin position="104" name="DSI_D0N" type="monoio"/>
+        <pin position="105" name="VSSDSI" type="power"/>
+        <pin position="106" name="DSI_CKP" type="monoio"/>
+        <pin position="107" name="DSI_CKN" type="monoio"/>
+        <pin position="108" name="VDD12DSI" type="power"/>
+        <pin position="109" name="VSSDSI" type="power"/>
+        <pin position="110" name="PG2"/>
+        <pin position="111" name="PG3"/>
+        <pin position="112" name="VSS" type="power"/>
+        <pin position="113" name="VDD" type="power"/>
+        <pin position="114" name="PG4"/>
+        <pin position="115" name="PG5"/>
+        <pin position="116" name="PG6"/>
+        <pin position="117" name="PG7"/>
+        <pin position="118" name="PG8"/>
+        <pin position="119" name="VSS" type="power"/>
+        <pin position="120" name="VDD50_USB" type="power"/>
+        <pin position="121" name="VDD33_USB" type="power"/>
+        <pin position="122" name="PC6"/>
+        <pin position="123" name="PC7"/>
+        <pin position="124" name="PC8"/>
+        <pin position="125" name="PC9"/>
+        <pin position="126" name="VDD" type="power"/>
+        <pin position="127" name="PA8"/>
+        <pin position="128" name="PA9"/>
+        <pin position="129" name="PA10"/>
+        <pin position="130" name="PA11"/>
+        <pin position="131" name="PA12"/>
+        <pin position="132" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="133" name="VCAP" type="power"/>
+        <pin position="134" name="VSS" type="power"/>
+        <pin position="135" name="VDDLDO" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="VSS" type="power"/>
+        <pin position="138" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="139" name="PA15 (JTDI)"/>
+        <pin position="140" name="PC10"/>
+        <pin position="141" name="PC11"/>
+        <pin position="142" name="PC12"/>
+        <pin position="143" name="PD0"/>
+        <pin position="144" name="PD1"/>
+        <pin position="145" name="PD2"/>
+        <pin position="146" name="PD3"/>
+        <pin position="147" name="PD4"/>
+        <pin position="148" name="PD5"/>
+        <pin position="149" name="PD6"/>
+        <pin position="150" name="PD7"/>
+        <pin position="151" name="VSS" type="power"/>
+        <pin position="152" name="VDD" type="power"/>
+        <pin position="153" name="PG9"/>
+        <pin position="154" name="PG10"/>
+        <pin position="155" name="PG11"/>
+        <pin position="156" name="PG12"/>
+        <pin position="157" name="PG13"/>
+        <pin position="158" name="PG14"/>
+        <pin position="159" name="VSS" type="power"/>
+        <pin position="160" name="VDD" type="power"/>
+        <pin position="161" name="PG15"/>
+        <pin position="162" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="163" name="PB4 (NJTRST)"/>
+        <pin position="164" name="PB5"/>
+        <pin position="165" name="PB6"/>
+        <pin position="166" name="PB7"/>
+        <pin position="167" name="BOOT0" type="boot"/>
+        <pin position="168" name="PB8"/>
+        <pin position="169" name="PB9"/>
+        <pin position="170" name="PE0"/>
+        <pin position="171" name="PE1"/>
+        <pin position="172" name="VCAP" type="power"/>
+        <pin position="173" name="VSS" type="power"/>
+        <pin position="174" name="PDR_ON" type="reset"/>
+        <pin position="175" name="VDDLDO" type="power"/>
+        <pin position="176" name="VDD" type="power"/>
+      </package>
+      <package device-pin="b" name="LQFP208">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VSS" type="power"/>
+        <pin position="7" name="VDD" type="power"/>
+        <pin position="8" name="VBAT" type="power"/>
+        <pin position="9" name="PI8"/>
+        <pin position="10" name="PC13"/>
+        <pin position="11" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="12" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="13" name="PI9"/>
+        <pin position="14" name="PI10"/>
+        <pin position="15" name="PI11"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="VSSSMPS" type="power"/>
+        <pin position="19" name="VLXSMPS" type="power"/>
+        <pin position="20" name="VDDSMPS" type="power"/>
+        <pin position="21" name="VFBSMPS" type="power"/>
+        <pin position="22" name="PF0"/>
+        <pin position="23" name="PF1"/>
+        <pin position="24" name="PF2"/>
+        <pin position="25" name="PF3"/>
+        <pin position="26" name="PF4"/>
+        <pin position="27" name="PF5"/>
+        <pin position="28" name="VSS" type="power"/>
+        <pin position="29" name="VDD" type="power"/>
+        <pin position="30" name="PF6"/>
+        <pin position="31" name="PF7"/>
+        <pin position="32" name="PF8"/>
+        <pin position="33" name="PF9"/>
+        <pin position="34" name="PF10"/>
+        <pin position="35" name="PH0-OSC_IN (PH0)"/>
+        <pin position="36" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="37" name="NRST" type="reset"/>
+        <pin position="38" name="PC0"/>
+        <pin position="39" name="PC1"/>
+        <pin position="40" name="PC2_C"/>
+        <pin position="41" name="PC3_C"/>
+        <pin position="42" name="VSSA" type="power"/>
+        <pin position="43" name="VREF+" type="monoio"/>
+        <pin position="44" name="VDDA" type="power"/>
+        <pin position="45" name="PA0"/>
+        <pin position="46" name="PA1"/>
+        <pin position="47" name="PA2"/>
+        <pin position="48" name="PH2"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="VSS" type="power"/>
+        <pin position="51" name="PH3"/>
+        <pin position="52" name="PH4"/>
+        <pin position="53" name="PH5"/>
+        <pin position="54" name="PA3"/>
+        <pin position="55" name="VSS" type="power"/>
+        <pin position="56" name="VDD" type="power"/>
+        <pin position="57" name="PA4"/>
+        <pin position="58" name="PA5"/>
+        <pin position="59" name="PA6"/>
+        <pin position="60" name="PA7"/>
+        <pin position="61" name="PC4"/>
+        <pin position="62" name="PC5"/>
+        <pin position="63" name="PB0"/>
+        <pin position="64" name="PB1"/>
+        <pin position="65" name="PB2"/>
+        <pin position="66" name="PI15"/>
+        <pin position="67" name="PF11"/>
+        <pin position="68" name="PF12"/>
+        <pin position="69" name="PF13"/>
+        <pin position="70" name="PF14"/>
+        <pin position="71" name="PF15"/>
+        <pin position="72" name="PG0"/>
+        <pin position="73" name="VSS" type="power"/>
+        <pin position="74" name="VDD" type="power"/>
+        <pin position="75" name="PG1"/>
+        <pin position="76" name="PE7"/>
+        <pin position="77" name="PE8"/>
+        <pin position="78" name="PE9"/>
+        <pin position="79" name="VSS" type="power"/>
+        <pin position="80" name="VDD" type="power"/>
+        <pin position="81" name="PE10"/>
+        <pin position="82" name="PE11"/>
+        <pin position="83" name="PE12"/>
+        <pin position="84" name="PE13"/>
+        <pin position="85" name="PE14"/>
+        <pin position="86" name="PE15"/>
+        <pin position="87" name="PB10"/>
+        <pin position="88" name="PB11"/>
+        <pin position="89" name="VCAP" type="power"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDDLDO" type="power"/>
+        <pin position="92" name="PH6"/>
+        <pin position="93" name="PH7"/>
+        <pin position="94" name="PH8"/>
+        <pin position="95" name="PH9"/>
+        <pin position="96" name="PH10"/>
+        <pin position="97" name="PH11"/>
+        <pin position="98" name="PH12"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+        <pin position="101" name="PB12"/>
+        <pin position="102" name="PB13"/>
+        <pin position="103" name="PB14"/>
+        <pin position="104" name="PB15"/>
+        <pin position="105" name="PD8"/>
+        <pin position="106" name="PD9"/>
+        <pin position="107" name="PD10"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="VSS" type="power"/>
+        <pin position="110" name="PD11"/>
+        <pin position="111" name="PD12"/>
+        <pin position="112" name="PD13"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD" type="power"/>
+        <pin position="115" name="PD14"/>
+        <pin position="116" name="PD15"/>
+        <pin position="117" name="VDD" type="power"/>
+        <pin position="118" name="VSS" type="power"/>
+        <pin position="119" name="VCAPDSI" type="power"/>
+        <pin position="120" name="VDD12DSI" type="power"/>
+        <pin position="121" name="DSI_D0P" type="monoio"/>
+        <pin position="122" name="DSI_D0N" type="monoio"/>
+        <pin position="123" name="VSSDSI" type="power"/>
+        <pin position="124" name="DSI_CKP" type="monoio"/>
+        <pin position="125" name="DSI_CKN" type="monoio"/>
+        <pin position="126" name="VDD12DSI" type="power"/>
+        <pin position="127" name="DSI_D1P" type="monoio"/>
+        <pin position="128" name="DSI_D1N" type="monoio"/>
+        <pin position="129" name="VSSDSI" type="power"/>
+        <pin position="130" name="PG2"/>
+        <pin position="131" name="PG3"/>
+        <pin position="132" name="VSS" type="power"/>
+        <pin position="133" name="VDD" type="power"/>
+        <pin position="134" name="PG4"/>
+        <pin position="135" name="PG5"/>
+        <pin position="136" name="PG6"/>
+        <pin position="137" name="PG7"/>
+        <pin position="138" name="PG8"/>
+        <pin position="139" name="VSS" type="power"/>
+        <pin position="140" name="VDD50_USB" type="power"/>
+        <pin position="141" name="VDD33_USB" type="power"/>
+        <pin position="142" name="PC6"/>
+        <pin position="143" name="PC7"/>
+        <pin position="144" name="PC8"/>
+        <pin position="145" name="PC9"/>
+        <pin position="146" name="PA8"/>
+        <pin position="147" name="PA9"/>
+        <pin position="148" name="PA10"/>
+        <pin position="149" name="PA11"/>
+        <pin position="150" name="PA12"/>
+        <pin position="151" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="152" name="VCAP" type="power"/>
+        <pin position="153" name="VSS" type="power"/>
+        <pin position="154" name="VDDLDO" type="power"/>
+        <pin position="155" name="VDD" type="power"/>
+        <pin position="156" name="PH13"/>
+        <pin position="157" name="PH14"/>
+        <pin position="158" name="PH15"/>
+        <pin position="159" name="PI0"/>
+        <pin position="160" name="VSS" type="power"/>
+        <pin position="161" name="VDD" type="power"/>
+        <pin position="162" name="PI1"/>
+        <pin position="163" name="PI2"/>
+        <pin position="164" name="PI3"/>
+        <pin position="165" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="166" name="PA15 (JTDI)"/>
+        <pin position="167" name="PC10"/>
+        <pin position="168" name="PC11"/>
+        <pin position="169" name="PC12"/>
+        <pin position="170" name="PD0"/>
+        <pin position="171" name="PD1"/>
+        <pin position="172" name="PD2"/>
+        <pin position="173" name="PD3"/>
+        <pin position="174" name="PD4"/>
+        <pin position="175" name="PD5"/>
+        <pin position="176" name="PD6"/>
+        <pin position="177" name="PD7"/>
+        <pin position="178" name="VSS" type="power"/>
+        <pin position="179" name="VDD" type="power"/>
+        <pin position="180" name="PG9"/>
+        <pin position="181" name="PG10"/>
+        <pin position="182" name="PG11"/>
+        <pin position="183" name="PG12"/>
+        <pin position="184" name="PG13"/>
+        <pin position="185" name="PG14"/>
+        <pin position="186" name="VSS" type="power"/>
+        <pin position="187" name="VDD" type="power"/>
+        <pin position="188" name="PG15"/>
+        <pin position="189" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="190" name="PB4 (NJTRST)"/>
+        <pin position="191" name="PB5"/>
+        <pin position="192" name="PB6"/>
+        <pin position="193" name="PB7"/>
+        <pin position="194" name="BOOT0" type="boot"/>
+        <pin position="195" name="PB8"/>
+        <pin position="196" name="PB9"/>
+        <pin position="197" name="PE0"/>
+        <pin position="198" name="PE1"/>
+        <pin position="199" name="VCAP" type="power"/>
+        <pin position="200" name="VSS" type="power"/>
+        <pin position="201" name="PDR_ON" type="reset"/>
+        <pin position="202" name="VDDLDO" type="power"/>
+        <pin position="203" name="PI4"/>
+        <pin position="204" name="PI5"/>
+        <pin position="205" name="PI6"/>
+        <pin position="206" name="PI7"/>
+        <pin position="207" name="VSS" type="power"/>
+        <pin position="208" name="VDD" type="power"/>
+      </package>
+      <package device-pin="x" name="TFBGA240">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PI4"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="VDDLDO" type="power"/>
+        <pin position="A7" name="VCAP" type="power"/>
+        <pin position="A8" name="PK5"/>
+        <pin position="A9" name="PG10"/>
+        <pin position="A10" name="PG9"/>
+        <pin position="A11" name="PD5"/>
+        <pin position="A12" name="PD4"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PA15 (JTDI)"/>
+        <pin position="A15" name="PI1"/>
+        <pin position="A16" name="PI0"/>
+        <pin position="A17" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PI7"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PB4 (NJTRST)"/>
+        <pin position="B8" name="PK4"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PJ15"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD3"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B15" name="PI2"/>
+        <pin position="B16" name="PH15"/>
+        <pin position="B17" name="PH14"/>
+        <pin position="C1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PK6"/>
+        <pin position="C8" name="PK3"/>
+        <pin position="C9" name="PG12"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PD7"/>
+        <pin position="C12" name="PC12"/>
+        <pin position="C13" name="VSS" type="power"/>
+        <pin position="C14" name="PI3"/>
+        <pin position="C15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C16" name="VSS" type="power"/>
+        <pin position="C17" name="VDDLDO" type="power"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE4"/>
+        <pin position="D3" name="PE3"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PG15"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG14"/>
+        <pin position="D9" name="PG13"/>
+        <pin position="D10" name="PJ14"/>
+        <pin position="D11" name="PJ12"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PD0"/>
+        <pin position="D14" name="PA10"/>
+        <pin position="D15" name="PA9"/>
+        <pin position="D16" name="PH13"/>
+        <pin position="D17" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PI8"/>
+        <pin position="E5" name="PE6"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="BOOT0" type="boot"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PJ13"/>
+        <pin position="E11" name="VDD" type="power"/>
+        <pin position="E12" name="PD1"/>
+        <pin position="E13" name="PC8"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PA8"/>
+        <pin position="E16" name="PA12"/>
+        <pin position="E17" name="PA11"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PI11"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F13" name="PC7"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="F16" name="PG7"/>
+        <pin position="F17" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF2"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG6"/>
+        <pin position="G16" name="VSS" type="power"/>
+        <pin position="G17" name="VDD50_USB" type="power"/>
+        <pin position="H1" name="PI12"/>
+        <pin position="H2" name="PI13"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG4"/>
+        <pin position="H15" name="PG3"/>
+        <pin position="H16" name="PG2"/>
+        <pin position="H17" name="PK2"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="VSS" type="power"/>
+        <pin position="J4" name="PF5"/>
+        <pin position="J5" name="PF4"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PK0"/>
+        <pin position="J15" name="PK1"/>
+        <pin position="J16" name="VSS" type="power"/>
+        <pin position="J17" name="VSS" type="power"/>
+        <pin position="K1" name="NRST" type="reset"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF7"/>
+        <pin position="K4" name="PF8"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K13" name="VDD" type="power"/>
+        <pin position="K14" name="PJ11"/>
+        <pin position="K15" name="VSSDSI" type="power"/>
+        <pin position="K16" name="DSI_D1P" type="monoio"/>
+        <pin position="K17" name="DSI_D1N" type="monoio"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PF10"/>
+        <pin position="L4" name="PF9"/>
+        <pin position="L5" name="VDD" type="power"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="VSS" type="power"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VSS" type="power"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="L14" name="PJ10"/>
+        <pin position="L15" name="VSSDSI" type="power"/>
+        <pin position="L16" name="DSI_CKP" type="monoio"/>
+        <pin position="L17" name="DSI_CKN" type="monoio"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PC2"/>
+        <pin position="M4" name="PC3"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M13" name="VDD" type="power"/>
+        <pin position="M14" name="PJ9"/>
+        <pin position="M15" name="VSSDSI" type="power"/>
+        <pin position="M16" name="DSI_D0P" type="monoio"/>
+        <pin position="M17" name="DSI_D0N" type="monoio"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA2"/>
+        <pin position="N4" name="PA1"/>
+        <pin position="N5" name="PA0"/>
+        <pin position="N6" name="PJ0"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="PE10"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="VDD" type="power"/>
+        <pin position="N13" name="PJ8"/>
+        <pin position="N14" name="PJ7"/>
+        <pin position="N15" name="PJ6"/>
+        <pin position="N16" name="VSS" type="power"/>
+        <pin position="N17" name="VCAPDSI" type="power"/>
+        <pin position="P1" name="VSSA" type="power"/>
+        <pin position="P2" name="PH3"/>
+        <pin position="P3" name="PH4"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PI15"/>
+        <pin position="P6" name="PJ1"/>
+        <pin position="P7" name="PF13"/>
+        <pin position="P8" name="PF14"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PB10"/>
+        <pin position="P12" name="PB11"/>
+        <pin position="P13" name="PH10"/>
+        <pin position="P14" name="PH11"/>
+        <pin position="P15" name="PD15"/>
+        <pin position="P16" name="PD14"/>
+        <pin position="P17" name="VDDDSI" type="power"/>
+        <pin position="R1" name="PC2_C"/>
+        <pin position="R2" name="PC3_C"/>
+        <pin position="R3" name="PA6"/>
+        <pin position="R4" name="VSS" type="power"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PF12"/>
+        <pin position="R8" name="VSS" type="power"/>
+        <pin position="R9" name="PF15"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PJ5"/>
+        <pin position="R13" name="PH9"/>
+        <pin position="R14" name="PH12"/>
+        <pin position="R15" name="PD11"/>
+        <pin position="R16" name="PD12"/>
+        <pin position="R17" name="PD13"/>
+        <pin position="T1" name="PA0_C"/>
+        <pin position="T2" name="PA1_C"/>
+        <pin position="T3" name="PA5"/>
+        <pin position="T4" name="PC4"/>
+        <pin position="T5" name="PB1"/>
+        <pin position="T6" name="PJ2"/>
+        <pin position="T7" name="PF11"/>
+        <pin position="T8" name="PG0"/>
+        <pin position="T9" name="PE8"/>
+        <pin position="T10" name="PE13"/>
+        <pin position="T11" name="PH6"/>
+        <pin position="T12" name="VSS" type="power"/>
+        <pin position="T13" name="PH8"/>
+        <pin position="T14" name="PB12"/>
+        <pin position="T15" name="PB15"/>
+        <pin position="T16" name="PD10"/>
+        <pin position="T17" name="PD9"/>
+        <pin position="U1" name="VSS" type="power"/>
+        <pin position="U2" name="PA3"/>
+        <pin position="U3" name="PA4"/>
+        <pin position="U4" name="PC5"/>
+        <pin position="U5" name="PB0"/>
+        <pin position="U6" name="PJ3"/>
+        <pin position="U7" name="PJ4"/>
+        <pin position="U8" name="PG1"/>
+        <pin position="U9" name="PE7"/>
+        <pin position="U10" name="PE14"/>
+        <pin position="U11" name="VCAP" type="power"/>
+        <pin position="U12" name="VDDLDO" type="power"/>
+        <pin position="U13" name="PH7"/>
+        <pin position="U14" name="PB13"/>
+        <pin position="U15" name="PB14"/>
+        <pin position="U16" name="PD8"/>
+        <pin position="U17" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDDLDO" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="A10" name="PD3"/>
+        <pin position="A11" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="A13" name="PA10"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PDR_ON" type="reset"/>
+        <pin position="B4" name="VSS" type="power"/>
+        <pin position="B5" name="BOOT0" type="boot"/>
+        <pin position="B6" name="PB4 (NJTRST)"/>
+        <pin position="B7" name="VDD" type="power"/>
+        <pin position="B8" name="PD6"/>
+        <pin position="B9" name="VSS" type="power"/>
+        <pin position="B10" name="PA15 (JTDI)"/>
+        <pin position="B11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B12" name="VDD" type="power"/>
+        <pin position="B13" name="VDDLDO" type="power"/>
+        <pin position="C1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE3"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PG15"/>
+        <pin position="C7" name="PG9"/>
+        <pin position="C8" name="PD5"/>
+        <pin position="C9" name="PD1"/>
+        <pin position="C10" name="PD0"/>
+        <pin position="C11" name="PC10"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VCAP" type="power"/>
+        <pin position="D1" name="VSS" type="power"/>
+        <pin position="D2" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="D3" name="PE4"/>
+        <pin position="D4" name="PE0"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PB9"/>
+        <pin position="D7" name="PG10"/>
+        <pin position="D8" name="PD4"/>
+        <pin position="D9" name="PC12"/>
+        <pin position="D10" name="PA8"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA11"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VDD" type="power"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PB6"/>
+        <pin position="E6" name="PG14"/>
+        <pin position="E7" name="PG11"/>
+        <pin position="E8" name="PD2"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PC7"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="VDD" type="power"/>
+        <pin position="E13" name="VSS" type="power"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="VFBSMPS" type="power"/>
+        <pin position="F4" name="PF0"/>
+        <pin position="F5" name="PF1"/>
+        <pin position="F6" name="PF2"/>
+        <pin position="F7" name="PG13"/>
+        <pin position="F8" name="PG7"/>
+        <pin position="F9" name="PG8"/>
+        <pin position="F10" name="PC8"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDD50_USB" type="power"/>
+        <pin position="F13" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF4"/>
+        <pin position="G2" name="PF3"/>
+        <pin position="G3" name="PF5"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF7"/>
+        <pin position="G6" name="PF8"/>
+        <pin position="G7" name="PG12"/>
+        <pin position="G8" name="PG3"/>
+        <pin position="G9" name="PG5"/>
+        <pin position="G10" name="PG4"/>
+        <pin position="G11" name="PG6"/>
+        <pin position="G12" name="VSSDSI" type="power"/>
+        <pin position="G13" name="VSSDSI" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PF9"/>
+        <pin position="H4" name="PF10"/>
+        <pin position="H5" name="NRST" type="reset"/>
+        <pin position="H6" name="PB1"/>
+        <pin position="H7" name="PG2"/>
+        <pin position="H8" name="PE13"/>
+        <pin position="H9" name="PD14"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H12" name="DSI_D1P" type="monoio"/>
+        <pin position="H13" name="DSI_D1N" type="monoio"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC0"/>
+        <pin position="J5" name="PA5"/>
+        <pin position="J6" name="PF12"/>
+        <pin position="J7" name="PG1"/>
+        <pin position="J8" name="PE12"/>
+        <pin position="J9" name="PD13"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J12" name="DSI_CKP" type="monoio"/>
+        <pin position="J13" name="DSI_CKN" type="monoio"/>
+        <pin position="K1" name="PC2_C"/>
+        <pin position="K2" name="PC3_C"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA7"/>
+        <pin position="K5" name="PC5"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PE7"/>
+        <pin position="K8" name="PE15"/>
+        <pin position="K9" name="PB10"/>
+        <pin position="K10" name="PD11"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K12" name="DSI_D0P" type="monoio"/>
+        <pin position="K13" name="DSI_D0N" type="monoio"/>
+        <pin position="L1" name="VREF-" type="power"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin position="L3" name="PA1"/>
+        <pin position="L4" name="PC4"/>
+        <pin position="L5" name="PB2"/>
+        <pin position="L6" name="PG0"/>
+        <pin position="L7" name="PE10"/>
+        <pin position="L8" name="PE8"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="PB12"/>
+        <pin position="L11" name="VDD" type="power"/>
+        <pin position="L12" name="VCAPDSI" type="power"/>
+        <pin position="L13" name="VSS" type="power"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="VDD" type="power"/>
+        <pin position="M3" name="PA2"/>
+        <pin position="M4" name="PA6"/>
+        <pin position="M5" name="PF13"/>
+        <pin position="M6" name="VSS" type="power"/>
+        <pin position="M7" name="PF15"/>
+        <pin position="M8" name="PE14"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="PB13"/>
+        <pin position="M11" name="PB15"/>
+        <pin position="M12" name="PD9"/>
+        <pin position="M13" name="VDDDSI" type="power"/>
+        <pin position="N1" name="VSS" type="power"/>
+        <pin position="N2" name="PA3"/>
+        <pin position="N3" name="PA4"/>
+        <pin position="N4" name="PB0"/>
+        <pin position="N5" name="PF14"/>
+        <pin position="N6" name="PE9"/>
+        <pin position="N7" name="PE11"/>
+        <pin position="N8" name="PB11"/>
+        <pin position="N9" name="VCAP" type="power"/>
+        <pin position="N10" name="VDDLDO" type="power"/>
+        <pin position="N11" name="PB14"/>
+        <pin position="N12" name="PD8"/>
+        <pin position="N13" name="PD10"/>
+      </package>
+      <package device-pin="z" name="WLCSP156">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="VDDLDO" type="power"/>
+        <pin position="A3" name="PA15 (JTDI)"/>
+        <pin position="A4" name="PD0"/>
+        <pin position="A5" name="PD4"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A7" name="PG15"/>
+        <pin position="A8" name="PB4 (NJTRST)"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="A10" name="PB8"/>
+        <pin position="A11" name="VCAP" type="power"/>
+        <pin position="A12" name="VDDLDO" type="power"/>
+        <pin position="A13" name="DNC" type="nc"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="VCAP" type="power"/>
+        <pin position="B3" name="VDD" type="power"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PD3"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B8" name="PB5"/>
+        <pin position="B9" name="VSS" type="power"/>
+        <pin position="B10" name="PE0"/>
+        <pin position="B11" name="VDD" type="power"/>
+        <pin position="B12" name="PE4"/>
+        <pin position="B13" name="VBAT" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C4" name="VSS" type="power"/>
+        <pin position="C5" name="PC11"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PB6"/>
+        <pin position="C8" name="PB7"/>
+        <pin position="C9" name="PB9"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PE5"/>
+        <pin position="C12" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C13" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="D1" name="PC8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PC10"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="BOOT0" type="boot"/>
+        <pin position="D8" name="PE1"/>
+        <pin position="D9" name="PE2"/>
+        <pin position="D10" name="PE3"/>
+        <pin position="D11" name="VSS" type="power"/>
+        <pin position="D12" name="VSSSMPS" type="power"/>
+        <pin position="D13" name="VDD" type="power"/>
+        <pin position="E1" name="VDD33_USB" type="power"/>
+        <pin position="E2" name="VDD" type="power"/>
+        <pin position="E3" name="VDD50_USB" type="power"/>
+        <pin position="E4" name="PC7"/>
+        <pin position="E5" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="E6" name="PD2"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="PE6"/>
+        <pin position="E9" name="PC13"/>
+        <pin position="E10" name="PF0"/>
+        <pin position="E11" name="VFBSMPS" type="power"/>
+        <pin position="E12" name="VLXSMPS" type="power"/>
+        <pin position="E13" name="VDDSMPS" type="power"/>
+        <pin position="F1" name="PG5"/>
+        <pin position="F2" name="PG8"/>
+        <pin position="F3" name="VSS" type="power"/>
+        <pin position="F4" name="PG4"/>
+        <pin position="F5" name="PC6"/>
+        <pin position="F6" name="PD1"/>
+        <pin position="F7" name="PD5"/>
+        <pin position="F8" name="PF11"/>
+        <pin position="F9" name="PF1"/>
+        <pin position="F10" name="PF5"/>
+        <pin position="F11" name="PF4"/>
+        <pin position="F12" name="PF2"/>
+        <pin position="F13" name="PF3"/>
+        <pin position="G1" name="DSI_D1N" type="monoio"/>
+        <pin position="G2" name="DSI_D1P" type="monoio"/>
+        <pin position="G3" name="PG2"/>
+        <pin position="G4" name="PG3"/>
+        <pin position="G5" name="PD8"/>
+        <pin position="G6" name="PE11"/>
+        <pin position="G7" name="PE10"/>
+        <pin position="G8" name="PF12"/>
+        <pin position="G9" name="PA6"/>
+        <pin position="G10" name="PC1"/>
+        <pin position="G11" name="PC0"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="H1" name="DSI_CKN" type="monoio"/>
+        <pin position="H2" name="DSI_CKP" type="monoio"/>
+        <pin position="H3" name="VSSDSI" type="power"/>
+        <pin position="H4" name="PD14"/>
+        <pin position="H5" name="PB13"/>
+        <pin position="H6" name="PB10"/>
+        <pin position="H7" name="PE7"/>
+        <pin position="H8" name="PF13"/>
+        <pin position="H9" name="PB1"/>
+        <pin position="H10" name="PA5"/>
+        <pin position="H11" name="NRST" type="reset"/>
+        <pin position="H12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J1" name="DSI_D0N" type="monoio"/>
+        <pin position="J2" name="DSI_D0P" type="monoio"/>
+        <pin position="J3" name="PD15"/>
+        <pin position="J4" name="PD11"/>
+        <pin position="J5" name="PB12"/>
+        <pin position="J6" name="PE12"/>
+        <pin position="J7" name="PE8"/>
+        <pin position="J8" name="PF15"/>
+        <pin position="J9" name="PA7"/>
+        <pin position="J10" name="PA3"/>
+        <pin position="J11" name="VDDA" type="power"/>
+        <pin position="J12" name="VREF+" type="monoio"/>
+        <pin position="J13" name="VSSA" type="power"/>
+        <pin position="K1" name="VCAPDSI" type="power"/>
+        <pin position="K2" name="VDD" type="power"/>
+        <pin position="K3" name="PD13"/>
+        <pin position="K4" name="PD9"/>
+        <pin position="K5" name="PB11"/>
+        <pin position="K6" name="PE13"/>
+        <pin position="K7" name="PE9"/>
+        <pin position="K8" name="PF14"/>
+        <pin position="K9" name="PB0"/>
+        <pin position="K10" name="PA4"/>
+        <pin position="K11" name="PA2"/>
+        <pin position="K12" name="PC3_C"/>
+        <pin position="K13" name="PC2_C"/>
+        <pin position="L1" name="VSS" type="power"/>
+        <pin position="L2" name="PD12"/>
+        <pin position="L3" name="PD10"/>
+        <pin position="L4" name="VDDLDO" type="power"/>
+        <pin position="L5" name="VSS" type="power"/>
+        <pin position="L6" name="PE15"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="PG0"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="PC5"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L12" name="PA1"/>
+        <pin position="L13" name="PA0"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PB15"/>
+        <pin position="M3" name="PB14"/>
+        <pin position="M4" name="VDD" type="power"/>
+        <pin position="M5" name="VCAP" type="power"/>
+        <pin position="M6" name="PE14"/>
+        <pin position="M7" name="VDD" type="power"/>
+        <pin position="M8" name="PG1"/>
+        <pin position="M9" name="VDD" type="power"/>
+        <pin position="M10" name="PB2"/>
+        <pin position="M11" name="PC4"/>
+        <pin position="M12" name="VDD" type="power"/>
+        <pin position="M13" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-50.xml
+++ b/devices/stm32/stm32h7-50.xml
@@ -2176,6 +2176,902 @@
       <gpio device-pin="x" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="9" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33_USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="10" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN (PH0)"/>
+        <pin position="30" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2_C"/>
+        <pin position="35" name="PC3_C"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="monoio"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD33_USB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="125" name="VCAP" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="138" name="PA15 (JTDI)"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDD" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="162" name="PB4 (NJTRST)"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="x" name="TFBGA240">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI6"/>
+        <pin position="A3" name="PI5"/>
+        <pin position="A4" name="PI4"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="VDDLDO" type="power"/>
+        <pin position="A7" name="VCAP" type="power"/>
+        <pin position="A8" name="PK5"/>
+        <pin position="A9" name="PG10"/>
+        <pin position="A10" name="PG9"/>
+        <pin position="A11" name="PD5"/>
+        <pin position="A12" name="PD4"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PA15 (JTDI)"/>
+        <pin position="A15" name="PI1"/>
+        <pin position="A16" name="PI0"/>
+        <pin position="A17" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PI7"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="NC" type="nc"/>
+        <pin position="B7" name="PB4 (NJTRST)"/>
+        <pin position="B8" name="PK4"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PJ15"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD3"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B15" name="PI2"/>
+        <pin position="B16" name="PH15"/>
+        <pin position="B17" name="PH14"/>
+        <pin position="C1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="C2" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE0"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PK6"/>
+        <pin position="C8" name="PK3"/>
+        <pin position="C9" name="PG12"/>
+        <pin position="C10" name="VSS" type="power"/>
+        <pin position="C11" name="PD7"/>
+        <pin position="C12" name="PC12"/>
+        <pin position="C13" name="VSS" type="power"/>
+        <pin position="C14" name="PI3"/>
+        <pin position="C15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C16" name="VSS" type="power"/>
+        <pin position="C17" name="VDDLDO" type="power"/>
+        <pin position="D1" name="PE5"/>
+        <pin position="D2" name="PE4"/>
+        <pin position="D3" name="PE3"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PG15"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG14"/>
+        <pin position="D9" name="PG13"/>
+        <pin position="D10" name="PJ14"/>
+        <pin position="D11" name="PJ12"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PD0"/>
+        <pin position="D14" name="PA10"/>
+        <pin position="D15" name="PA9"/>
+        <pin position="D16" name="PH13"/>
+        <pin position="D17" name="VCAP" type="power"/>
+        <pin position="E1" name="NC" type="nc"/>
+        <pin position="E2" name="PI9"/>
+        <pin position="E3" name="PC13"/>
+        <pin position="E4" name="PI8"/>
+        <pin position="E5" name="PE6"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PDR_ON" type="reset"/>
+        <pin position="E8" name="BOOT0" type="boot"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PJ13"/>
+        <pin position="E11" name="VDD" type="power"/>
+        <pin position="E12" name="PD1"/>
+        <pin position="E13" name="PC8"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PA8"/>
+        <pin position="E16" name="PA12"/>
+        <pin position="E17" name="PA11"/>
+        <pin position="F1" name="NC" type="nc"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PI11"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F13" name="PC7"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="F16" name="PG7"/>
+        <pin position="F17" name="VDD33_USB" type="power"/>
+        <pin position="G1" name="PF2"/>
+        <pin position="G2" name="NC" type="nc"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG6"/>
+        <pin position="G16" name="VSS" type="power"/>
+        <pin position="G17" name="VDD50_USB" type="power"/>
+        <pin position="H1" name="PI12"/>
+        <pin position="H2" name="PI13"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="H14" name="PG4"/>
+        <pin position="H15" name="PG3"/>
+        <pin position="H16" name="PG2"/>
+        <pin position="H17" name="PK2"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="J3" name="VSS" type="power"/>
+        <pin position="J4" name="PF5"/>
+        <pin position="J5" name="PF4"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PK0"/>
+        <pin position="J15" name="PK1"/>
+        <pin position="J16" name="VSS" type="power"/>
+        <pin position="J17" name="VSS" type="power"/>
+        <pin position="K1" name="NRST" type="reset"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF7"/>
+        <pin position="K4" name="PF8"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VSS" type="power"/>
+        <pin position="K13" name="VDD" type="power"/>
+        <pin position="K14" name="PJ11"/>
+        <pin position="K15" name="VSS" type="power"/>
+        <pin position="K16" name="NC" type="nc"/>
+        <pin position="K17" name="NC" type="nc"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PF10"/>
+        <pin position="L4" name="PF9"/>
+        <pin position="L5" name="VDD" type="power"/>
+        <pin position="L7" name="VSS" type="power"/>
+        <pin position="L8" name="VSS" type="power"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VSS" type="power"/>
+        <pin position="L11" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="L14" name="PJ10"/>
+        <pin position="L15" name="VSS" type="power"/>
+        <pin position="L16" name="NC" type="nc"/>
+        <pin position="L17" name="NC" type="nc"/>
+        <pin position="M1" name="VREF+" type="monoio"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PC2"/>
+        <pin position="M4" name="PC3"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M13" name="VDD" type="power"/>
+        <pin position="M14" name="PJ9"/>
+        <pin position="M15" name="VSS" type="power"/>
+        <pin position="M16" name="NC" type="nc"/>
+        <pin position="M17" name="NC" type="nc"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA2"/>
+        <pin position="N4" name="PA1"/>
+        <pin position="N5" name="PA0"/>
+        <pin position="N6" name="PJ0"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="PE10"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="VDD" type="power"/>
+        <pin position="N13" name="PJ8"/>
+        <pin position="N14" name="PJ7"/>
+        <pin position="N15" name="PJ6"/>
+        <pin position="N16" name="VSS" type="power"/>
+        <pin position="N17" name="NC" type="nc"/>
+        <pin position="P1" name="VSSA" type="power"/>
+        <pin position="P2" name="PH3"/>
+        <pin position="P3" name="PH4"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PI15"/>
+        <pin position="P6" name="PJ1"/>
+        <pin position="P7" name="PF13"/>
+        <pin position="P8" name="PF14"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PB10"/>
+        <pin position="P12" name="PB11"/>
+        <pin position="P13" name="PH10"/>
+        <pin position="P14" name="PH11"/>
+        <pin position="P15" name="PD15"/>
+        <pin position="P16" name="PD14"/>
+        <pin position="P17" name="VDD" type="power"/>
+        <pin position="R1" name="PC2_C"/>
+        <pin position="R2" name="PC3_C"/>
+        <pin position="R3" name="PA6"/>
+        <pin position="R4" name="VSS" type="power"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PF12"/>
+        <pin position="R8" name="VSS" type="power"/>
+        <pin position="R9" name="PF15"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PJ5"/>
+        <pin position="R13" name="PH9"/>
+        <pin position="R14" name="PH12"/>
+        <pin position="R15" name="PD11"/>
+        <pin position="R16" name="PD12"/>
+        <pin position="R17" name="PD13"/>
+        <pin position="T1" name="PA0_C"/>
+        <pin position="T2" name="PA1_C"/>
+        <pin position="T3" name="PA5"/>
+        <pin position="T4" name="PC4"/>
+        <pin position="T5" name="PB1"/>
+        <pin position="T6" name="PJ2"/>
+        <pin position="T7" name="PF11"/>
+        <pin position="T8" name="PG0"/>
+        <pin position="T9" name="PE8"/>
+        <pin position="T10" name="PE13"/>
+        <pin position="T11" name="PH6"/>
+        <pin position="T12" name="VSS" type="power"/>
+        <pin position="T13" name="PH8"/>
+        <pin position="T14" name="PB12"/>
+        <pin position="T15" name="PB15"/>
+        <pin position="T16" name="PD10"/>
+        <pin position="T17" name="PD9"/>
+        <pin position="U1" name="VSS" type="power"/>
+        <pin position="U2" name="PA3"/>
+        <pin position="U3" name="PA4"/>
+        <pin position="U4" name="PC5"/>
+        <pin position="U5" name="PB0"/>
+        <pin position="U6" name="PJ3"/>
+        <pin position="U7" name="PJ4"/>
+        <pin position="U8" name="PG1"/>
+        <pin position="U9" name="PE7"/>
+        <pin position="U10" name="PE14"/>
+        <pin position="U11" name="VCAP" type="power"/>
+        <pin position="U12" name="VDDLDO" type="power"/>
+        <pin position="U13" name="PH7"/>
+        <pin position="U14" name="PB13"/>
+        <pin position="U15" name="PB14"/>
+        <pin position="U16" name="PD8"/>
+        <pin position="U17" name="VSS" type="power"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="PE1"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB8"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG13"/>
+        <pin position="A9" name="PB4 (NJTRST)"/>
+        <pin position="A10" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15 (JTDI)"/>
+        <pin position="A14" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A15" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE5"/>
+        <pin position="B3" name="PE6"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG12"/>
+        <pin position="B9" name="PG11"/>
+        <pin position="B10" name="PG10"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI7"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PI5"/>
+        <pin position="C5" name="VDD" type="power"/>
+        <pin position="C6" name="PDR_ON" type="reset"/>
+        <pin position="C7" name="VDD" type="power"/>
+        <pin position="C8" name="VDD" type="power"/>
+        <pin position="C9" name="VDD" type="power"/>
+        <pin position="C10" name="PG9"/>
+        <pin position="C11" name="PD5"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PI8"/>
+        <pin position="D3" name="PI9"/>
+        <pin position="D4" name="PI4"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="BOOT0" type="boot"/>
+        <pin position="D7" name="VSS" type="power"/>
+        <pin position="D8" name="VSS" type="power"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PD4"/>
+        <pin position="D11" name="PD3"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN (OSC32_IN)"/>
+        <pin position="E2" name="PF0"/>
+        <pin position="E3" name="PI10"/>
+        <pin position="E4" name="PI11"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT (OSC32_OUT)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="VDD" type="power"/>
+        <pin position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VCAP" type="power"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="VDD" type="power"/>
+        <pin position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="VSS" type="power"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H2" name="PF2"/>
+        <pin position="H3" name="PF1"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD33_USB" type="power"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF3"/>
+        <pin position="J3" name="PF4"/>
+        <pin position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="VDD" type="power"/>
+        <pin position="J13" name="VDD" type="power"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="PH12"/>
+        <pin position="K13" name="PG5"/>
+        <pin position="K14" name="PG4"/>
+        <pin position="K15" name="PG3"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="VSS" type="power"/>
+        <pin position="L12" name="PH11"/>
+        <pin position="L13" name="PH10"/>
+        <pin position="L14" name="PD15"/>
+        <pin position="L15" name="PG2"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2_C"/>
+        <pin position="M5" name="PC3_C"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="VSS" type="power"/>
+        <pin position="M10" name="VCAP" type="power"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH8"/>
+        <pin position="M13" name="PH9"/>
+        <pin position="M14" name="PD14"/>
+        <pin position="M15" name="PD13"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="VDD" type="power"/>
+        <pin position="N9" name="VDD" type="power"/>
+        <pin position="N10" name="VDD" type="power"/>
+        <pin position="N11" name="PE13"/>
+        <pin position="N12" name="PH7"/>
+        <pin position="N13" name="PD12"/>
+        <pin position="N14" name="PD11"/>
+        <pin position="N15" name="PD10"/>
+        <pin position="P1" name="VREF+" type="monoio"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF12"/>
+        <pin position="P7" name="PF15"/>
+        <pin position="P8" name="PE8"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB12"/>
+        <pin position="P13" name="PB13"/>
+        <pin position="P14" name="PD9"/>
+        <pin position="P15" name="PD8"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PF11"/>
+        <pin position="R7" name="PF14"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PB10"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-a3.xml
+++ b/devices/stm32/stm32h7-a3.xml
@@ -3609,6 +3609,2207 @@
       <gpio device-pin="l|n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin device-size="g|i" device-variant="q" position="2" name="PE4"/>
+        <pin device-size="g|i" device-variant="" position="2" name="PE3"/>
+        <pin device-size="g|i" device-variant="q" position="3" name="PE5"/>
+        <pin device-size="g|i" device-variant="" position="3" name="PE4"/>
+        <pin device-size="g|i" device-variant="q" position="4" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="4" name="PE5"/>
+        <pin device-size="g|i" device-variant="q" position="5" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="" position="5" name="PE6"/>
+        <pin device-size="g|i" device-variant="q" position="6" name="PC13"/>
+        <pin device-size="g|i" device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="7" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="" position="7" name="PC13"/>
+        <pin device-size="g|i" device-variant="q" position="8" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="" position="8" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="q" position="9" name="VSSSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="9" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="10" name="VLXSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="11" name="VDDSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="11" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="12" name="VFBSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="12" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="q" position="13" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="" position="13" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="14" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="" position="14" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="15" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="15" name="PC0"/>
+        <pin device-size="g|i" device-variant="q" position="16" name="PC0"/>
+        <pin device-size="g|i" device-variant="" position="16" name="PC1"/>
+        <pin device-size="g|i" device-variant="q" position="17" name="PC1"/>
+        <pin device-size="g|i" device-variant="" position="17" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="q" position="18" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="" position="18" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="q" position="19" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="" position="19" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="20" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="20" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="q" position="21" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="21" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="22" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="22" name="PA0"/>
+        <pin device-size="g|i" device-variant="q" position="23" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="" position="23" name="PA1"/>
+        <pin device-size="g|i" device-variant="q" position="24" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="24" name="PA2"/>
+        <pin device-size="g|i" device-variant="q" position="25" name="PA0"/>
+        <pin device-size="g|i" device-variant="" position="25" name="PA3"/>
+        <pin device-size="g|i" device-variant="q" position="26" name="PA1"/>
+        <pin device-size="g|i" device-variant="" position="26" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="27" name="PA2"/>
+        <pin device-size="g|i" device-variant="" position="27" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="28" name="PA3"/>
+        <pin device-size="g|i" device-variant="" position="28" name="PA4"/>
+        <pin device-size="g|i" device-variant="q" position="29" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="29" name="PA5"/>
+        <pin device-size="g|i" device-variant="q" position="30" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="30" name="PA6"/>
+        <pin device-size="g|i" device-variant="q" position="31" name="PA4"/>
+        <pin device-size="g|i" device-variant="" position="31" name="PA7"/>
+        <pin device-size="g|i" device-variant="q" position="32" name="PA5"/>
+        <pin device-size="g|i" device-variant="" position="32" name="PC4"/>
+        <pin device-size="g|i" device-variant="q" position="33" name="PA6"/>
+        <pin device-size="g|i" device-variant="" position="33" name="PC5"/>
+        <pin device-size="g|i" device-variant="q" position="34" name="PA7"/>
+        <pin device-size="g|i" device-variant="" position="34" name="PB0"/>
+        <pin device-size="g|i" device-variant="q" position="35" name="PC4"/>
+        <pin device-size="g|i" device-variant="" position="35" name="PB1"/>
+        <pin device-size="g|i" device-variant="q" position="36" name="PC5"/>
+        <pin device-size="g|i" device-variant="" position="36" name="PB2"/>
+        <pin device-size="g|i" device-variant="q" position="37" name="PB0"/>
+        <pin device-size="g|i" device-variant="" position="37" name="PE7"/>
+        <pin device-size="g|i" device-variant="q" position="38" name="PB1"/>
+        <pin device-size="g|i" device-variant="" position="38" name="PE8"/>
+        <pin device-size="g|i" device-variant="q" position="39" name="PB2"/>
+        <pin device-size="g|i" device-variant="" position="39" name="PE9"/>
+        <pin device-size="g|i" device-variant="q" position="40" name="PE7"/>
+        <pin device-size="g|i" device-variant="" position="40" name="PE10"/>
+        <pin device-size="g|i" device-variant="q" position="41" name="PE8"/>
+        <pin device-size="g|i" device-variant="" position="41" name="PE11"/>
+        <pin device-size="g|i" device-variant="q" position="42" name="PB10"/>
+        <pin device-size="g|i" device-variant="" position="42" name="PE12"/>
+        <pin device-size="g|i" device-variant="q" position="43" name="PB11"/>
+        <pin device-size="g|i" device-variant="" position="43" name="PE13"/>
+        <pin device-size="g|i" device-variant="q" position="44" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="44" name="PE14"/>
+        <pin device-size="g|i" device-variant="q" position="45" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="45" name="PE15"/>
+        <pin device-size="g|i" device-variant="q" position="46" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="46" name="PB10"/>
+        <pin device-size="g|i" device-variant="q" position="47" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="47" name="PB11"/>
+        <pin device-size="g|i" device-variant="q" position="48" name="PB12"/>
+        <pin device-size="g|i" device-variant="" position="48" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="49" name="PB13"/>
+        <pin device-size="g|i" device-variant="" position="49" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="50" name="PB14"/>
+        <pin device-size="g|i" device-variant="" position="50" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="51" name="PB15"/>
+        <pin device-size="g|i" device-variant="" position="51" name="PB12"/>
+        <pin device-size="g|i" device-variant="q" position="52" name="PD8"/>
+        <pin device-size="g|i" device-variant="" position="52" name="PB13"/>
+        <pin device-size="g|i" device-variant="q" position="53" name="PD9"/>
+        <pin device-size="g|i" device-variant="" position="53" name="PB14"/>
+        <pin device-size="g|i" device-variant="q" position="54" name="PD10"/>
+        <pin device-size="g|i" device-variant="" position="54" name="PB15"/>
+        <pin device-size="g|i" device-variant="q" position="55" name="PD11"/>
+        <pin device-size="g|i" device-variant="" position="55" name="PD8"/>
+        <pin device-size="g|i" device-variant="q" position="56" name="PD12"/>
+        <pin device-size="g|i" device-variant="" position="56" name="PD9"/>
+        <pin device-size="g|i" device-variant="q" position="57" name="PD13"/>
+        <pin device-size="g|i" device-variant="" position="57" name="PD10"/>
+        <pin device-size="g|i" device-variant="q" position="58" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="58" name="PD11"/>
+        <pin device-size="g|i" device-variant="q" position="59" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="59" name="PD12"/>
+        <pin device-size="g|i" device-variant="q" position="60" name="PD14"/>
+        <pin device-size="g|i" device-variant="" position="60" name="PD13"/>
+        <pin device-size="g|i" device-variant="q" position="61" name="PD15"/>
+        <pin device-size="g|i" device-variant="" position="61" name="PD14"/>
+        <pin device-size="g|i" device-variant="q" position="62" name="PC6"/>
+        <pin device-size="g|i" device-variant="" position="62" name="PD15"/>
+        <pin device-size="g|i" device-variant="q" position="63" name="PC7"/>
+        <pin device-size="g|i" device-variant="" position="63" name="PC6"/>
+        <pin device-size="g|i" device-variant="q" position="64" name="PC8"/>
+        <pin device-size="g|i" device-variant="" position="64" name="PC7"/>
+        <pin device-size="g|i" device-variant="q" position="65" name="PC9"/>
+        <pin device-size="g|i" device-variant="" position="65" name="PC8"/>
+        <pin device-size="g|i" device-variant="q" position="66" name="PA8"/>
+        <pin device-size="g|i" device-variant="" position="66" name="PC9"/>
+        <pin device-size="g|i" device-variant="q" position="67" name="PA9"/>
+        <pin device-size="g|i" device-variant="" position="67" name="PA8"/>
+        <pin device-size="g|i" device-variant="q" position="68" name="PA10"/>
+        <pin device-size="g|i" device-variant="" position="68" name="PA9"/>
+        <pin device-size="g|i" device-variant="q" position="69" name="PA11"/>
+        <pin device-size="g|i" device-variant="" position="69" name="PA10"/>
+        <pin device-size="g|i" device-variant="q" position="70" name="PA12"/>
+        <pin device-size="g|i" device-variant="" position="70" name="PA11"/>
+        <pin device-size="g|i" device-variant="q" position="71" name="PA13"/>
+        <pin device-size="g|i" device-variant="" position="71" name="PA12"/>
+        <pin device-size="g|i" device-variant="q" position="72" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="72" name="PA13"/>
+        <pin device-size="g|i" device-variant="q" position="73" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="73" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="74" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="76" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="76" name="PA14"/>
+        <pin device-size="g|i" device-variant="q" position="77" name="PA14"/>
+        <pin device-size="g|i" device-variant="" position="77" name="PA15"/>
+        <pin device-size="g|i" device-variant="q" position="78" name="PA15"/>
+        <pin device-size="g|i" device-variant="" position="78" name="PC10"/>
+        <pin device-size="g|i" device-variant="q" position="79" name="PC10"/>
+        <pin device-size="g|i" device-variant="" position="79" name="PC11"/>
+        <pin device-size="g|i" device-variant="q" position="80" name="PC11"/>
+        <pin device-size="g|i" device-variant="" position="80" name="PC12"/>
+        <pin device-size="g|i" device-variant="q" position="81" name="PC12"/>
+        <pin device-size="g|i" device-variant="" position="81" name="PD0"/>
+        <pin device-size="g|i" device-variant="q" position="82" name="PD0"/>
+        <pin device-size="g|i" device-variant="" position="82" name="PD1"/>
+        <pin device-size="g|i" device-variant="q" position="83" name="PD1"/>
+        <pin device-size="g|i" device-variant="" position="83" name="PD2"/>
+        <pin device-size="g|i" device-variant="q" position="84" name="PD2"/>
+        <pin device-size="g|i" device-variant="" position="84" name="PD3"/>
+        <pin device-size="g|i" device-variant="q" position="85" name="PD3"/>
+        <pin device-size="g|i" device-variant="" position="85" name="PD4"/>
+        <pin device-size="g|i" device-variant="q" position="86" name="PD4"/>
+        <pin device-size="g|i" device-variant="" position="86" name="PD5"/>
+        <pin device-size="g|i" device-variant="q" position="87" name="PD5"/>
+        <pin device-size="g|i" device-variant="" position="87" name="PD6"/>
+        <pin device-size="g|i" device-variant="q" position="88" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="" position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin device-size="g|i" device-variant="q" position="98" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="98" name="PE1"/>
+        <pin device-size="g|i" device-variant="q" position="99" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin device-size="g|i" device-variant="q" position="6" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="7" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="7" name="PC13"/>
+        <pin device-size="g|i" device-variant="q" position="8" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="" position="8" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="q" position="9" name="PC13"/>
+        <pin device-size="g|i" device-variant="" position="9" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="10" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="" position="10" name="PF0"/>
+        <pin device-size="g|i" device-variant="q" position="11" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="" position="11" name="PF1"/>
+        <pin device-size="g|i" device-variant="q" position="12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="12" name="PF2"/>
+        <pin device-size="g|i" device-variant="q" position="13" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="13" name="PF3"/>
+        <pin device-size="g|i" device-variant="q" position="14" name="VSSSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="14" name="PF4"/>
+        <pin device-size="g|i" device-variant="q" position="15" name="VLXSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="15" name="PF5"/>
+        <pin device-size="g|i" device-variant="q" position="16" name="VDDSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="16" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="17" name="VFBSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="17" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="18" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="18" name="PF6"/>
+        <pin device-size="g|i" device-variant="q" position="19" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="19" name="PF7"/>
+        <pin device-size="g|i" device-variant="q" position="20" name="PF6"/>
+        <pin device-size="g|i" device-variant="" position="20" name="PF8"/>
+        <pin device-size="g|i" device-variant="q" position="21" name="PF7"/>
+        <pin device-size="g|i" device-variant="" position="21" name="PF9"/>
+        <pin device-size="g|i" device-variant="q" position="22" name="PF8"/>
+        <pin device-size="g|i" device-variant="" position="22" name="PF10"/>
+        <pin device-size="g|i" device-variant="q" position="23" name="PF9"/>
+        <pin device-size="g|i" device-variant="" position="23" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="q" position="24" name="PF10"/>
+        <pin device-size="g|i" device-variant="" position="24" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="25" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="" position="25" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="26" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="" position="26" name="PC0"/>
+        <pin device-size="g|i" device-variant="q" position="27" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="27" name="PC1"/>
+        <pin device-size="g|i" device-variant="q" position="28" name="PC0"/>
+        <pin device-size="g|i" device-variant="" position="28" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="q" position="29" name="PC1"/>
+        <pin device-size="g|i" device-variant="" position="29" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="q" position="30" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="" position="30" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="31" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="" position="31" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="32" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="32" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="q" position="33" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="33" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="34" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="34" name="PA0"/>
+        <pin device-size="g|i" device-variant="q" position="35" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="" position="35" name="PA1"/>
+        <pin device-size="g|i" device-variant="q" position="36" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="36" name="PA2"/>
+        <pin device-size="g|i" device-variant="q" position="37" name="PA0"/>
+        <pin device-size="g|i" device-variant="" position="37" name="PA3"/>
+        <pin device-size="g|i" device-variant="q" position="38" name="PA1"/>
+        <pin device-size="g|i" device-variant="" position="38" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="39" name="PA2"/>
+        <pin device-size="g|i" device-variant="" position="39" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="40" name="PA3"/>
+        <pin device-size="g|i" device-variant="" position="40" name="PA4"/>
+        <pin device-size="g|i" device-variant="q" position="41" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="41" name="PA5"/>
+        <pin device-size="g|i" device-variant="q" position="42" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="42" name="PA6"/>
+        <pin device-size="g|i" device-variant="q" position="43" name="PA4"/>
+        <pin device-size="g|i" device-variant="" position="43" name="PA7"/>
+        <pin device-size="g|i" device-variant="q" position="44" name="PA5"/>
+        <pin device-size="g|i" device-variant="" position="44" name="PC4"/>
+        <pin device-size="g|i" device-variant="q" position="45" name="PA6"/>
+        <pin device-size="g|i" device-variant="" position="45" name="PC5"/>
+        <pin device-size="g|i" device-variant="q" position="46" name="PA7"/>
+        <pin device-size="g|i" device-variant="" position="46" name="PB0"/>
+        <pin device-size="g|i" device-variant="q" position="47" name="PC4"/>
+        <pin device-size="g|i" device-variant="" position="47" name="PB1"/>
+        <pin device-size="g|i" device-variant="q" position="48" name="PC5"/>
+        <pin device-size="g|i" device-variant="" position="48" name="PB2"/>
+        <pin device-size="g|i" device-variant="q" position="49" name="PB0"/>
+        <pin device-size="g|i" device-variant="" position="49" name="PF11"/>
+        <pin device-size="g|i" device-variant="q" position="50" name="PB1"/>
+        <pin device-size="g|i" device-variant="" position="50" name="PF12"/>
+        <pin device-size="g|i" device-variant="q" position="51" name="PB2"/>
+        <pin device-size="g|i" device-variant="" position="51" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="52" name="PF11"/>
+        <pin device-size="g|i" device-variant="" position="52" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="53" name="PF14"/>
+        <pin device-size="g|i" device-variant="" position="53" name="PF13"/>
+        <pin device-size="g|i" device-variant="q" position="54" name="PF15"/>
+        <pin device-size="g|i" device-variant="" position="54" name="PF14"/>
+        <pin device-size="g|i" device-variant="q" position="55" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="55" name="PF15"/>
+        <pin device-size="g|i" device-variant="q" position="56" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="56" name="PG0"/>
+        <pin device-size="g|i" device-variant="q" position="57" name="PE7"/>
+        <pin device-size="g|i" device-variant="" position="57" name="PG1"/>
+        <pin device-size="g|i" device-variant="q" position="58" name="PE8"/>
+        <pin device-size="g|i" device-variant="" position="58" name="PE7"/>
+        <pin device-size="g|i" device-variant="q" position="59" name="PE9"/>
+        <pin device-size="g|i" device-variant="" position="59" name="PE8"/>
+        <pin device-size="g|i" device-variant="q" position="60" name="PE10"/>
+        <pin device-size="g|i" device-variant="" position="60" name="PE9"/>
+        <pin device-size="g|i" device-variant="q" position="61" name="PE11"/>
+        <pin device-size="g|i" device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="62" name="PE12"/>
+        <pin device-size="g|i" device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="63" name="PE13"/>
+        <pin device-size="g|i" device-variant="" position="63" name="PE10"/>
+        <pin device-size="g|i" device-variant="q" position="64" name="PE14"/>
+        <pin device-size="g|i" device-variant="" position="64" name="PE11"/>
+        <pin device-size="g|i" device-variant="q" position="65" name="PE15"/>
+        <pin device-size="g|i" device-variant="" position="65" name="PE12"/>
+        <pin device-size="g|i" device-variant="q" position="66" name="PB10"/>
+        <pin device-size="g|i" device-variant="" position="66" name="PE13"/>
+        <pin device-size="g|i" device-variant="q" position="67" name="PB11"/>
+        <pin device-size="g|i" device-variant="" position="67" name="PE14"/>
+        <pin device-size="g|i" device-variant="q" position="68" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="68" name="PE15"/>
+        <pin device-size="g|i" device-variant="q" position="69" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="69" name="PB10"/>
+        <pin device-size="g|i" device-variant="q" position="70" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="70" name="PB11"/>
+        <pin device-size="g|i" device-variant="q" position="71" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="71" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="72" name="PB12"/>
+        <pin device-size="g|i" device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="73" name="PB13"/>
+        <pin device-size="g|i" device-variant="" position="73" name="PB12"/>
+        <pin device-size="g|i" device-variant="q" position="74" name="PB14"/>
+        <pin device-size="g|i" device-variant="" position="74" name="PB13"/>
+        <pin device-size="g|i" device-variant="q" position="75" name="PB15"/>
+        <pin device-size="g|i" device-variant="" position="75" name="PB14"/>
+        <pin device-size="g|i" device-variant="q" position="76" name="PD8"/>
+        <pin device-size="g|i" device-variant="" position="76" name="PB15"/>
+        <pin device-size="g|i" device-variant="q" position="77" name="PD9"/>
+        <pin device-size="g|i" device-variant="" position="77" name="PD8"/>
+        <pin device-size="g|i" device-variant="q" position="78" name="PD10"/>
+        <pin device-size="g|i" device-variant="" position="78" name="PD9"/>
+        <pin device-size="g|i" device-variant="q" position="79" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="79" name="PD10"/>
+        <pin device-size="g|i" device-variant="q" position="80" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="80" name="PD11"/>
+        <pin device-size="g|i" device-variant="q" position="81" name="PD11"/>
+        <pin device-size="g|i" device-variant="" position="81" name="PD12"/>
+        <pin device-size="g|i" device-variant="q" position="82" name="PD12"/>
+        <pin device-size="g|i" device-variant="" position="82" name="PD13"/>
+        <pin device-size="g|i" device-variant="q" position="83" name="PD13"/>
+        <pin device-size="g|i" device-variant="" position="83" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="84" name="PD14"/>
+        <pin device-size="g|i" device-variant="" position="84" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="85" name="PD15"/>
+        <pin device-size="g|i" device-variant="" position="85" name="PD14"/>
+        <pin device-size="g|i" device-variant="q" position="86" name="PG6"/>
+        <pin device-size="g|i" device-variant="" position="86" name="PD15"/>
+        <pin device-size="g|i" device-variant="q" position="87" name="PG7"/>
+        <pin device-size="g|i" device-variant="" position="87" name="PG2"/>
+        <pin device-size="g|i" device-variant="q" position="88" name="PG8"/>
+        <pin device-size="g|i" device-variant="" position="88" name="PG3"/>
+        <pin device-size="g|i" device-variant="q" position="89" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="89" name="PG4"/>
+        <pin device-size="g|i" device-variant="q" position="90" name="VDD50_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="90" name="PG5"/>
+        <pin device-size="g|i" device-variant="q" position="91" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="91" name="PG6"/>
+        <pin device-size="g|i" device-variant="q" position="92" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="92" name="PG7"/>
+        <pin device-size="g|i" device-variant="q" position="93" name="PC6"/>
+        <pin device-size="g|i" device-variant="" position="93" name="PG8"/>
+        <pin device-size="g|i" device-variant="q" position="94" name="PC7"/>
+        <pin device-size="g|i" device-variant="" position="94" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="95" name="PC8"/>
+        <pin device-size="g|i" device-variant="" position="95" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="96" name="PC9"/>
+        <pin device-size="g|i" device-variant="" position="96" name="PC6"/>
+        <pin device-size="g|i" device-variant="q" position="97" name="PA8"/>
+        <pin device-size="g|i" device-variant="" position="97" name="PC7"/>
+        <pin device-size="g|i" device-variant="q" position="98" name="PA9"/>
+        <pin device-size="g|i" device-variant="" position="98" name="PC8"/>
+        <pin device-size="g|i" device-variant="q" position="99" name="PA10"/>
+        <pin device-size="g|i" device-variant="" position="99" name="PC9"/>
+        <pin device-size="g|i" device-variant="q" position="100" name="PA11"/>
+        <pin device-size="g|i" device-variant="" position="100" name="PA8"/>
+        <pin device-size="g|i" device-variant="q" position="101" name="PA12"/>
+        <pin device-size="g|i" device-variant="" position="101" name="PA9"/>
+        <pin device-size="g|i" device-variant="q" position="102" name="PA13"/>
+        <pin device-size="g|i" device-variant="" position="102" name="PA10"/>
+        <pin device-size="g|i" device-variant="q" position="103" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="103" name="PA11"/>
+        <pin device-size="g|i" device-variant="q" position="104" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="104" name="PA12"/>
+        <pin device-size="g|i" device-variant="q" position="105" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="105" name="PA13"/>
+        <pin device-size="g|i" device-variant="q" position="106" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="106" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="107" name="PA14"/>
+        <pin device-size="g|i" device-variant="" position="107" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="108" name="PA15"/>
+        <pin device-size="g|i" device-variant="" position="108" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="109" name="PC10"/>
+        <pin device-size="g|i" device-variant="" position="109" name="PA14"/>
+        <pin device-size="g|i" device-variant="q" position="110" name="PC11"/>
+        <pin device-size="g|i" device-variant="" position="110" name="PA15"/>
+        <pin device-size="g|i" device-variant="q" position="111" name="PC12"/>
+        <pin device-size="g|i" device-variant="" position="111" name="PC10"/>
+        <pin device-size="g|i" device-variant="q" position="112" name="PD0"/>
+        <pin device-size="g|i" device-variant="" position="112" name="PC11"/>
+        <pin device-size="g|i" device-variant="q" position="113" name="PD1"/>
+        <pin device-size="g|i" device-variant="" position="113" name="PC12"/>
+        <pin device-size="g|i" device-variant="q" position="114" name="PD2"/>
+        <pin device-size="g|i" device-variant="" position="114" name="PD0"/>
+        <pin device-size="g|i" device-variant="q" position="115" name="PD3"/>
+        <pin device-size="g|i" device-variant="" position="115" name="PD1"/>
+        <pin device-size="g|i" device-variant="q" position="116" name="PD4"/>
+        <pin device-size="g|i" device-variant="" position="116" name="PD2"/>
+        <pin device-size="g|i" device-variant="q" position="117" name="PD5"/>
+        <pin device-size="g|i" device-variant="" position="117" name="PD3"/>
+        <pin device-size="g|i" device-variant="q" position="118" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="118" name="PD4"/>
+        <pin device-size="g|i" device-variant="q" position="119" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="" position="119" name="PD5"/>
+        <pin device-size="g|i" device-variant="q" position="120" name="PD6"/>
+        <pin device-size="g|i" device-variant="" position="120" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="121" name="PD7"/>
+        <pin device-size="g|i" device-variant="" position="121" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="122" name="PG9"/>
+        <pin device-size="g|i" device-variant="" position="122" name="PD6"/>
+        <pin device-size="g|i" device-variant="q" position="123" name="PG10"/>
+        <pin device-size="g|i" device-variant="" position="123" name="PD7"/>
+        <pin device-size="g|i" device-variant="q" position="124" name="PG11"/>
+        <pin device-size="g|i" device-variant="" position="124" name="PG9"/>
+        <pin device-size="g|i" device-variant="q" position="125" name="PG12"/>
+        <pin device-size="g|i" device-variant="" position="125" name="PG10"/>
+        <pin device-size="g|i" device-variant="q" position="126" name="PG13"/>
+        <pin device-size="g|i" device-variant="" position="126" name="PG11"/>
+        <pin device-size="g|i" device-variant="q" position="127" name="PG14"/>
+        <pin device-size="g|i" device-variant="" position="127" name="PG12"/>
+        <pin device-size="g|i" device-variant="q" position="128" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="128" name="PG13"/>
+        <pin device-size="g|i" device-variant="q" position="129" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="129" name="PG14"/>
+        <pin device-size="g|i" device-variant="q" position="130" name="PB3"/>
+        <pin device-size="g|i" device-variant="" position="130" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="131" name="PB4"/>
+        <pin device-size="g|i" device-variant="" position="131" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="132" name="PB5"/>
+        <pin device-size="g|i" device-variant="" position="132" name="PG15"/>
+        <pin device-size="g|i" device-variant="q" position="133" name="PB6"/>
+        <pin device-size="g|i" device-variant="" position="133" name="PB3"/>
+        <pin device-size="g|i" device-variant="q" position="134" name="PB7"/>
+        <pin device-size="g|i" device-variant="" position="134" name="PB4"/>
+        <pin device-size="g|i" device-variant="q" position="135" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="" position="135" name="PB5"/>
+        <pin device-size="g|i" device-variant="q" position="136" name="PB8"/>
+        <pin device-size="g|i" device-variant="" position="136" name="PB6"/>
+        <pin device-size="g|i" device-variant="q" position="137" name="PB9"/>
+        <pin device-size="g|i" device-variant="" position="137" name="PB7"/>
+        <pin device-size="g|i" device-variant="q" position="138" name="PE0"/>
+        <pin device-size="g|i" device-variant="" position="138" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="q" position="139" name="PE1"/>
+        <pin device-size="g|i" device-variant="" position="139" name="PB8"/>
+        <pin device-size="g|i" device-variant="q" position="140" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="140" name="PB9"/>
+        <pin device-size="g|i" device-variant="q" position="141" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="141" name="PE0"/>
+        <pin device-size="g|i" device-variant="q" position="142" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="142" name="PE1"/>
+        <pin device-size="g|i" device-variant="q" position="143" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin device-size="g|i" device-variant="q" position="6" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="7" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="7" name="PI8"/>
+        <pin device-size="g|i" device-variant="q" position="8" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="" position="8" name="PC13"/>
+        <pin device-size="g|i" device-variant="q" position="9" name="PC13"/>
+        <pin device-size="g|i" device-variant="" position="9" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="q" position="10" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="" position="10" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="11" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="" position="11" name="PI9"/>
+        <pin device-size="g|i" device-variant="q" position="12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="12" name="PI10"/>
+        <pin device-size="g|i" device-variant="q" position="13" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="13" name="PI11"/>
+        <pin device-size="g|i" device-variant="q" position="14" name="VSSSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="14" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="15" name="VLXSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="15" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="16" name="VDDSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="16" name="PF0"/>
+        <pin device-size="g|i" device-variant="q" position="17" name="VFBSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="17" name="PF1"/>
+        <pin device-size="g|i" device-variant="q" position="18" name="PF0"/>
+        <pin device-size="g|i" device-variant="" position="18" name="PF2"/>
+        <pin device-size="g|i" device-variant="q" position="19" name="PF1"/>
+        <pin device-size="g|i" device-variant="" position="19" name="PF3"/>
+        <pin device-size="g|i" device-variant="q" position="20" name="PF2"/>
+        <pin device-size="g|i" device-variant="" position="20" name="PF4"/>
+        <pin device-size="g|i" device-variant="q" position="21" name="PF3"/>
+        <pin device-size="g|i" device-variant="" position="21" name="PF5"/>
+        <pin device-size="g|i" device-variant="q" position="22" name="PF4"/>
+        <pin device-size="g|i" device-variant="" position="22" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="23" name="PF5"/>
+        <pin device-size="g|i" device-variant="" position="23" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="24" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="24" name="PF6"/>
+        <pin device-size="g|i" device-variant="q" position="25" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="25" name="PF7"/>
+        <pin device-size="g|i" device-variant="q" position="26" name="PF6"/>
+        <pin device-size="g|i" device-variant="" position="26" name="PF8"/>
+        <pin device-size="g|i" device-variant="q" position="27" name="PF7"/>
+        <pin device-size="g|i" device-variant="" position="27" name="PF9"/>
+        <pin device-size="g|i" device-variant="q" position="28" name="PF8"/>
+        <pin device-size="g|i" device-variant="" position="28" name="PF10"/>
+        <pin device-size="g|i" device-variant="q" position="29" name="PF9"/>
+        <pin device-size="g|i" device-variant="" position="29" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="q" position="30" name="PF10"/>
+        <pin device-size="g|i" device-variant="" position="30" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="31" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="" position="31" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="32" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="" position="32" name="PC0"/>
+        <pin device-size="g|i" device-variant="q" position="33" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="33" name="PC1"/>
+        <pin device-size="g|i" device-variant="q" position="34" name="PC0"/>
+        <pin device-size="g|i" device-variant="" position="34" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="q" position="35" name="PC1"/>
+        <pin device-size="g|i" device-variant="" position="35" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="q" position="36" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="" position="36" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="37" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="" position="37" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="38" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="38" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="q" position="39" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="" position="39" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="40" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="40" name="PA0"/>
+        <pin device-size="g|i" device-variant="q" position="41" name="PA0"/>
+        <pin device-size="g|i" device-variant="" position="41" name="PA1"/>
+        <pin device-size="g|i" device-variant="q" position="42" name="PA1"/>
+        <pin device-size="g|i" device-variant="" position="42" name="PA2"/>
+        <pin device-size="g|i" device-variant="q" position="43" name="PA2"/>
+        <pin device-size="g|i" device-variant="" position="43" name="PH2"/>
+        <pin device-size="g|i" device-variant="q" position="44" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="44" name="PH3"/>
+        <pin device-size="g|i" device-variant="q" position="45" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="45" name="PH4"/>
+        <pin device-size="g|i" device-variant="q" position="46" name="PA3"/>
+        <pin device-size="g|i" device-variant="" position="46" name="PH5"/>
+        <pin device-size="g|i" device-variant="q" position="47" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="47" name="PA3"/>
+        <pin device-size="g|i" device-variant="q" position="48" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="48" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="49" name="PA4"/>
+        <pin device-size="g|i" device-variant="" position="49" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="50" name="PA5"/>
+        <pin device-size="g|i" device-variant="" position="50" name="PA4"/>
+        <pin device-size="g|i" device-variant="q" position="51" name="PA6"/>
+        <pin device-size="g|i" device-variant="" position="51" name="PA5"/>
+        <pin device-size="g|i" device-variant="q" position="52" name="PA7"/>
+        <pin device-size="g|i" device-variant="" position="52" name="PA6"/>
+        <pin device-size="g|i" device-variant="q" position="53" name="PC4"/>
+        <pin device-size="g|i" device-variant="" position="53" name="PA7"/>
+        <pin device-size="g|i" device-variant="q" position="54" name="PC5"/>
+        <pin device-size="g|i" device-variant="" position="54" name="PC4"/>
+        <pin device-size="g|i" device-variant="q" position="55" name="PB0"/>
+        <pin device-size="g|i" device-variant="" position="55" name="PC5"/>
+        <pin device-size="g|i" device-variant="q" position="56" name="PB1"/>
+        <pin device-size="g|i" device-variant="" position="56" name="PB0"/>
+        <pin device-size="g|i" device-variant="q" position="57" name="PB2"/>
+        <pin device-size="g|i" device-variant="" position="57" name="PB1"/>
+        <pin device-size="g|i" device-variant="q" position="58" name="PF11"/>
+        <pin device-size="g|i" device-variant="" position="58" name="PB2"/>
+        <pin device-size="g|i" device-variant="q" position="59" name="PF12"/>
+        <pin device-size="g|i" device-variant="" position="59" name="PF11"/>
+        <pin device-size="g|i" device-variant="q" position="60" name="PF13"/>
+        <pin device-size="g|i" device-variant="" position="60" name="PF12"/>
+        <pin device-size="g|i" device-variant="q" position="61" name="PF14"/>
+        <pin device-size="g|i" device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="62" name="PF15"/>
+        <pin device-size="g|i" device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="63" name="PG0"/>
+        <pin device-size="g|i" device-variant="" position="63" name="PF13"/>
+        <pin device-size="g|i" device-variant="q" position="64" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="64" name="PF14"/>
+        <pin device-size="g|i" device-variant="q" position="65" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="65" name="PF15"/>
+        <pin device-size="g|i" device-variant="q" position="66" name="PG1"/>
+        <pin device-size="g|i" device-variant="" position="66" name="PG0"/>
+        <pin device-size="g|i" device-variant="q" position="67" name="PE7"/>
+        <pin device-size="g|i" device-variant="" position="67" name="PG1"/>
+        <pin device-size="g|i" device-variant="q" position="68" name="PE8"/>
+        <pin device-size="g|i" device-variant="" position="68" name="PE7"/>
+        <pin device-size="g|i" device-variant="q" position="69" name="PE9"/>
+        <pin device-size="g|i" device-variant="" position="69" name="PE8"/>
+        <pin device-size="g|i" device-variant="q" position="70" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="70" name="PE9"/>
+        <pin device-size="g|i" device-variant="q" position="71" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="71" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="72" name="PE10"/>
+        <pin device-size="g|i" device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="73" name="PE11"/>
+        <pin device-size="g|i" device-variant="" position="73" name="PE10"/>
+        <pin device-size="g|i" device-variant="q" position="74" name="PE12"/>
+        <pin device-size="g|i" device-variant="" position="74" name="PE11"/>
+        <pin device-size="g|i" device-variant="q" position="75" name="PE13"/>
+        <pin device-size="g|i" device-variant="" position="75" name="PE12"/>
+        <pin device-size="g|i" device-variant="q" position="76" name="PE14"/>
+        <pin device-size="g|i" device-variant="" position="76" name="PE13"/>
+        <pin device-size="g|i" device-variant="q" position="77" name="PE15"/>
+        <pin device-size="g|i" device-variant="" position="77" name="PE14"/>
+        <pin device-size="g|i" device-variant="q" position="78" name="PB10"/>
+        <pin device-size="g|i" device-variant="" position="78" name="PE15"/>
+        <pin device-size="g|i" device-variant="q" position="79" name="PB11"/>
+        <pin device-size="g|i" device-variant="" position="79" name="PB10"/>
+        <pin device-size="g|i" device-variant="q" position="80" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="80" name="PB11"/>
+        <pin device-size="g|i" device-variant="q" position="81" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="81" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="82" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="82" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="83" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="83" name="PH6"/>
+        <pin device-size="g|i" device-variant="q" position="84" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="84" name="PH7"/>
+        <pin device-size="g|i" device-variant="q" position="85" name="PB12"/>
+        <pin device-size="g|i" device-variant="" position="85" name="PH8"/>
+        <pin device-size="g|i" device-variant="q" position="86" name="PB13"/>
+        <pin device-size="g|i" device-variant="" position="86" name="PH9"/>
+        <pin device-size="g|i" device-variant="q" position="87" name="PB14"/>
+        <pin device-size="g|i" device-variant="" position="87" name="PH10"/>
+        <pin device-size="g|i" device-variant="q" position="88" name="PB15"/>
+        <pin device-size="g|i" device-variant="" position="88" name="PH11"/>
+        <pin device-size="g|i" device-variant="q" position="89" name="PD8"/>
+        <pin device-size="g|i" device-variant="" position="89" name="PH12"/>
+        <pin device-size="g|i" device-variant="q" position="90" name="PD9"/>
+        <pin device-size="g|i" device-variant="" position="90" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="91" name="PD10"/>
+        <pin device-size="g|i" device-variant="" position="91" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="92" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="92" name="PB12"/>
+        <pin device-size="g|i" device-variant="q" position="93" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="93" name="PB13"/>
+        <pin device-size="g|i" device-variant="q" position="94" name="PD11"/>
+        <pin device-size="g|i" device-variant="" position="94" name="PB14"/>
+        <pin device-size="g|i" device-variant="q" position="95" name="PD12"/>
+        <pin device-size="g|i" device-variant="" position="95" name="PB15"/>
+        <pin device-size="g|i" device-variant="q" position="96" name="PD13"/>
+        <pin device-size="g|i" device-variant="" position="96" name="PD8"/>
+        <pin device-size="g|i" device-variant="q" position="97" name="PD14"/>
+        <pin device-size="g|i" device-variant="" position="97" name="PD9"/>
+        <pin device-size="g|i" device-variant="q" position="98" name="PD15"/>
+        <pin device-size="g|i" device-variant="" position="98" name="PD10"/>
+        <pin device-size="g|i" device-variant="q" position="99" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="99" name="PD11"/>
+        <pin device-size="g|i" device-variant="q" position="100" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="100" name="PD12"/>
+        <pin device-size="g|i" device-variant="q" position="101" name="PJ8"/>
+        <pin device-size="g|i" device-variant="" position="101" name="PD13"/>
+        <pin device-size="g|i" device-variant="q" position="102" name="PJ9"/>
+        <pin device-size="g|i" device-variant="" position="102" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="103" name="PJ10"/>
+        <pin device-size="g|i" device-variant="" position="103" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="104" name="PJ11"/>
+        <pin device-size="g|i" device-variant="" position="104" name="PD14"/>
+        <pin device-size="g|i" device-variant="q" position="105" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="105" name="PD15"/>
+        <pin device-size="g|i" device-variant="q" position="106" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="106" name="PG2"/>
+        <pin device-size="g|i" device-variant="q" position="107" name="PK0"/>
+        <pin device-size="g|i" device-variant="" position="107" name="PG3"/>
+        <pin device-size="g|i" device-variant="q" position="108" name="PK1"/>
+        <pin device-size="g|i" device-variant="" position="108" name="PG4"/>
+        <pin device-size="g|i" device-variant="q" position="109" name="PK2"/>
+        <pin device-size="g|i" device-variant="" position="109" name="PG5"/>
+        <pin device-size="g|i" device-variant="q" position="110" name="PG2"/>
+        <pin device-size="g|i" device-variant="" position="110" name="PG6"/>
+        <pin device-size="g|i" device-variant="q" position="111" name="PG3"/>
+        <pin device-size="g|i" device-variant="" position="111" name="PG7"/>
+        <pin device-size="g|i" device-variant="q" position="112" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="112" name="PG8"/>
+        <pin device-size="g|i" device-variant="q" position="113" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="113" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="114" name="PG4"/>
+        <pin device-size="g|i" device-variant="" position="114" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="115" name="PG5"/>
+        <pin device-size="g|i" device-variant="" position="115" name="PC6"/>
+        <pin device-size="g|i" device-variant="q" position="116" name="PG6"/>
+        <pin device-size="g|i" device-variant="" position="116" name="PC7"/>
+        <pin device-size="g|i" device-variant="q" position="117" name="PG7"/>
+        <pin device-size="g|i" device-variant="" position="117" name="PC8"/>
+        <pin device-size="g|i" device-variant="q" position="118" name="PG8"/>
+        <pin device-size="g|i" device-variant="" position="118" name="PC9"/>
+        <pin device-size="g|i" device-variant="q" position="119" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="119" name="PA8"/>
+        <pin device-size="g|i" device-variant="q" position="120" name="VDD50_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="120" name="PA9"/>
+        <pin device-size="g|i" device-variant="q" position="121" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="121" name="PA10"/>
+        <pin device-size="g|i" device-variant="q" position="122" name="PC6"/>
+        <pin device-size="g|i" device-variant="" position="122" name="PA11"/>
+        <pin device-size="g|i" device-variant="q" position="123" name="PC7"/>
+        <pin device-size="g|i" device-variant="" position="123" name="PA12"/>
+        <pin device-size="g|i" device-variant="q" position="124" name="PC8"/>
+        <pin device-size="g|i" device-variant="" position="124" name="PA13"/>
+        <pin device-size="g|i" device-variant="q" position="125" name="PC9"/>
+        <pin device-size="g|i" device-variant="" position="125" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="126" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="126" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="127" name="PA8"/>
+        <pin device-size="g|i" device-variant="" position="127" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="128" name="PA9"/>
+        <pin device-size="g|i" device-variant="" position="128" name="PH13"/>
+        <pin device-size="g|i" device-variant="q" position="129" name="PA10"/>
+        <pin device-size="g|i" device-variant="" position="129" name="PH14"/>
+        <pin device-size="g|i" device-variant="q" position="130" name="PA11"/>
+        <pin device-size="g|i" device-variant="" position="130" name="PH15"/>
+        <pin device-size="g|i" device-variant="q" position="131" name="PA12"/>
+        <pin device-size="g|i" device-variant="" position="131" name="PI0"/>
+        <pin device-size="g|i" device-variant="q" position="132" name="PA13"/>
+        <pin device-size="g|i" device-variant="" position="132" name="PI1"/>
+        <pin device-size="g|i" device-variant="q" position="133" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="133" name="PI2"/>
+        <pin device-size="g|i" device-variant="q" position="134" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="134" name="PI3"/>
+        <pin device-size="g|i" device-variant="q" position="135" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="137" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="137" name="PA14"/>
+        <pin device-size="g|i" device-variant="q" position="138" name="PA14"/>
+        <pin device-size="g|i" device-variant="" position="138" name="PA15"/>
+        <pin device-size="g|i" device-variant="q" position="139" name="PA15"/>
+        <pin device-size="g|i" device-variant="" position="139" name="PC10"/>
+        <pin device-size="g|i" device-variant="q" position="140" name="PC10"/>
+        <pin device-size="g|i" device-variant="" position="140" name="PC11"/>
+        <pin device-size="g|i" device-variant="q" position="141" name="PC11"/>
+        <pin device-size="g|i" device-variant="" position="141" name="PC12"/>
+        <pin device-size="g|i" device-variant="q" position="142" name="PC12"/>
+        <pin device-size="g|i" device-variant="" position="142" name="PD0"/>
+        <pin device-size="g|i" device-variant="q" position="143" name="PD0"/>
+        <pin device-size="g|i" device-variant="" position="143" name="PD1"/>
+        <pin device-size="g|i" device-variant="q" position="144" name="PD1"/>
+        <pin device-size="g|i" device-variant="" position="144" name="PD2"/>
+        <pin device-size="g|i" device-variant="q" position="145" name="PD2"/>
+        <pin device-size="g|i" device-variant="" position="145" name="PD3"/>
+        <pin device-size="g|i" device-variant="q" position="146" name="PD3"/>
+        <pin device-size="g|i" device-variant="" position="146" name="PD4"/>
+        <pin device-size="g|i" device-variant="q" position="147" name="PD4"/>
+        <pin device-size="g|i" device-variant="" position="147" name="PD5"/>
+        <pin device-size="g|i" device-variant="q" position="148" name="PD5"/>
+        <pin device-size="g|i" device-variant="" position="148" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="149" name="PD6"/>
+        <pin device-size="g|i" device-variant="" position="149" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="150" name="PD7"/>
+        <pin device-size="g|i" device-variant="" position="150" name="PD6"/>
+        <pin device-size="g|i" device-variant="q" position="151" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="151" name="PD7"/>
+        <pin device-size="g|i" device-variant="q" position="152" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="" position="152" name="PG9"/>
+        <pin device-size="g|i" device-variant="q" position="153" name="PG9"/>
+        <pin device-size="g|i" device-variant="" position="153" name="PG10"/>
+        <pin device-size="g|i" device-variant="q" position="154" name="PG10"/>
+        <pin device-size="g|i" device-variant="" position="154" name="PG11"/>
+        <pin device-size="g|i" device-variant="q" position="155" name="PG11"/>
+        <pin device-size="g|i" device-variant="" position="155" name="PG12"/>
+        <pin device-size="g|i" device-variant="q" position="156" name="PG12"/>
+        <pin device-size="g|i" device-variant="" position="156" name="PG13"/>
+        <pin device-size="g|i" device-variant="q" position="157" name="PG13"/>
+        <pin device-size="g|i" device-variant="" position="157" name="PG14"/>
+        <pin device-size="g|i" device-variant="q" position="158" name="PG14"/>
+        <pin device-size="g|i" device-variant="" position="158" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="159" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="159" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="160" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="160" name="PG15"/>
+        <pin device-size="g|i" device-variant="q" position="161" name="PG15"/>
+        <pin device-size="g|i" device-variant="" position="161" name="PB3"/>
+        <pin device-size="g|i" device-variant="q" position="162" name="PB3"/>
+        <pin device-size="g|i" device-variant="" position="162" name="PB4"/>
+        <pin device-size="g|i" device-variant="q" position="163" name="PB4"/>
+        <pin device-size="g|i" device-variant="" position="163" name="PB5"/>
+        <pin device-size="g|i" device-variant="q" position="164" name="PB5"/>
+        <pin device-size="g|i" device-variant="" position="164" name="PB6"/>
+        <pin device-size="g|i" device-variant="q" position="165" name="PB6"/>
+        <pin device-size="g|i" device-variant="" position="165" name="PB7"/>
+        <pin device-size="g|i" device-variant="q" position="166" name="PB7"/>
+        <pin device-size="g|i" device-variant="" position="166" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="q" position="167" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="" position="167" name="PB8"/>
+        <pin device-size="g|i" device-variant="q" position="168" name="PB8"/>
+        <pin device-size="g|i" device-variant="" position="168" name="PB9"/>
+        <pin device-size="g|i" device-variant="q" position="169" name="PB9"/>
+        <pin device-size="g|i" device-variant="" position="169" name="PE0"/>
+        <pin device-size="g|i" device-variant="q" position="170" name="PE0"/>
+        <pin device-size="g|i" device-variant="" position="170" name="PE1"/>
+        <pin device-size="g|i" device-variant="q" position="171" name="PE1"/>
+        <pin device-size="g|i" device-variant="" position="171" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="172" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="172" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="173" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="173" name="PI4"/>
+        <pin device-size="g|i" device-variant="q" position="174" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="174" name="PI5"/>
+        <pin device-size="g|i" device-variant="q" position="175" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="175" name="PI6"/>
+        <pin device-size="g|i" device-variant="q" position="176" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="176" name="PI7"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC9"/>
+        <pin position="40" name="PA8"/>
+        <pin position="41" name="PA9"/>
+        <pin position="42" name="PA10"/>
+        <pin position="43" name="PA11"/>
+        <pin position="44" name="PA12"/>
+        <pin position="45" name="PA13"/>
+        <pin position="46" name="VCAP" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin device-size="g|i" device-variant="q" position="A1" name="PE6"/>
+        <pin device-size="g|i" device-variant="" position="A1" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="q" position="A2" name="PE5"/>
+        <pin device-size="g|i" device-variant="" position="A2" name="PC13"/>
+        <pin position="A3" name="PE2"/>
+        <pin device-size="g|i" device-variant="q" position="A4" name="PB8"/>
+        <pin device-size="g|i" device-variant="" position="A4" name="PB9"/>
+        <pin device-size="g|i" device-variant="q" position="A5" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="" position="A5" name="PB7"/>
+        <pin device-size="g|i" device-variant="q" position="A6" name="PB5"/>
+        <pin device-size="g|i" device-variant="" position="A6" name="PB4"/>
+        <pin device-size="g|i" device-variant="q" position="A7" name="PD6"/>
+        <pin device-size="g|i" device-variant="" position="A7" name="PB3"/>
+        <pin device-size="g|i" device-variant="q" position="A8" name="PD3"/>
+        <pin device-size="g|i" device-variant="" position="A8" name="PA15"/>
+        <pin device-size="g|i" device-variant="q" position="A9" name="PD2"/>
+        <pin device-size="g|i" device-variant="" position="A9" name="PA14"/>
+        <pin device-size="g|i" device-variant="q" position="A10" name="PC12"/>
+        <pin device-size="g|i" device-variant="" position="A10" name="PA13"/>
+        <pin device-size="g|i" device-variant="q" position="B1" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="" position="B1" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="B2" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="" position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin device-size="g|i" device-variant="q" position="B4" name="PE0"/>
+        <pin device-size="g|i" device-variant="" position="B4" name="PB8"/>
+        <pin device-size="g|i" device-variant="q" position="B5" name="PB7"/>
+        <pin device-size="g|i" device-variant="" position="B5" name="PB6"/>
+        <pin device-size="g|i" device-variant="q" position="B6" name="PB3"/>
+        <pin device-size="g|i" device-variant="" position="B6" name="PD5"/>
+        <pin device-size="g|i" device-variant="q" position="B7" name="PD4"/>
+        <pin device-size="g|i" device-variant="" position="B7" name="PD2"/>
+        <pin device-size="g|i" device-variant="q" position="B8" name="PD1"/>
+        <pin device-size="g|i" device-variant="" position="B8" name="PC11"/>
+        <pin device-size="g|i" device-variant="q" position="B9" name="PC11"/>
+        <pin device-size="g|i" device-variant="" position="B9" name="PC10"/>
+        <pin device-size="g|i" device-variant="q" position="B10" name="PC10"/>
+        <pin device-size="g|i" device-variant="" position="B10" name="PA12"/>
+        <pin device-size="g|i" device-variant="q" position="C1" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="C1" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="q" position="C2" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="" position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin device-size="g|i" device-variant="q" position="C5" name="PB4"/>
+        <pin device-size="g|i" device-variant="" position="C5" name="PB5"/>
+        <pin device-size="g|i" device-variant="q" position="C6" name="PD7"/>
+        <pin device-size="g|i" device-variant="" position="C6" name="PD6"/>
+        <pin device-size="g|i" device-variant="q" position="C7" name="PD0"/>
+        <pin device-size="g|i" device-variant="" position="C7" name="PD3"/>
+        <pin device-size="g|i" device-variant="q" position="C8" name="PA15"/>
+        <pin device-size="g|i" device-variant="" position="C8" name="PC12"/>
+        <pin device-size="g|i" device-variant="q" position="C9" name="PA14"/>
+        <pin device-size="g|i" device-variant="" position="C9" name="PA9"/>
+        <pin device-size="g|i" device-variant="q" position="C10" name="PA13"/>
+        <pin device-size="g|i" device-variant="" position="C10" name="PA11"/>
+        <pin device-size="g|i" device-variant="q" position="D1" name="VSSSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D1" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="D2" name="VLXSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D2" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="D3" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="D3" name="PE5"/>
+        <pin device-size="g|i" device-variant="q" position="D4" name="PB6"/>
+        <pin device-size="g|i" device-variant="" position="D4" name="PE0"/>
+        <pin device-size="g|i" device-variant="q" position="D5" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D5" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="q" position="D6" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D6" name="PD7"/>
+        <pin device-size="g|i" device-variant="q" position="D7" name="PD5"/>
+        <pin device-size="g|i" device-variant="" position="D7" name="PD4"/>
+        <pin device-size="g|i" device-variant="q" position="D8" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D8" name="PD0"/>
+        <pin device-size="g|i" device-variant="q" position="D9" name="PA12"/>
+        <pin device-size="g|i" device-variant="" position="D9" name="PA8"/>
+        <pin device-size="g|i" device-variant="q" position="D10" name="PA11"/>
+        <pin device-size="g|i" device-variant="" position="D10" name="PA10"/>
+        <pin device-size="g|i" device-variant="q" position="E1" name="VDDSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E1" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="E2" name="VFBSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E2" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="q" position="E3" name="PB9"/>
+        <pin device-size="g|i" device-variant="" position="E3" name="PE6"/>
+        <pin device-size="g|i" device-variant="q" position="E4" name="PC13"/>
+        <pin device-size="g|i" device-variant="" position="E4" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="E5" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E5" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="E6" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E6" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="E7" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E7" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="E8" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E8" name="PD1"/>
+        <pin device-size="g|i" device-variant="q" position="E9" name="PA9"/>
+        <pin device-size="g|i" device-variant="" position="E9" name="PC9"/>
+        <pin device-size="g|i" device-variant="q" position="E10" name="PA10"/>
+        <pin device-size="g|i" device-variant="" position="E10" name="PC7"/>
+        <pin device-size="g|i" device-variant="q" position="F1" name="PC1"/>
+        <pin device-size="g|i" device-variant="" position="F1" name="PC0"/>
+        <pin device-size="g|i" device-variant="q" position="F2" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="F2" name="PC1"/>
+        <pin device-size="g|i" device-variant="q" position="F3" name="PC0"/>
+        <pin device-size="g|i" device-variant="" position="F3" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="q" position="F4" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="" position="F4" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F5" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F5" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F6" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F6" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F7" name="VDD50_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F7" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="F8" name="PC6"/>
+        <pin device-size="g|i" device-variant="" position="F8" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F9" name="PC9"/>
+        <pin device-size="g|i" device-variant="" position="F9" name="PC8"/>
+        <pin device-size="g|i" device-variant="q" position="F10" name="PA8"/>
+        <pin device-size="g|i" device-variant="" position="F10" name="PC6"/>
+        <pin device-size="g|i" device-variant="q" position="G1" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="" position="G1" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G2" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="" position="G2" name="PA0"/>
+        <pin device-size="g|i" device-variant="q" position="G3" name="PA0"/>
+        <pin device-size="g|i" device-variant="" position="G3" name="PA4"/>
+        <pin device-size="g|i" device-variant="q" position="G4" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="" position="G4" name="PC4"/>
+        <pin device-size="g|i" device-variant="q" position="G5" name="PA3"/>
+        <pin device-size="g|i" device-variant="" position="G5" name="PB2"/>
+        <pin device-size="g|i" device-variant="q" position="G6" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="G6" name="PE10"/>
+        <pin device-size="g|i" device-variant="q" position="G7" name="PD14"/>
+        <pin device-size="g|i" device-variant="" position="G7" name="PE14"/>
+        <pin position="G8" name="PD15"/>
+        <pin device-size="g|i" device-variant="q" position="G9" name="PC7"/>
+        <pin device-size="g|i" device-variant="" position="G9" name="PD11"/>
+        <pin device-size="g|i" device-variant="q" position="G10" name="PC8"/>
+        <pin device-size="g|i" device-variant="" position="G10" name="PB15"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="H2" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="H2" name="PA1"/>
+        <pin device-size="g|i" device-variant="q" position="H3" name="PA2"/>
+        <pin device-size="g|i" device-variant="" position="H3" name="PA5"/>
+        <pin device-size="g|i" device-variant="q" position="H4" name="PC4"/>
+        <pin device-size="g|i" device-variant="" position="H4" name="PC5"/>
+        <pin position="H5" name="PE7"/>
+        <pin device-size="g|i" device-variant="q" position="H6" name="PE10"/>
+        <pin device-size="g|i" device-variant="" position="H6" name="PE11"/>
+        <pin device-size="g|i" device-variant="q" position="H7" name="PD11"/>
+        <pin device-size="g|i" device-variant="" position="H7" name="PE15"/>
+        <pin device-size="g|i" device-variant="q" position="H8" name="PD9"/>
+        <pin device-size="g|i" device-variant="" position="H8" name="PD14"/>
+        <pin device-size="g|i" device-variant="q" position="H9" name="PD12"/>
+        <pin device-size="g|i" device-variant="" position="H9" name="PD10"/>
+        <pin device-size="g|i" device-variant="q" position="H10" name="PD13"/>
+        <pin device-size="g|i" device-variant="" position="H10" name="PB14"/>
+        <pin device-size="g|i" device-variant="q" position="J1" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="" position="J1" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="J2" name="PA1"/>
+        <pin device-size="g|i" device-variant="" position="J2" name="PA2"/>
+        <pin position="J3" name="PA6"/>
+        <pin device-size="g|i" device-variant="q" position="J4" name="PC5"/>
+        <pin device-size="g|i" device-variant="" position="J4" name="PB0"/>
+        <pin device-size="g|i" device-variant="q" position="J5" name="PB2"/>
+        <pin device-size="g|i" device-variant="" position="J5" name="PE8"/>
+        <pin device-size="g|i" device-variant="q" position="J6" name="PE8"/>
+        <pin device-size="g|i" device-variant="" position="J6" name="PE12"/>
+        <pin device-size="g|i" device-variant="q" position="J7" name="PB11"/>
+        <pin device-size="g|i" device-variant="" position="J7" name="PB10"/>
+        <pin position="J8" name="PB13"/>
+        <pin device-size="g|i" device-variant="q" position="J9" name="PD8"/>
+        <pin device-size="g|i" device-variant="" position="J9" name="PD9"/>
+        <pin device-size="g|i" device-variant="q" position="J10" name="PD10"/>
+        <pin device-size="g|i" device-variant="" position="J10" name="PD13"/>
+        <pin device-size="g|i" device-variant="q" position="K1" name="PA4"/>
+        <pin device-size="g|i" device-variant="" position="K1" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="K2" name="PA5"/>
+        <pin device-size="g|i" device-variant="" position="K2" name="PA3"/>
+        <pin position="K3" name="PA7"/>
+        <pin device-size="g|i" device-variant="q" position="K4" name="PB0"/>
+        <pin device-size="g|i" device-variant="" position="K4" name="PB1"/>
+        <pin device-size="g|i" device-variant="q" position="K5" name="PB1"/>
+        <pin device-size="g|i" device-variant="" position="K5" name="PE9"/>
+        <pin device-size="g|i" device-variant="q" position="K6" name="PE9"/>
+        <pin device-size="g|i" device-variant="" position="K6" name="PE13"/>
+        <pin device-size="g|i" device-variant="q" position="K7" name="PB10"/>
+        <pin device-size="g|i" device-variant="" position="K7" name="PB11"/>
+        <pin position="K8" name="PB12"/>
+        <pin device-size="g|i" device-variant="q" position="K9" name="PB14"/>
+        <pin device-size="g|i" device-variant="" position="K9" name="PD8"/>
+        <pin device-size="g|i" device-variant="q" position="K10" name="PB15"/>
+        <pin device-size="g|i" device-variant="" position="K10" name="PD12"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDDMMC" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="PK1"/>
+        <pin position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDD33_USB" type="power"/>
+        <pin position="G12" name="PJ11"/>
+        <pin position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD" type="power"/>
+        <pin position="H12" name="PJ8"/>
+        <pin position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PJ7"/>
+        <pin position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3_C"/>
+        <pin position="L5" name="VSS" type="power"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2_C"/>
+        <pin position="M5" name="PB2"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="monoio"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="l" name="TFBGA225">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI4"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PG15"/>
+        <pin position="A6" name="PK5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PG9"/>
+        <pin position="A10" name="PD7"/>
+        <pin position="A11" name="PD4"/>
+        <pin position="A12" name="PD1"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PI3"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE3"/>
+        <pin position="B2" name="PI5"/>
+        <pin position="B3" name="PE0"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PK6"/>
+        <pin position="B7" name="PK3"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ15"/>
+        <pin position="B10" name="PD6"/>
+        <pin position="B11" name="PD2"/>
+        <pin position="B12" name="PC12"/>
+        <pin position="B13" name="PA14"/>
+        <pin position="B14" name="PH15"/>
+        <pin position="B15" name="PH14"/>
+        <pin position="C1" name="PI8"/>
+        <pin position="C2" name="PE4"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB3"/>
+        <pin position="C7" name="PK4"/>
+        <pin position="C8" name="PG12"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD0"/>
+        <pin position="C12" name="PA15"/>
+        <pin position="C13" name="PI0"/>
+        <pin position="C14" name="PA12"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PC15-OSC32_OUT"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PDR_ON" type="reset"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG13"/>
+        <pin position="D9" name="PJ13"/>
+        <pin position="D10" name="PD3"/>
+        <pin position="D11" name="PC11"/>
+        <pin position="D12" name="PI2"/>
+        <pin position="D13" name="PH13"/>
+        <pin position="D14" name="VSS" type="power"/>
+        <pin position="D15" name="VDD50_USB" type="power"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PI9"/>
+        <pin position="E4" name="PE6"/>
+        <pin position="E5" name="PE2"/>
+        <pin position="E6" name="VCAP" type="power"/>
+        <pin position="E7" name="PB5"/>
+        <pin position="E8" name="VDDMMC" type="power"/>
+        <pin position="E9" name="PJ12"/>
+        <pin position="E10" name="VDDLDO" type="power"/>
+        <pin position="E11" name="PI1"/>
+        <pin position="E12" name="PA13"/>
+        <pin position="E13" name="PA10"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PC7"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PC13"/>
+        <pin position="F5" name="VDDLDO" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VCAP" type="power"/>
+        <pin position="F12" name="PA9"/>
+        <pin position="F13" name="PC8"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VSSSMPS" type="power"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="PI11"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VDD" type="power"/>
+        <pin position="G10" name="VDD" type="power"/>
+        <pin position="G11" name="PA8"/>
+        <pin position="G12" name="PG7"/>
+        <pin position="G13" name="PG6"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG3"/>
+        <pin position="H1" name="PF2"/>
+        <pin position="H2" name="PI12"/>
+        <pin position="H3" name="PF4"/>
+        <pin position="H4" name="PI14"/>
+        <pin position="H5" name="PI13"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD33_USB" type="power"/>
+        <pin position="H12" name="PG4"/>
+        <pin position="H13" name="PG2"/>
+        <pin position="H14" name="PK2"/>
+        <pin position="H15" name="PK1"/>
+        <pin position="J1" name="PF3"/>
+        <pin position="J2" name="PF5"/>
+        <pin position="J3" name="PF6"/>
+        <pin position="J4" name="PF7"/>
+        <pin position="J5" name="PC2"/>
+        <pin position="J6" name="VDD" type="power"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VDD" type="power"/>
+        <pin position="J10" name="VDD" type="power"/>
+        <pin position="J11" name="PJ11"/>
+        <pin position="J12" name="PK0"/>
+        <pin position="J13" name="PJ10"/>
+        <pin position="J14" name="PJ9"/>
+        <pin position="J15" name="PJ8"/>
+        <pin position="K1" name="PF8"/>
+        <pin position="K2" name="PF9"/>
+        <pin position="K3" name="NRST" type="reset"/>
+        <pin position="K4" name="VREF-" type="power"/>
+        <pin position="K5" name="VSSA" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VDD" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VDD" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="PD13"/>
+        <pin position="K12" name="PD14"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PJ6"/>
+        <pin position="K15" name="PJ7"/>
+        <pin position="L1" name="PH0-OSC_IN"/>
+        <pin position="L2" name="PH1-OSC_OUT"/>
+        <pin position="L3" name="PC0"/>
+        <pin position="L4" name="VREF+" type="monoio"/>
+        <pin position="L5" name="VDDA" type="power"/>
+        <pin position="L6" name="PA4"/>
+        <pin position="L7" name="PB1"/>
+        <pin position="L8" name="VCAP" type="power"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="VDDLDO" type="power"/>
+        <pin position="L11" name="PH12"/>
+        <pin position="L12" name="PD8"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD11"/>
+        <pin position="L15" name="PD12"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PF10"/>
+        <pin position="M4" name="PH2"/>
+        <pin position="M5" name="PH4"/>
+        <pin position="M6" name="PC4"/>
+        <pin position="M7" name="PI15"/>
+        <pin position="M8" name="PF13"/>
+        <pin position="M9" name="PE7"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH10"/>
+        <pin position="M13" name="PB13"/>
+        <pin position="M14" name="PB14"/>
+        <pin position="M15" name="PB15"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="PC3"/>
+        <pin position="N4" name="PH3"/>
+        <pin position="N5" name="PA5"/>
+        <pin position="N6" name="PC5"/>
+        <pin position="N7" name="PJ0"/>
+        <pin position="N8" name="PF11"/>
+        <pin position="N9" name="PF15"/>
+        <pin position="N10" name="PE14"/>
+        <pin position="N11" name="PE10"/>
+        <pin position="N12" name="PJ5"/>
+        <pin position="N13" name="PH9"/>
+        <pin position="N14" name="PB12"/>
+        <pin position="N15" name="PD9"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA0_C"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PA6"/>
+        <pin position="P6" name="PB0"/>
+        <pin position="P7" name="PJ1"/>
+        <pin position="P8" name="PJ4"/>
+        <pin position="P9" name="PF14"/>
+        <pin position="P10" name="PG1"/>
+        <pin position="P11" name="PE9"/>
+        <pin position="P12" name="PE15"/>
+        <pin position="P13" name="PB11"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH11"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA1_C"/>
+        <pin position="R4" name="PA3"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PJ2"/>
+        <pin position="R8" name="PJ3"/>
+        <pin position="R9" name="PF12"/>
+        <pin position="R10" name="PG0"/>
+        <pin position="R11" name="PE8"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="PB10"/>
+        <pin position="R14" name="PH7"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="VDDMMC" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="B13" name="PH13"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="reset"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VSSSMPS" type="power"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50_USB" type="power"/>
+        <pin position="G13" name="VDD33_USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN"/>
+        <pin position="H2" name="PH1-OSC_OUT"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PC2"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PA0_C"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PA1_C"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin device-size="g|i" device-variant="q" position="A1" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A1" name="PE3"/>
+        <pin device-size="g|i" device-variant="q" position="A2" name="PB8"/>
+        <pin device-size="g|i" device-variant="" position="A2" name="PE2"/>
+        <pin device-size="g|i" device-variant="q" position="A3" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A3" name="PE1"/>
+        <pin device-size="g|i" device-variant="q" position="A4" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A4" name="PE0"/>
+        <pin device-size="g|i" device-variant="q" position="A5" name="PB6"/>
+        <pin device-size="g|i" device-variant="" position="A5" name="PB8"/>
+        <pin device-size="g|i" device-variant="q" position="A6" name="PB3"/>
+        <pin device-size="g|i" device-variant="" position="A6" name="PB5"/>
+        <pin device-size="g|i" device-variant="q" position="A7" name="PG11"/>
+        <pin device-size="g|i" device-variant="" position="A7" name="PG14"/>
+        <pin device-size="g|i" device-variant="q" position="A8" name="PG9"/>
+        <pin device-size="g|i" device-variant="" position="A8" name="PG13"/>
+        <pin device-size="g|i" device-variant="q" position="A9" name="PD3"/>
+        <pin device-size="g|i" device-variant="" position="A9" name="PB4"/>
+        <pin device-size="g|i" device-variant="q" position="A10" name="PD1"/>
+        <pin device-size="g|i" device-variant="" position="A10" name="PB3"/>
+        <pin device-size="g|i" device-variant="q" position="A11" name="PA15"/>
+        <pin device-size="g|i" device-variant="" position="A11" name="PD7"/>
+        <pin device-size="g|i" device-variant="q" position="A12" name="PA14"/>
+        <pin device-size="g|i" device-variant="" position="A12" name="PC12"/>
+        <pin device-size="g|i" device-variant="q" position="A13" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A13" name="PA15"/>
+        <pin device-size="g|i" device-variant="q" position="A14" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A14" name="PA14"/>
+        <pin device-size="g|i" device-variant="q" position="A15" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="A15" name="PA13"/>
+        <pin position="B1" name="PE4"/>
+        <pin device-size="g|i" device-variant="q" position="B2" name="PE3"/>
+        <pin device-size="g|i" device-variant="" position="B2" name="PE5"/>
+        <pin device-size="g|i" device-variant="q" position="B3" name="PB9"/>
+        <pin device-size="g|i" device-variant="" position="B3" name="PE6"/>
+        <pin device-size="g|i" device-variant="q" position="B4" name="PE0"/>
+        <pin device-size="g|i" device-variant="" position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin device-size="g|i" device-variant="q" position="B6" name="PB4"/>
+        <pin device-size="g|i" device-variant="" position="B6" name="PB6"/>
+        <pin device-size="g|i" device-variant="q" position="B7" name="PG13"/>
+        <pin device-size="g|i" device-variant="" position="B7" name="PG15"/>
+        <pin device-size="g|i" device-variant="q" position="B8" name="PD7"/>
+        <pin device-size="g|i" device-variant="" position="B8" name="PG12"/>
+        <pin device-size="g|i" device-variant="q" position="B9" name="PD5"/>
+        <pin device-size="g|i" device-variant="" position="B9" name="PG11"/>
+        <pin device-size="g|i" device-variant="q" position="B10" name="PD2"/>
+        <pin device-size="g|i" device-variant="" position="B10" name="PG10"/>
+        <pin device-size="g|i" device-variant="q" position="B11" name="PC12"/>
+        <pin device-size="g|i" device-variant="" position="B11" name="PD6"/>
+        <pin device-size="g|i" device-variant="q" position="B12" name="PH14"/>
+        <pin device-size="g|i" device-variant="" position="B12" name="PD0"/>
+        <pin device-size="g|i" device-variant="q" position="B13" name="PA13"/>
+        <pin device-size="g|i" device-variant="" position="B13" name="PC11"/>
+        <pin device-size="g|i" device-variant="q" position="B14" name="PA8"/>
+        <pin device-size="g|i" device-variant="" position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin device-size="g|i" device-variant="q" position="C1" name="PC13"/>
+        <pin device-size="g|i" device-variant="" position="C1" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="C2" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="C2" name="PI7"/>
+        <pin device-size="g|i" device-variant="q" position="C3" name="PE2"/>
+        <pin device-size="g|i" device-variant="" position="C3" name="PI6"/>
+        <pin device-size="g|i" device-variant="q" position="C4" name="PE1"/>
+        <pin device-size="g|i" device-variant="" position="C4" name="PI5"/>
+        <pin device-size="g|i" device-variant="q" position="C5" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="" position="C5" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="C6" name="PB5"/>
+        <pin device-size="g|i" device-variant="" position="C6" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="C7" name="PG14"/>
+        <pin device-size="g|i" device-variant="" position="C7" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="C8" name="PG10"/>
+        <pin device-size="g|i" device-variant="" position="C8" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="C9" name="PD4"/>
+        <pin device-size="g|i" device-variant="" position="C9" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="C10" name="PD0"/>
+        <pin device-size="g|i" device-variant="" position="C10" name="PG9"/>
+        <pin device-size="g|i" device-variant="q" position="C11" name="PC11"/>
+        <pin device-size="g|i" device-variant="" position="C11" name="PD5"/>
+        <pin device-size="g|i" device-variant="q" position="C12" name="PC10"/>
+        <pin device-size="g|i" device-variant="" position="C12" name="PD1"/>
+        <pin device-size="g|i" device-variant="q" position="C13" name="PH13"/>
+        <pin device-size="g|i" device-variant="" position="C13" name="PI3"/>
+        <pin device-size="g|i" device-variant="q" position="C14" name="PA10"/>
+        <pin device-size="g|i" device-variant="" position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin device-size="g|i" device-variant="q" position="D1" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="" position="D1" name="PC13"/>
+        <pin device-size="g|i" device-variant="q" position="D2" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="" position="D2" name="PI8"/>
+        <pin device-size="g|i" device-variant="q" position="D3" name="PE5"/>
+        <pin device-size="g|i" device-variant="" position="D3" name="PI9"/>
+        <pin device-size="g|i" device-variant="q" position="D4" name="PDR_ON" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="D4" name="PI4"/>
+        <pin device-size="g|i" device-variant="q" position="D5" name="VDDMMC" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D5" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="D6" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D6" name="BOOT0" type="boot"/>
+        <pin device-size="g|i" device-variant="q" position="D7" name="PG15"/>
+        <pin device-size="g|i" device-variant="" position="D7" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="D8" name="PG12"/>
+        <pin device-size="g|i" device-variant="" position="D8" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="D9" name="PD6"/>
+        <pin device-size="g|i" device-variant="" position="D9" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="D10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D10" name="PD4"/>
+        <pin device-size="g|i" device-variant="q" position="D11" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="D11" name="PD3"/>
+        <pin device-size="g|i" device-variant="q" position="D12" name="PH15"/>
+        <pin device-size="g|i" device-variant="" position="D12" name="PD2"/>
+        <pin device-size="g|i" device-variant="q" position="D13" name="PA9"/>
+        <pin device-size="g|i" device-variant="" position="D13" name="PH15"/>
+        <pin device-size="g|i" device-variant="q" position="D14" name="PC8"/>
+        <pin device-size="g|i" device-variant="" position="D14" name="PI1"/>
+        <pin device-size="g|i" device-variant="q" position="D15" name="PC7"/>
+        <pin device-size="g|i" device-variant="" position="D15" name="PA10"/>
+        <pin device-size="g|i" device-variant="q" position="E1" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E1" name="PC14-OSC32_IN"/>
+        <pin device-size="g|i" device-variant="q" position="E2" name="VBAT" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E2" name="PF0"/>
+        <pin device-size="g|i" device-variant="q" position="E3" name="PE6"/>
+        <pin device-size="g|i" device-variant="" position="E3" name="PI10"/>
+        <pin device-size="g|i" device-variant="q" position="E4" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E4" name="PI11"/>
+        <pin device-size="g|i" device-variant="q" position="E12" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E12" name="PH13"/>
+        <pin device-size="g|i" device-variant="q" position="E13" name="PC9"/>
+        <pin device-size="g|i" device-variant="" position="E13" name="PH14"/>
+        <pin device-size="g|i" device-variant="q" position="E14" name="PC6"/>
+        <pin device-size="g|i" device-variant="" position="E14" name="PI0"/>
+        <pin device-size="g|i" device-variant="q" position="E15" name="VDD50_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="E15" name="PA9"/>
+        <pin device-size="g|i" device-variant="q" position="F1" name="VLXSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F1" name="PC15-OSC32_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="F2" name="VSSSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F2" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F3" name="PF1"/>
+        <pin device-size="g|i" device-variant="" position="F3" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F4" name="PF0"/>
+        <pin device-size="g|i" device-variant="" position="F4" name="PH2"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F13" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="" position="F13" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="F14" name="PG6"/>
+        <pin device-size="g|i" device-variant="" position="F14" name="PC9"/>
+        <pin device-size="g|i" device-variant="q" position="F15" name="PG5"/>
+        <pin device-size="g|i" device-variant="" position="F15" name="PA8"/>
+        <pin device-size="g|i" device-variant="q" position="G1" name="VDDSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="G1" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="q" position="G2" name="VFBSMPS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="G2" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G3" name="PF2"/>
+        <pin device-size="g|i" device-variant="" position="G3" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G4" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="G4" name="PH3"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G12" name="PG8"/>
+        <pin device-size="g|i" device-variant="" position="G12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G13" name="PG7"/>
+        <pin device-size="g|i" device-variant="" position="G13" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="G14" name="PG4"/>
+        <pin device-size="g|i" device-variant="" position="G14" name="PC8"/>
+        <pin device-size="g|i" device-variant="q" position="G15" name="PG2"/>
+        <pin device-size="g|i" device-variant="" position="G15" name="PC7"/>
+        <pin device-size="g|i" device-variant="q" position="H1" name="PF6"/>
+        <pin device-size="g|i" device-variant="" position="H1" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="q" position="H2" name="PF4"/>
+        <pin device-size="g|i" device-variant="" position="H2" name="PF2"/>
+        <pin device-size="g|i" device-variant="q" position="H3" name="PF5"/>
+        <pin device-size="g|i" device-variant="" position="H3" name="PF1"/>
+        <pin device-size="g|i" device-variant="q" position="H4" name="PF3"/>
+        <pin device-size="g|i" device-variant="" position="H4" name="PH4"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="H12" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="H12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="H13" name="PG3"/>
+        <pin device-size="g|i" device-variant="" position="H13" name="VDD33_USB" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="H14" name="PD14"/>
+        <pin device-size="g|i" device-variant="" position="H14" name="PG8"/>
+        <pin device-size="g|i" device-variant="q" position="H15" name="PD13"/>
+        <pin device-size="g|i" device-variant="" position="H15" name="PC6"/>
+        <pin device-size="g|i" device-variant="q" position="J1" name="PH0-OSC_IN"/>
+        <pin device-size="g|i" device-variant="" position="J1" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="q" position="J2" name="PF8"/>
+        <pin device-size="g|i" device-variant="" position="J2" name="PF3"/>
+        <pin device-size="g|i" device-variant="q" position="J3" name="PF7"/>
+        <pin device-size="g|i" device-variant="" position="J3" name="PF4"/>
+        <pin device-size="g|i" device-variant="q" position="J4" name="PF9"/>
+        <pin device-size="g|i" device-variant="" position="J4" name="PH5"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="J12" name="PD15"/>
+        <pin device-size="g|i" device-variant="" position="J12" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="J13" name="PD11"/>
+        <pin device-size="g|i" device-variant="" position="J13" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="J14" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="J14" name="PG7"/>
+        <pin device-size="g|i" device-variant="q" position="J15" name="PD12"/>
+        <pin device-size="g|i" device-variant="" position="J15" name="PG6"/>
+        <pin device-size="g|i" device-variant="q" position="K1" name="PH1-OSC_OUT"/>
+        <pin device-size="g|i" device-variant="" position="K1" name="PF7"/>
+        <pin device-size="g|i" device-variant="q" position="K2" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="K2" name="PF6"/>
+        <pin device-size="g|i" device-variant="q" position="K3" name="PF10"/>
+        <pin device-size="g|i" device-variant="" position="K3" name="PF5"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="K12" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="K12" name="PH12"/>
+        <pin device-size="g|i" device-variant="q" position="K13" name="PD9"/>
+        <pin device-size="g|i" device-variant="" position="K13" name="PG5"/>
+        <pin device-size="g|i" device-variant="q" position="K14" name="PB15"/>
+        <pin device-size="g|i" device-variant="" position="K14" name="PG4"/>
+        <pin device-size="g|i" device-variant="q" position="K15" name="PB14"/>
+        <pin device-size="g|i" device-variant="" position="K15" name="PG3"/>
+        <pin device-size="g|i" device-variant="q" position="L1" name="NRST" type="reset"/>
+        <pin device-size="g|i" device-variant="" position="L1" name="PF10"/>
+        <pin device-size="g|i" device-variant="q" position="L2" name="PC0"/>
+        <pin device-size="g|i" device-variant="" position="L2" name="PF9"/>
+        <pin device-size="g|i" device-variant="q" position="L3" name="PC1"/>
+        <pin device-size="g|i" device-variant="" position="L3" name="PF8"/>
+        <pin device-size="g|i" device-variant="q" position="L4" name="VREF-" type="power"/>
+        <pin device-size="g|i" device-variant="" position="L4" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="L12" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="L12" name="PH11"/>
+        <pin device-size="g|i" device-variant="q" position="L13" name="PD10"/>
+        <pin device-size="g|i" device-variant="" position="L13" name="PH10"/>
+        <pin device-size="g|i" device-variant="q" position="L14" name="PD8"/>
+        <pin device-size="g|i" device-variant="" position="L14" name="PD15"/>
+        <pin device-size="g|i" device-variant="q" position="L15" name="PB13"/>
+        <pin device-size="g|i" device-variant="" position="L15" name="PG2"/>
+        <pin device-size="g|i" device-variant="q" position="M1" name="PC2"/>
+        <pin device-size="g|i" device-variant="" position="M1" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="M2" name="PC3"/>
+        <pin device-size="g|i" device-variant="" position="M2" name="PC0"/>
+        <pin device-size="g|i" device-variant="q" position="M3" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="" position="M3" name="PC1"/>
+        <pin device-size="g|i" device-variant="q" position="M4" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="M4" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="q" position="M5" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="M5" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="q" position="M6" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="M6" name="PB2"/>
+        <pin device-size="g|i" device-variant="q" position="M7" name="PC5"/>
+        <pin device-size="g|i" device-variant="" position="M7" name="PG1"/>
+        <pin device-size="g|i" device-variant="q" position="M8" name="PB1"/>
+        <pin device-size="g|i" device-variant="" position="M8" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="M9" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="" position="M9" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="M10" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="M10" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="M11" name="PH7"/>
+        <pin device-size="g|i" device-variant="" position="M11" name="PH6"/>
+        <pin device-size="g|i" device-variant="q" position="M12" name="PE14"/>
+        <pin device-size="g|i" device-variant="" position="M12" name="PH8"/>
+        <pin device-size="g|i" device-variant="q" position="M13" name="PH11"/>
+        <pin device-size="g|i" device-variant="" position="M13" name="PH9"/>
+        <pin device-size="g|i" device-variant="q" position="M14" name="PH9"/>
+        <pin device-size="g|i" device-variant="" position="M14" name="PD14"/>
+        <pin device-size="g|i" device-variant="q" position="M15" name="PB12"/>
+        <pin device-size="g|i" device-variant="" position="M15" name="PD13"/>
+        <pin device-size="g|i" device-variant="q" position="N1" name="PC2_C"/>
+        <pin device-size="g|i" device-variant="" position="N1" name="VREF-" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="N2" name="PC3_C"/>
+        <pin device-size="g|i" device-variant="" position="N2" name="PA1"/>
+        <pin device-size="g|i" device-variant="q" position="N3" name="VSSA" type="power"/>
+        <pin device-size="g|i" device-variant="" position="N3" name="PA0"/>
+        <pin device-size="g|i" device-variant="q" position="N4" name="PH2"/>
+        <pin device-size="g|i" device-variant="" position="N4" name="PA4"/>
+        <pin device-size="g|i" device-variant="q" position="N5" name="PA3"/>
+        <pin device-size="g|i" device-variant="" position="N5" name="PC4"/>
+        <pin device-size="g|i" device-variant="q" position="N6" name="PA7"/>
+        <pin device-size="g|i" device-variant="" position="N6" name="PF13"/>
+        <pin device-size="g|i" device-variant="q" position="N7" name="PF11"/>
+        <pin device-size="g|i" device-variant="" position="N7" name="PG0"/>
+        <pin device-size="g|i" device-variant="q" position="N8" name="PE8"/>
+        <pin device-size="g|i" device-variant="" position="N8" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="N9" name="PG1"/>
+        <pin device-size="g|i" device-variant="" position="N9" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="N10" name="PF15"/>
+        <pin device-size="g|i" device-variant="" position="N10" name="VDD" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="N11" name="PF13"/>
+        <pin device-size="g|i" device-variant="" position="N11" name="PE13"/>
+        <pin device-size="g|i" device-variant="q" position="N12" name="PB10"/>
+        <pin device-size="g|i" device-variant="" position="N12" name="PH7"/>
+        <pin device-size="g|i" device-variant="q" position="N13" name="PH8"/>
+        <pin device-size="g|i" device-variant="" position="N13" name="PD12"/>
+        <pin device-size="g|i" device-variant="q" position="N14" name="PH10"/>
+        <pin device-size="g|i" device-variant="" position="N14" name="PD11"/>
+        <pin device-size="g|i" device-variant="q" position="N15" name="PH12"/>
+        <pin device-size="g|i" device-variant="" position="N15" name="PD10"/>
+        <pin device-size="g|i" device-variant="q" position="P1" name="PA0"/>
+        <pin device-size="g|i" device-variant="" position="P1" name="VREF+" type="monoio"/>
+        <pin device-size="g|i" device-variant="q" position="P2" name="PA1"/>
+        <pin device-size="g|i" device-variant="" position="P2" name="PA2"/>
+        <pin device-size="g|i" device-variant="q" position="P3" name="PA1_C"/>
+        <pin device-size="g|i" device-variant="" position="P3" name="PA6"/>
+        <pin device-size="g|i" device-variant="q" position="P4" name="PH4"/>
+        <pin device-size="g|i" device-variant="" position="P4" name="PA5"/>
+        <pin device-size="g|i" device-variant="q" position="P5" name="PA4"/>
+        <pin device-size="g|i" device-variant="" position="P5" name="PC5"/>
+        <pin device-size="g|i" device-variant="q" position="P6" name="PA5"/>
+        <pin device-size="g|i" device-variant="" position="P6" name="PF12"/>
+        <pin device-size="g|i" device-variant="q" position="P7" name="PB2"/>
+        <pin device-size="g|i" device-variant="" position="P7" name="PF15"/>
+        <pin device-size="g|i" device-variant="q" position="P8" name="PG0"/>
+        <pin device-size="g|i" device-variant="" position="P8" name="PE8"/>
+        <pin device-size="g|i" device-variant="q" position="P9" name="PE7"/>
+        <pin device-size="g|i" device-variant="" position="P9" name="PE9"/>
+        <pin device-size="g|i" device-variant="q" position="P10" name="PB11"/>
+        <pin device-size="g|i" device-variant="" position="P10" name="PE11"/>
+        <pin device-size="g|i" device-variant="q" position="P11" name="PF12"/>
+        <pin device-size="g|i" device-variant="" position="P11" name="PE14"/>
+        <pin device-size="g|i" device-variant="q" position="P12" name="PE12"/>
+        <pin device-size="g|i" device-variant="" position="P12" name="PB12"/>
+        <pin device-size="g|i" device-variant="q" position="P13" name="PE13"/>
+        <pin device-size="g|i" device-variant="" position="P13" name="PB13"/>
+        <pin device-size="g|i" device-variant="q" position="P14" name="PE15"/>
+        <pin device-size="g|i" device-variant="" position="P14" name="PD9"/>
+        <pin device-size="g|i" device-variant="q" position="P15" name="PH6"/>
+        <pin device-size="g|i" device-variant="" position="P15" name="PD8"/>
+        <pin device-size="g|i" device-variant="q" position="R1" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="R1" name="VDDA" type="power"/>
+        <pin device-size="g|i" device-variant="q" position="R2" name="PA2"/>
+        <pin device-size="g|i" device-variant="" position="R2" name="PA3"/>
+        <pin device-size="g|i" device-variant="q" position="R3" name="PA0_C"/>
+        <pin device-size="g|i" device-variant="" position="R3" name="PA7"/>
+        <pin device-size="g|i" device-variant="q" position="R4" name="PH3"/>
+        <pin device-size="g|i" device-variant="" position="R4" name="PB1"/>
+        <pin device-size="g|i" device-variant="q" position="R5" name="PH5"/>
+        <pin device-size="g|i" device-variant="" position="R5" name="PB0"/>
+        <pin device-size="g|i" device-variant="q" position="R6" name="PC4"/>
+        <pin device-size="g|i" device-variant="" position="R6" name="PF11"/>
+        <pin device-size="g|i" device-variant="q" position="R7" name="PA6"/>
+        <pin device-size="g|i" device-variant="" position="R7" name="PF14"/>
+        <pin device-size="g|i" device-variant="q" position="R8" name="PB0"/>
+        <pin device-size="g|i" device-variant="" position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin device-size="g|i" device-variant="q" position="R10" name="PF14"/>
+        <pin device-size="g|i" device-variant="" position="R10" name="PE12"/>
+        <pin device-size="g|i" device-variant="q" position="R11" name="PE9"/>
+        <pin device-size="g|i" device-variant="" position="R11" name="PE15"/>
+        <pin device-size="g|i" device-variant="q" position="R12" name="PE11"/>
+        <pin device-size="g|i" device-variant="" position="R12" name="PB10"/>
+        <pin device-size="g|i" device-variant="q" position="R13" name="VCAP" type="power"/>
+        <pin device-size="g|i" device-variant="" position="R13" name="PB11"/>
+        <pin device-size="g|i" device-variant="q" position="R14" name="VDDLDO" type="power"/>
+        <pin device-size="g|i" device-variant="" position="R14" name="PB14"/>
+        <pin device-size="g|i" device-variant="q" position="R15" name="VSS" type="power"/>
+        <pin device-size="g|i" device-variant="" position="R15" name="PB15"/>
+      </package>
+      <package device-pin="q" name="WLCSP132">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="VDD" type="power"/>
+        <pin position="A3" name="PC10"/>
+        <pin position="A4" name="PD3"/>
+        <pin position="A5" name="VSS" type="power"/>
+        <pin position="A6" name="PG10"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="BOOT0" type="boot"/>
+        <pin position="A10" name="VCAP" type="power"/>
+        <pin position="A11" name="VDDLDO" type="power"/>
+        <pin position="A12" name="VDD" type="power"/>
+        <pin position="B1" name="VDDLDO" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PC12"/>
+        <pin position="B4" name="PD4"/>
+        <pin position="B5" name="VDDMMC" type="power"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="VDDMMC" type="power"/>
+        <pin position="B9" name="PB8"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="VDD" type="power"/>
+        <pin position="B12" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="VCAP" type="power"/>
+        <pin position="C3" name="PA15"/>
+        <pin position="C4" name="PD0"/>
+        <pin position="C5" name="PD5"/>
+        <pin position="C6" name="PG12"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PB6"/>
+        <pin position="C9" name="PE1"/>
+        <pin position="C10" name="PE6"/>
+        <pin position="C11" name="PC15-OSC32_OUT"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA13"/>
+        <pin position="D4" name="PC11"/>
+        <pin position="D5" name="PD2"/>
+        <pin position="D6" name="PG9"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PB7"/>
+        <pin position="D9" name="PDR_ON" type="reset"/>
+        <pin position="D10" name="PE5"/>
+        <pin position="D11" name="VBAT" type="power"/>
+        <pin position="D12" name="VSSSMPS" type="power"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PA14"/>
+        <pin position="E5" name="PD1"/>
+        <pin position="E6" name="PD7"/>
+        <pin position="E7" name="PB4"/>
+        <pin position="E8" name="PB9"/>
+        <pin position="E9" name="PE3"/>
+        <pin position="E10" name="PC13"/>
+        <pin position="E11" name="VFBSMPS" type="power"/>
+        <pin position="E12" name="VLXSMPS" type="power"/>
+        <pin position="F1" name="VDD33_USB" type="power"/>
+        <pin position="F2" name="VDD50_USB" type="power"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F4" name="PA9"/>
+        <pin position="F5" name="PB10"/>
+        <pin position="F6" name="PD6"/>
+        <pin position="F7" name="PB5"/>
+        <pin position="F8" name="PE0"/>
+        <pin position="F9" name="PE4"/>
+        <pin position="F10" name="NRST" type="reset"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VDDSMPS" type="power"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PD12"/>
+        <pin position="G4" name="PD11"/>
+        <pin position="G5" name="PE15"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PA6"/>
+        <pin position="G8" name="PA1"/>
+        <pin position="G9" name="PC3"/>
+        <pin position="G10" name="PC0"/>
+        <pin position="G11" name="PH0-OSC_IN"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PD15"/>
+        <pin position="H2" name="PD13"/>
+        <pin position="H3" name="PD8"/>
+        <pin position="H4" name="PB15"/>
+        <pin position="H5" name="PE14"/>
+        <pin position="H6" name="PE8"/>
+        <pin position="H7" name="PC4"/>
+        <pin position="H8" name="PA2"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VDD" type="power"/>
+        <pin position="H11" name="PC1"/>
+        <pin position="H12" name="PH1-OSC_OUT"/>
+        <pin position="J1" name="PD14"/>
+        <pin position="J2" name="PD9"/>
+        <pin position="J3" name="PB14"/>
+        <pin position="J4" name="PB11"/>
+        <pin position="J5" name="PE11"/>
+        <pin position="J6" name="PE9"/>
+        <pin position="J7" name="PB1"/>
+        <pin position="J8" name="PC5"/>
+        <pin position="J9" name="PA3"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin position="J11" name="VREF+" type="monoio"/>
+        <pin position="J12" name="PC2"/>
+        <pin position="K1" name="PD10"/>
+        <pin position="K2" name="PB13"/>
+        <pin position="K3" name="VDDLDO" type="power"/>
+        <pin position="K4" name="VSS" type="power"/>
+        <pin position="K5" name="PE12"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="PF14"/>
+        <pin position="K8" name="PB0"/>
+        <pin position="K9" name="PA7"/>
+        <pin position="K10" name="PA4"/>
+        <pin position="K11" name="PA0"/>
+        <pin position="K12" name="VSSA" type="power"/>
+        <pin position="L1" name="VDD" type="power"/>
+        <pin position="L2" name="PB12"/>
+        <pin position="L3" name="VDD" type="power"/>
+        <pin position="L4" name="VCAP" type="power"/>
+        <pin position="L5" name="PE13"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PB2"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="PA5"/>
+        <pin position="L12" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-b0.xml
+++ b/devices/stm32/stm32h7-b0.xml
@@ -2125,6 +2125,872 @@
         <signal af="10" driver="usb_otg_hs" name="ulpi_dir"/>
         <signal af="13" driver="pssi" name="d15"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2_C"/>
+        <pin position="18" name="PC3_C"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF+" type="monoio"/>
+        <pin position="21" name="VDDA" type="power"/>
+        <pin position="22" name="PA0"/>
+        <pin position="23" name="PA1"/>
+        <pin position="24" name="PA2"/>
+        <pin position="25" name="PA3"/>
+        <pin position="26" name="VSS" type="power"/>
+        <pin position="27" name="VDD" type="power"/>
+        <pin position="28" name="PA4"/>
+        <pin position="29" name="PA5"/>
+        <pin position="30" name="PA6"/>
+        <pin position="31" name="PA7"/>
+        <pin position="32" name="PC4"/>
+        <pin position="33" name="PC5"/>
+        <pin position="34" name="PB0"/>
+        <pin position="35" name="PB1"/>
+        <pin position="36" name="PB2"/>
+        <pin position="37" name="PE7"/>
+        <pin position="38" name="PE8"/>
+        <pin position="39" name="PE9"/>
+        <pin position="40" name="PE10"/>
+        <pin position="41" name="PE11"/>
+        <pin position="42" name="PE12"/>
+        <pin position="43" name="PE13"/>
+        <pin position="44" name="PE14"/>
+        <pin position="45" name="PE15"/>
+        <pin position="46" name="PB10"/>
+        <pin position="47" name="PB11"/>
+        <pin position="48" name="VCAP" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VCAP" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2_C"/>
+        <pin position="29" name="PC3_C"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="VSSA" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VCAP" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD33_USB" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="VCAP" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDDMMC" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PI8"/>
+        <pin position="8" name="PC13"/>
+        <pin position="9" name="PC14-OSC32_IN"/>
+        <pin position="10" name="PC15-OSC32_OUT"/>
+        <pin position="11" name="PI9"/>
+        <pin position="12" name="PI10"/>
+        <pin position="13" name="PI11"/>
+        <pin position="14" name="VSS" type="power"/>
+        <pin position="15" name="VDD" type="power"/>
+        <pin position="16" name="PF0"/>
+        <pin position="17" name="PF1"/>
+        <pin position="18" name="PF2"/>
+        <pin position="19" name="PF3"/>
+        <pin position="20" name="PF4"/>
+        <pin position="21" name="PF5"/>
+        <pin position="22" name="VSS" type="power"/>
+        <pin position="23" name="VDD" type="power"/>
+        <pin position="24" name="PF6"/>
+        <pin position="25" name="PF7"/>
+        <pin position="26" name="PF8"/>
+        <pin position="27" name="PF9"/>
+        <pin position="28" name="PF10"/>
+        <pin position="29" name="PH0-OSC_IN"/>
+        <pin position="30" name="PH1-OSC_OUT"/>
+        <pin position="31" name="NRST" type="reset"/>
+        <pin position="32" name="PC0"/>
+        <pin position="33" name="PC1"/>
+        <pin position="34" name="PC2_C"/>
+        <pin position="35" name="PC3_C"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="VSSA" type="power"/>
+        <pin position="38" name="VREF+" type="monoio"/>
+        <pin position="39" name="VDDA" type="power"/>
+        <pin position="40" name="PA0"/>
+        <pin position="41" name="PA1"/>
+        <pin position="42" name="PA2"/>
+        <pin position="43" name="PH2"/>
+        <pin position="44" name="PH3"/>
+        <pin position="45" name="PH4"/>
+        <pin position="46" name="PH5"/>
+        <pin position="47" name="PA3"/>
+        <pin position="48" name="VSS" type="power"/>
+        <pin position="49" name="VDD" type="power"/>
+        <pin position="50" name="PA4"/>
+        <pin position="51" name="PA5"/>
+        <pin position="52" name="PA6"/>
+        <pin position="53" name="PA7"/>
+        <pin position="54" name="PC4"/>
+        <pin position="55" name="PC5"/>
+        <pin position="56" name="PB0"/>
+        <pin position="57" name="PB1"/>
+        <pin position="58" name="PB2"/>
+        <pin position="59" name="PF11"/>
+        <pin position="60" name="PF12"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PF13"/>
+        <pin position="64" name="PF14"/>
+        <pin position="65" name="PF15"/>
+        <pin position="66" name="PG0"/>
+        <pin position="67" name="PG1"/>
+        <pin position="68" name="PE7"/>
+        <pin position="69" name="PE8"/>
+        <pin position="70" name="PE9"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PE10"/>
+        <pin position="74" name="PE11"/>
+        <pin position="75" name="PE12"/>
+        <pin position="76" name="PE13"/>
+        <pin position="77" name="PE14"/>
+        <pin position="78" name="PE15"/>
+        <pin position="79" name="PB10"/>
+        <pin position="80" name="PB11"/>
+        <pin position="81" name="VCAP" type="power"/>
+        <pin position="82" name="VDD" type="power"/>
+        <pin position="83" name="PH6"/>
+        <pin position="84" name="PH7"/>
+        <pin position="85" name="PH8"/>
+        <pin position="86" name="PH9"/>
+        <pin position="87" name="PH10"/>
+        <pin position="88" name="PH11"/>
+        <pin position="89" name="PH12"/>
+        <pin position="90" name="VSS" type="power"/>
+        <pin position="91" name="VDD" type="power"/>
+        <pin position="92" name="PB12"/>
+        <pin position="93" name="PB13"/>
+        <pin position="94" name="PB14"/>
+        <pin position="95" name="PB15"/>
+        <pin position="96" name="PD8"/>
+        <pin position="97" name="PD9"/>
+        <pin position="98" name="PD10"/>
+        <pin position="99" name="PD11"/>
+        <pin position="100" name="PD12"/>
+        <pin position="101" name="PD13"/>
+        <pin position="102" name="VSS" type="power"/>
+        <pin position="103" name="VDD" type="power"/>
+        <pin position="104" name="PD14"/>
+        <pin position="105" name="PD15"/>
+        <pin position="106" name="PG2"/>
+        <pin position="107" name="PG3"/>
+        <pin position="108" name="PG4"/>
+        <pin position="109" name="PG5"/>
+        <pin position="110" name="PG6"/>
+        <pin position="111" name="PG7"/>
+        <pin position="112" name="PG8"/>
+        <pin position="113" name="VSS" type="power"/>
+        <pin position="114" name="VDD33_USB" type="power"/>
+        <pin position="115" name="PC6"/>
+        <pin position="116" name="PC7"/>
+        <pin position="117" name="PC8"/>
+        <pin position="118" name="PC9"/>
+        <pin position="119" name="PA8"/>
+        <pin position="120" name="PA9"/>
+        <pin position="121" name="PA10"/>
+        <pin position="122" name="PA11"/>
+        <pin position="123" name="PA12"/>
+        <pin position="124" name="PA13"/>
+        <pin position="125" name="VCAP" type="power"/>
+        <pin position="126" name="VSS" type="power"/>
+        <pin position="127" name="VDD" type="power"/>
+        <pin position="128" name="PH13"/>
+        <pin position="129" name="PH14"/>
+        <pin position="130" name="PH15"/>
+        <pin position="131" name="PI0"/>
+        <pin position="132" name="PI1"/>
+        <pin position="133" name="PI2"/>
+        <pin position="134" name="PI3"/>
+        <pin position="135" name="VSS" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin position="137" name="PA14"/>
+        <pin position="138" name="PA15"/>
+        <pin position="139" name="PC10"/>
+        <pin position="140" name="PC11"/>
+        <pin position="141" name="PC12"/>
+        <pin position="142" name="PD0"/>
+        <pin position="143" name="PD1"/>
+        <pin position="144" name="PD2"/>
+        <pin position="145" name="PD3"/>
+        <pin position="146" name="PD4"/>
+        <pin position="147" name="PD5"/>
+        <pin position="148" name="VSS" type="power"/>
+        <pin position="149" name="VDDMMC" type="power"/>
+        <pin position="150" name="PD6"/>
+        <pin position="151" name="PD7"/>
+        <pin position="152" name="PG9"/>
+        <pin position="153" name="PG10"/>
+        <pin position="154" name="PG11"/>
+        <pin position="155" name="PG12"/>
+        <pin position="156" name="PG13"/>
+        <pin position="157" name="PG14"/>
+        <pin position="158" name="VSS" type="power"/>
+        <pin position="159" name="VDD" type="power"/>
+        <pin position="160" name="PG15"/>
+        <pin position="161" name="PB3"/>
+        <pin position="162" name="PB4"/>
+        <pin position="163" name="PB5"/>
+        <pin position="164" name="PB6"/>
+        <pin position="165" name="PB7"/>
+        <pin position="166" name="BOOT0" type="boot"/>
+        <pin position="167" name="PB8"/>
+        <pin position="168" name="PB9"/>
+        <pin position="169" name="PE0"/>
+        <pin position="170" name="PE1"/>
+        <pin position="171" name="PDR_ON" type="reset"/>
+        <pin position="172" name="VDD" type="power"/>
+        <pin position="173" name="PI4"/>
+        <pin position="174" name="PI5"/>
+        <pin position="175" name="PI6"/>
+        <pin position="176" name="PI7"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC9"/>
+        <pin position="40" name="PA8"/>
+        <pin position="41" name="PA9"/>
+        <pin position="42" name="PA10"/>
+        <pin position="43" name="PA11"/>
+        <pin position="44" name="PA12"/>
+        <pin position="45" name="PA13"/>
+        <pin position="46" name="VCAP" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="VDDMMC" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="B13" name="PH13"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="reset"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VSSSMPS" type="power"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50_USB" type="power"/>
+        <pin position="G13" name="VDD33_USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN"/>
+        <pin position="H2" name="PH1-OSC_OUT"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PC2"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PA0_C"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PA1_C"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PB8"/>
+        <pin position="A3" name="VDDLDO" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="PB3"/>
+        <pin position="A7" name="PG11"/>
+        <pin position="A8" name="PG9"/>
+        <pin position="A9" name="PD3"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PA15"/>
+        <pin position="A12" name="PA14"/>
+        <pin position="A13" name="VDDLDO" type="power"/>
+        <pin position="A14" name="VCAP" type="power"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB4"/>
+        <pin position="B7" name="PG13"/>
+        <pin position="B8" name="PD7"/>
+        <pin position="B9" name="PD5"/>
+        <pin position="B10" name="PD2"/>
+        <pin position="B11" name="PC12"/>
+        <pin position="B12" name="PH14"/>
+        <pin position="B13" name="PA13"/>
+        <pin position="B14" name="PA8"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD0"/>
+        <pin position="C11" name="PC11"/>
+        <pin position="C12" name="PC10"/>
+        <pin position="C13" name="PH13"/>
+        <pin position="C14" name="PA10"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC15-OSC32_OUT"/>
+        <pin position="D2" name="PC14-OSC32_IN"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PDR_ON" type="reset"/>
+        <pin position="D5" name="VDDMMC" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PG15"/>
+        <pin position="D8" name="PG12"/>
+        <pin position="D9" name="PD6"/>
+        <pin position="D10" name="VSS" type="power"/>
+        <pin position="D11" name="VDD" type="power"/>
+        <pin position="D12" name="PH15"/>
+        <pin position="D13" name="PA9"/>
+        <pin position="D14" name="PC8"/>
+        <pin position="D15" name="PC7"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E12" name="VDD" type="power"/>
+        <pin position="E13" name="PC9"/>
+        <pin position="E14" name="PC6"/>
+        <pin position="E15" name="VDD50_USB" type="power"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VSSSMPS" type="power"/>
+        <pin position="F3" name="PF1"/>
+        <pin position="F4" name="PF0"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="F13" name="VDD33_USB" type="power"/>
+        <pin position="F14" name="PG6"/>
+        <pin position="F15" name="PG5"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VFBSMPS" type="power"/>
+        <pin position="G3" name="PF2"/>
+        <pin position="G4" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G12" name="PG8"/>
+        <pin position="G13" name="PG7"/>
+        <pin position="G14" name="PG4"/>
+        <pin position="G15" name="PG2"/>
+        <pin position="H1" name="PF6"/>
+        <pin position="H2" name="PF4"/>
+        <pin position="H3" name="PF5"/>
+        <pin position="H4" name="PF3"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H12" name="VDD" type="power"/>
+        <pin position="H13" name="PG3"/>
+        <pin position="H14" name="PD14"/>
+        <pin position="H15" name="PD13"/>
+        <pin position="J1" name="PH0-OSC_IN"/>
+        <pin position="J2" name="PF8"/>
+        <pin position="J3" name="PF7"/>
+        <pin position="J4" name="PF9"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD11"/>
+        <pin position="J14" name="VSS" type="power"/>
+        <pin position="J15" name="PD12"/>
+        <pin position="K1" name="PH1-OSC_OUT"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PF10"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K12" name="VSS" type="power"/>
+        <pin position="K13" name="PD9"/>
+        <pin position="K14" name="PB15"/>
+        <pin position="K15" name="PB14"/>
+        <pin position="L1" name="NRST" type="reset"/>
+        <pin position="L2" name="PC0"/>
+        <pin position="L3" name="PC1"/>
+        <pin position="L4" name="VREF-" type="power"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD8"/>
+        <pin position="L15" name="PB13"/>
+        <pin position="M1" name="PC2"/>
+        <pin position="M2" name="PC3"/>
+        <pin position="M3" name="VREF+" type="monoio"/>
+        <pin position="M4" name="VDDA" type="power"/>
+        <pin position="M5" name="VDD" type="power"/>
+        <pin position="M6" name="VSS" type="power"/>
+        <pin position="M7" name="PC5"/>
+        <pin position="M8" name="PB1"/>
+        <pin position="M9" name="VDD" type="power"/>
+        <pin position="M10" name="VSS" type="power"/>
+        <pin position="M11" name="PH7"/>
+        <pin position="M12" name="PE14"/>
+        <pin position="M13" name="PH11"/>
+        <pin position="M14" name="PH9"/>
+        <pin position="M15" name="PB12"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="VSSA" type="power"/>
+        <pin position="N4" name="PH2"/>
+        <pin position="N5" name="PA3"/>
+        <pin position="N6" name="PA7"/>
+        <pin position="N7" name="PF11"/>
+        <pin position="N8" name="PE8"/>
+        <pin position="N9" name="PG1"/>
+        <pin position="N10" name="PF15"/>
+        <pin position="N11" name="PF13"/>
+        <pin position="N12" name="PB10"/>
+        <pin position="N13" name="PH8"/>
+        <pin position="N14" name="PH10"/>
+        <pin position="N15" name="PH12"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA1_C"/>
+        <pin position="P4" name="PH4"/>
+        <pin position="P5" name="PA4"/>
+        <pin position="P6" name="PA5"/>
+        <pin position="P7" name="PB2"/>
+        <pin position="P8" name="PG0"/>
+        <pin position="P9" name="PE7"/>
+        <pin position="P10" name="PB11"/>
+        <pin position="P11" name="PF12"/>
+        <pin position="P12" name="PE12"/>
+        <pin position="P13" name="PE13"/>
+        <pin position="P14" name="PE15"/>
+        <pin position="P15" name="PH6"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA0_C"/>
+        <pin position="R4" name="PH3"/>
+        <pin position="R5" name="PH5"/>
+        <pin position="R6" name="PC4"/>
+        <pin position="R7" name="PA6"/>
+        <pin position="R8" name="PB0"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PF14"/>
+        <pin position="R11" name="PE9"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="VCAP" type="power"/>
+        <pin position="R14" name="VDDLDO" type="power"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32h7-b3.xml
+++ b/devices/stm32/stm32h7-b3.xml
@@ -3615,6 +3615,2207 @@
       <gpio device-pin="l|n" port="k" pin="7">
         <signal af="14" driver="ltdc" name="de"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin device-variant="" position="2" name="PE3"/>
+        <pin device-variant="q" position="2" name="PE4"/>
+        <pin device-variant="" position="3" name="PE4"/>
+        <pin device-variant="q" position="3" name="PE5"/>
+        <pin device-variant="" position="4" name="PE5"/>
+        <pin device-variant="q" position="4" name="VDD" type="power"/>
+        <pin device-variant="" position="5" name="PE6"/>
+        <pin device-variant="q" position="5" name="VBAT" type="power"/>
+        <pin device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-variant="q" position="6" name="PC13"/>
+        <pin device-variant="" position="7" name="PC13"/>
+        <pin device-variant="q" position="7" name="PC14-OSC32_IN"/>
+        <pin device-variant="" position="8" name="PC14-OSC32_IN"/>
+        <pin device-variant="q" position="8" name="PC15-OSC32_OUT"/>
+        <pin device-variant="" position="9" name="PC15-OSC32_OUT"/>
+        <pin device-variant="q" position="9" name="VSSSMPS" type="power"/>
+        <pin device-variant="" position="10" name="VSS" type="power"/>
+        <pin device-variant="q" position="10" name="VLXSMPS" type="power"/>
+        <pin device-variant="" position="11" name="VDD" type="power"/>
+        <pin device-variant="q" position="11" name="VDDSMPS" type="power"/>
+        <pin device-variant="" position="12" name="PH0-OSC_IN"/>
+        <pin device-variant="q" position="12" name="VFBSMPS" type="power"/>
+        <pin device-variant="" position="13" name="PH1-OSC_OUT"/>
+        <pin device-variant="q" position="13" name="PH0-OSC_IN"/>
+        <pin device-variant="" position="14" name="NRST" type="reset"/>
+        <pin device-variant="q" position="14" name="PH1-OSC_OUT"/>
+        <pin device-variant="" position="15" name="PC0"/>
+        <pin device-variant="q" position="15" name="NRST" type="reset"/>
+        <pin device-variant="" position="16" name="PC1"/>
+        <pin device-variant="q" position="16" name="PC0"/>
+        <pin device-variant="" position="17" name="PC2_C"/>
+        <pin device-variant="q" position="17" name="PC1"/>
+        <pin device-variant="" position="18" name="PC3_C"/>
+        <pin device-variant="q" position="18" name="PC2_C"/>
+        <pin device-variant="" position="19" name="VSSA" type="power"/>
+        <pin device-variant="q" position="19" name="PC3_C"/>
+        <pin device-variant="" position="20" name="VREF+" type="monoio"/>
+        <pin device-variant="q" position="20" name="VDD" type="power"/>
+        <pin device-variant="" position="21" name="VDDA" type="power"/>
+        <pin device-variant="q" position="21" name="VSS" type="power"/>
+        <pin device-variant="" position="22" name="PA0"/>
+        <pin device-variant="q" position="22" name="VSSA" type="power"/>
+        <pin device-variant="" position="23" name="PA1"/>
+        <pin device-variant="q" position="23" name="VREF+" type="monoio"/>
+        <pin device-variant="" position="24" name="PA2"/>
+        <pin device-variant="q" position="24" name="VDDA" type="power"/>
+        <pin device-variant="" position="25" name="PA3"/>
+        <pin device-variant="q" position="25" name="PA0"/>
+        <pin device-variant="" position="26" name="VSS" type="power"/>
+        <pin device-variant="q" position="26" name="PA1"/>
+        <pin device-variant="" position="27" name="VDD" type="power"/>
+        <pin device-variant="q" position="27" name="PA2"/>
+        <pin device-variant="" position="28" name="PA4"/>
+        <pin device-variant="q" position="28" name="PA3"/>
+        <pin device-variant="" position="29" name="PA5"/>
+        <pin device-variant="q" position="29" name="VSS" type="power"/>
+        <pin device-variant="" position="30" name="PA6"/>
+        <pin device-variant="q" position="30" name="VDD" type="power"/>
+        <pin device-variant="" position="31" name="PA7"/>
+        <pin device-variant="q" position="31" name="PA4"/>
+        <pin device-variant="" position="32" name="PC4"/>
+        <pin device-variant="q" position="32" name="PA5"/>
+        <pin device-variant="" position="33" name="PC5"/>
+        <pin device-variant="q" position="33" name="PA6"/>
+        <pin device-variant="" position="34" name="PB0"/>
+        <pin device-variant="q" position="34" name="PA7"/>
+        <pin device-variant="" position="35" name="PB1"/>
+        <pin device-variant="q" position="35" name="PC4"/>
+        <pin device-variant="" position="36" name="PB2"/>
+        <pin device-variant="q" position="36" name="PC5"/>
+        <pin device-variant="" position="37" name="PE7"/>
+        <pin device-variant="q" position="37" name="PB0"/>
+        <pin device-variant="" position="38" name="PE8"/>
+        <pin device-variant="q" position="38" name="PB1"/>
+        <pin device-variant="" position="39" name="PE9"/>
+        <pin device-variant="q" position="39" name="PB2"/>
+        <pin device-variant="" position="40" name="PE10"/>
+        <pin device-variant="q" position="40" name="PE7"/>
+        <pin device-variant="" position="41" name="PE11"/>
+        <pin device-variant="q" position="41" name="PE8"/>
+        <pin device-variant="" position="42" name="PE12"/>
+        <pin device-variant="q" position="42" name="PB10"/>
+        <pin device-variant="" position="43" name="PE13"/>
+        <pin device-variant="q" position="43" name="PB11"/>
+        <pin device-variant="" position="44" name="PE14"/>
+        <pin device-variant="q" position="44" name="VCAP" type="power"/>
+        <pin device-variant="" position="45" name="PE15"/>
+        <pin device-variant="q" position="45" name="VSS" type="power"/>
+        <pin device-variant="" position="46" name="PB10"/>
+        <pin device-variant="q" position="46" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="47" name="PB11"/>
+        <pin device-variant="q" position="47" name="VDD" type="power"/>
+        <pin device-variant="" position="48" name="VCAP" type="power"/>
+        <pin device-variant="q" position="48" name="PB12"/>
+        <pin device-variant="" position="49" name="VSS" type="power"/>
+        <pin device-variant="q" position="49" name="PB13"/>
+        <pin device-variant="" position="50" name="VDD" type="power"/>
+        <pin device-variant="q" position="50" name="PB14"/>
+        <pin device-variant="" position="51" name="PB12"/>
+        <pin device-variant="q" position="51" name="PB15"/>
+        <pin device-variant="" position="52" name="PB13"/>
+        <pin device-variant="q" position="52" name="PD8"/>
+        <pin device-variant="" position="53" name="PB14"/>
+        <pin device-variant="q" position="53" name="PD9"/>
+        <pin device-variant="" position="54" name="PB15"/>
+        <pin device-variant="q" position="54" name="PD10"/>
+        <pin device-variant="" position="55" name="PD8"/>
+        <pin device-variant="q" position="55" name="PD11"/>
+        <pin device-variant="" position="56" name="PD9"/>
+        <pin device-variant="q" position="56" name="PD12"/>
+        <pin device-variant="" position="57" name="PD10"/>
+        <pin device-variant="q" position="57" name="PD13"/>
+        <pin device-variant="" position="58" name="PD11"/>
+        <pin device-variant="q" position="58" name="VSS" type="power"/>
+        <pin device-variant="" position="59" name="PD12"/>
+        <pin device-variant="q" position="59" name="VDD" type="power"/>
+        <pin device-variant="" position="60" name="PD13"/>
+        <pin device-variant="q" position="60" name="PD14"/>
+        <pin device-variant="" position="61" name="PD14"/>
+        <pin device-variant="q" position="61" name="PD15"/>
+        <pin device-variant="" position="62" name="PD15"/>
+        <pin device-variant="q" position="62" name="PC6"/>
+        <pin device-variant="" position="63" name="PC6"/>
+        <pin device-variant="q" position="63" name="PC7"/>
+        <pin device-variant="" position="64" name="PC7"/>
+        <pin device-variant="q" position="64" name="PC8"/>
+        <pin device-variant="" position="65" name="PC8"/>
+        <pin device-variant="q" position="65" name="PC9"/>
+        <pin device-variant="" position="66" name="PC9"/>
+        <pin device-variant="q" position="66" name="PA8"/>
+        <pin device-variant="" position="67" name="PA8"/>
+        <pin device-variant="q" position="67" name="PA9"/>
+        <pin device-variant="" position="68" name="PA9"/>
+        <pin device-variant="q" position="68" name="PA10"/>
+        <pin device-variant="" position="69" name="PA10"/>
+        <pin device-variant="q" position="69" name="PA11"/>
+        <pin device-variant="" position="70" name="PA11"/>
+        <pin device-variant="q" position="70" name="PA12"/>
+        <pin device-variant="" position="71" name="PA12"/>
+        <pin device-variant="q" position="71" name="PA13"/>
+        <pin device-variant="" position="72" name="PA13"/>
+        <pin device-variant="q" position="72" name="VCAP" type="power"/>
+        <pin device-variant="" position="73" name="VCAP" type="power"/>
+        <pin device-variant="q" position="73" name="VSS" type="power"/>
+        <pin device-variant="" position="74" name="VSS" type="power"/>
+        <pin device-variant="q" position="74" name="VDDLDO" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin device-variant="" position="76" name="PA14"/>
+        <pin device-variant="q" position="76" name="VDD33_USB" type="power"/>
+        <pin device-variant="" position="77" name="PA15"/>
+        <pin device-variant="q" position="77" name="PA14"/>
+        <pin device-variant="" position="78" name="PC10"/>
+        <pin device-variant="q" position="78" name="PA15"/>
+        <pin device-variant="" position="79" name="PC11"/>
+        <pin device-variant="q" position="79" name="PC10"/>
+        <pin device-variant="" position="80" name="PC12"/>
+        <pin device-variant="q" position="80" name="PC11"/>
+        <pin device-variant="" position="81" name="PD0"/>
+        <pin device-variant="q" position="81" name="PC12"/>
+        <pin device-variant="" position="82" name="PD1"/>
+        <pin device-variant="q" position="82" name="PD0"/>
+        <pin device-variant="" position="83" name="PD2"/>
+        <pin device-variant="q" position="83" name="PD1"/>
+        <pin device-variant="" position="84" name="PD3"/>
+        <pin device-variant="q" position="84" name="PD2"/>
+        <pin device-variant="" position="85" name="PD4"/>
+        <pin device-variant="q" position="85" name="PD3"/>
+        <pin device-variant="" position="86" name="PD5"/>
+        <pin device-variant="q" position="86" name="PD4"/>
+        <pin device-variant="" position="87" name="PD6"/>
+        <pin device-variant="q" position="87" name="PD5"/>
+        <pin device-variant="" position="88" name="PD7"/>
+        <pin device-variant="q" position="88" name="VDDMMC" type="power"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin device-variant="" position="98" name="PE1"/>
+        <pin device-variant="q" position="98" name="VSS" type="power"/>
+        <pin device-variant="" position="99" name="VSS" type="power"/>
+        <pin device-variant="q" position="99" name="VDDLDO" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin device-temperature="6|7" device-variant="q" position="6" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="7" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="7" name="PC13"/>
+        <pin device-temperature="6|7" device-variant="q" position="8" name="VBAT" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="8" name="PC14-OSC32_IN"/>
+        <pin device-temperature="6|7" device-variant="q" position="9" name="PC13"/>
+        <pin device-temperature="6|7" device-variant="" position="9" name="PC15-OSC32_OUT"/>
+        <pin device-temperature="6|7" device-variant="q" position="10" name="PC14-OSC32_IN"/>
+        <pin device-temperature="6|7" device-variant="" position="10" name="PF0"/>
+        <pin device-temperature="6|7" device-variant="q" position="11" name="PC15-OSC32_OUT"/>
+        <pin device-temperature="6|7" device-variant="" position="11" name="PF1"/>
+        <pin device-temperature="6|7" device-variant="q" position="12" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="12" name="PF2"/>
+        <pin device-temperature="6|7" device-variant="q" position="13" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="13" name="PF3"/>
+        <pin device-temperature="6|7" device-variant="q" position="14" name="VSSSMPS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="14" name="PF4"/>
+        <pin device-temperature="6|7" device-variant="q" position="15" name="VLXSMPS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="15" name="PF5"/>
+        <pin device-temperature="6|7" device-variant="q" position="16" name="VDDSMPS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="16" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="17" name="VFBSMPS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="17" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="18" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="18" name="PF6"/>
+        <pin device-temperature="6|7" device-variant="q" position="19" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="19" name="PF7"/>
+        <pin device-temperature="6|7" device-variant="q" position="20" name="PF6"/>
+        <pin device-temperature="6|7" device-variant="" position="20" name="PF8"/>
+        <pin device-temperature="6|7" device-variant="q" position="21" name="PF7"/>
+        <pin device-temperature="6|7" device-variant="" position="21" name="PF9"/>
+        <pin device-temperature="6|7" device-variant="q" position="22" name="PF8"/>
+        <pin device-temperature="6|7" device-variant="" position="22" name="PF10"/>
+        <pin device-temperature="6|7" device-variant="q" position="23" name="PF9"/>
+        <pin device-temperature="6|7" device-variant="" position="23" name="PH0-OSC_IN"/>
+        <pin device-temperature="6|7" device-variant="q" position="24" name="PF10"/>
+        <pin device-temperature="6|7" device-variant="" position="24" name="PH1-OSC_OUT"/>
+        <pin device-temperature="6|7" device-variant="q" position="25" name="PH0-OSC_IN"/>
+        <pin device-temperature="6|7" device-variant="" position="25" name="NRST" type="reset"/>
+        <pin device-temperature="6|7" device-variant="q" position="26" name="PH1-OSC_OUT"/>
+        <pin device-temperature="6|7" device-variant="" position="26" name="PC0"/>
+        <pin device-temperature="6|7" device-variant="q" position="27" name="NRST" type="reset"/>
+        <pin device-temperature="6|7" device-variant="" position="27" name="PC1"/>
+        <pin device-temperature="6|7" device-variant="q" position="28" name="PC0"/>
+        <pin device-temperature="6|7" device-variant="" position="28" name="PC2_C"/>
+        <pin device-temperature="6|7" device-variant="q" position="29" name="PC1"/>
+        <pin device-temperature="6|7" device-variant="" position="29" name="PC3_C"/>
+        <pin device-temperature="6|7" device-variant="q" position="30" name="PC2_C"/>
+        <pin device-temperature="6|7" device-variant="" position="30" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="31" name="PC3_C"/>
+        <pin device-temperature="6|7" device-variant="" position="31" name="VSSA" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="32" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="32" name="VREF+" type="monoio"/>
+        <pin device-temperature="6|7" device-variant="q" position="33" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="33" name="VDDA" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="34" name="VSSA" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="34" name="PA0"/>
+        <pin device-temperature="6|7" device-variant="q" position="35" name="VREF+" type="monoio"/>
+        <pin device-temperature="6|7" device-variant="" position="35" name="PA1"/>
+        <pin device-temperature="6|7" device-variant="q" position="36" name="VDDA" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="36" name="PA2"/>
+        <pin device-temperature="6|7" device-variant="q" position="37" name="PA0"/>
+        <pin device-temperature="6|7" device-variant="" position="37" name="PA3"/>
+        <pin device-temperature="6|7" device-variant="q" position="38" name="PA1"/>
+        <pin device-temperature="6|7" device-variant="" position="38" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="39" name="PA2"/>
+        <pin device-temperature="6|7" device-variant="" position="39" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="40" name="PA3"/>
+        <pin device-temperature="6|7" device-variant="" position="40" name="PA4"/>
+        <pin device-temperature="6|7" device-variant="q" position="41" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="41" name="PA5"/>
+        <pin device-temperature="6|7" device-variant="q" position="42" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="42" name="PA6"/>
+        <pin device-temperature="6|7" device-variant="q" position="43" name="PA4"/>
+        <pin device-temperature="6|7" device-variant="" position="43" name="PA7"/>
+        <pin device-temperature="6|7" device-variant="q" position="44" name="PA5"/>
+        <pin device-temperature="6|7" device-variant="" position="44" name="PC4"/>
+        <pin device-temperature="6|7" device-variant="q" position="45" name="PA6"/>
+        <pin device-temperature="6|7" device-variant="" position="45" name="PC5"/>
+        <pin device-temperature="6|7" device-variant="q" position="46" name="PA7"/>
+        <pin device-temperature="6|7" device-variant="" position="46" name="PB0"/>
+        <pin device-temperature="6|7" device-variant="q" position="47" name="PC4"/>
+        <pin device-temperature="6|7" device-variant="" position="47" name="PB1"/>
+        <pin device-temperature="6|7" device-variant="q" position="48" name="PC5"/>
+        <pin device-temperature="6|7" device-variant="" position="48" name="PB2"/>
+        <pin device-temperature="6|7" device-variant="q" position="49" name="PB0"/>
+        <pin device-temperature="6|7" device-variant="" position="49" name="PF11"/>
+        <pin device-temperature="6|7" device-variant="q" position="50" name="PB1"/>
+        <pin device-temperature="6|7" device-variant="" position="50" name="PF12"/>
+        <pin device-temperature="6|7" device-variant="q" position="51" name="PB2"/>
+        <pin device-temperature="6|7" device-variant="" position="51" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="52" name="PF11"/>
+        <pin device-temperature="6|7" device-variant="" position="52" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="53" name="PF14"/>
+        <pin device-temperature="6|7" device-variant="" position="53" name="PF13"/>
+        <pin device-temperature="6|7" device-variant="q" position="54" name="PF15"/>
+        <pin device-temperature="6|7" device-variant="" position="54" name="PF14"/>
+        <pin device-temperature="6|7" device-variant="q" position="55" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="55" name="PF15"/>
+        <pin device-temperature="6|7" device-variant="q" position="56" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="56" name="PG0"/>
+        <pin device-temperature="6|7" device-variant="q" position="57" name="PE7"/>
+        <pin device-temperature="6|7" device-variant="" position="57" name="PG1"/>
+        <pin device-temperature="6|7" device-variant="q" position="58" name="PE8"/>
+        <pin device-temperature="6|7" device-variant="" position="58" name="PE7"/>
+        <pin device-temperature="6|7" device-variant="q" position="59" name="PE9"/>
+        <pin device-temperature="6|7" device-variant="" position="59" name="PE8"/>
+        <pin device-temperature="6|7" device-variant="q" position="60" name="PE10"/>
+        <pin device-temperature="6|7" device-variant="" position="60" name="PE9"/>
+        <pin device-temperature="6|7" device-variant="q" position="61" name="PE11"/>
+        <pin device-temperature="6|7" device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="62" name="PE12"/>
+        <pin device-temperature="6|7" device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="63" name="PE13"/>
+        <pin device-temperature="6|7" device-variant="" position="63" name="PE10"/>
+        <pin device-temperature="6|7" device-variant="q" position="64" name="PE14"/>
+        <pin device-temperature="6|7" device-variant="" position="64" name="PE11"/>
+        <pin device-temperature="6|7" device-variant="q" position="65" name="PE15"/>
+        <pin device-temperature="6|7" device-variant="" position="65" name="PE12"/>
+        <pin device-temperature="6|7" device-variant="q" position="66" name="PB10"/>
+        <pin device-temperature="6|7" device-variant="" position="66" name="PE13"/>
+        <pin device-temperature="6|7" device-variant="q" position="67" name="PB11"/>
+        <pin device-temperature="6|7" device-variant="" position="67" name="PE14"/>
+        <pin device-temperature="6|7" device-variant="q" position="68" name="VCAP" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="68" name="PE15"/>
+        <pin device-temperature="6|7" device-variant="q" position="69" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="69" name="PB10"/>
+        <pin device-temperature="6|7" device-variant="q" position="70" name="VDDLDO" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="70" name="PB11"/>
+        <pin device-temperature="6|7" device-variant="q" position="71" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="71" name="VCAP" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="72" name="PB12"/>
+        <pin device-temperature="6|7" device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="73" name="PB13"/>
+        <pin device-temperature="6|7" device-variant="" position="73" name="PB12"/>
+        <pin device-temperature="6|7" device-variant="q" position="74" name="PB14"/>
+        <pin device-temperature="6|7" device-variant="" position="74" name="PB13"/>
+        <pin device-temperature="6|7" device-variant="q" position="75" name="PB15"/>
+        <pin device-temperature="6|7" device-variant="" position="75" name="PB14"/>
+        <pin device-temperature="6|7" device-variant="q" position="76" name="PD8"/>
+        <pin device-temperature="6|7" device-variant="" position="76" name="PB15"/>
+        <pin device-temperature="6|7" device-variant="q" position="77" name="PD9"/>
+        <pin device-temperature="6|7" device-variant="" position="77" name="PD8"/>
+        <pin device-temperature="6|7" device-variant="q" position="78" name="PD10"/>
+        <pin device-temperature="6|7" device-variant="" position="78" name="PD9"/>
+        <pin device-temperature="6|7" device-variant="q" position="79" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="79" name="PD10"/>
+        <pin device-temperature="6|7" device-variant="q" position="80" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="80" name="PD11"/>
+        <pin device-temperature="6|7" device-variant="q" position="81" name="PD11"/>
+        <pin device-temperature="6|7" device-variant="" position="81" name="PD12"/>
+        <pin device-temperature="6|7" device-variant="q" position="82" name="PD12"/>
+        <pin device-temperature="6|7" device-variant="" position="82" name="PD13"/>
+        <pin device-temperature="6|7" device-variant="q" position="83" name="PD13"/>
+        <pin device-temperature="6|7" device-variant="" position="83" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="84" name="PD14"/>
+        <pin device-temperature="6|7" device-variant="" position="84" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="85" name="PD15"/>
+        <pin device-temperature="6|7" device-variant="" position="85" name="PD14"/>
+        <pin device-temperature="6|7" device-variant="q" position="86" name="PG6"/>
+        <pin device-temperature="6|7" device-variant="" position="86" name="PD15"/>
+        <pin device-temperature="6|7" device-variant="q" position="87" name="PG7"/>
+        <pin device-temperature="6|7" device-variant="" position="87" name="PG2"/>
+        <pin device-temperature="6|7" device-variant="q" position="88" name="PG8"/>
+        <pin device-temperature="6|7" device-variant="" position="88" name="PG3"/>
+        <pin device-temperature="6|7" device-variant="q" position="89" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="89" name="PG4"/>
+        <pin device-temperature="6|7" device-variant="q" position="90" name="VDD50_USB" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="90" name="PG5"/>
+        <pin device-temperature="6|7" device-variant="q" position="91" name="VDD33_USB" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="91" name="PG6"/>
+        <pin device-temperature="6|7" device-variant="q" position="92" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="92" name="PG7"/>
+        <pin device-temperature="6|7" device-variant="q" position="93" name="PC6"/>
+        <pin device-temperature="6|7" device-variant="" position="93" name="PG8"/>
+        <pin device-temperature="6|7" device-variant="q" position="94" name="PC7"/>
+        <pin device-temperature="6|7" device-variant="" position="94" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="95" name="PC8"/>
+        <pin device-temperature="6|7" device-variant="" position="95" name="VDD33_USB" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="96" name="PC9"/>
+        <pin device-temperature="6|7" device-variant="" position="96" name="PC6"/>
+        <pin device-temperature="6|7" device-variant="q" position="97" name="PA8"/>
+        <pin device-temperature="6|7" device-variant="" position="97" name="PC7"/>
+        <pin device-temperature="6|7" device-variant="q" position="98" name="PA9"/>
+        <pin device-temperature="6|7" device-variant="" position="98" name="PC8"/>
+        <pin device-temperature="6|7" device-variant="q" position="99" name="PA10"/>
+        <pin device-temperature="6|7" device-variant="" position="99" name="PC9"/>
+        <pin device-temperature="6|7" device-variant="q" position="100" name="PA11"/>
+        <pin device-temperature="6|7" device-variant="" position="100" name="PA8"/>
+        <pin device-temperature="6|7" device-variant="q" position="101" name="PA12"/>
+        <pin device-temperature="6|7" device-variant="" position="101" name="PA9"/>
+        <pin device-temperature="6|7" device-variant="q" position="102" name="PA13"/>
+        <pin device-temperature="6|7" device-variant="" position="102" name="PA10"/>
+        <pin device-temperature="6|7" device-variant="q" position="103" name="VCAP" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="103" name="PA11"/>
+        <pin device-temperature="6|7" device-variant="q" position="104" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="104" name="PA12"/>
+        <pin device-temperature="6|7" device-variant="q" position="105" name="VDDLDO" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="105" name="PA13"/>
+        <pin device-temperature="6|7" device-variant="q" position="106" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="106" name="VCAP" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="107" name="PA14"/>
+        <pin device-temperature="6|7" device-variant="" position="107" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="108" name="PA15"/>
+        <pin device-temperature="6|7" device-variant="" position="108" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="109" name="PC10"/>
+        <pin device-temperature="6|7" device-variant="" position="109" name="PA14"/>
+        <pin device-temperature="6|7" device-variant="q" position="110" name="PC11"/>
+        <pin device-temperature="6|7" device-variant="" position="110" name="PA15"/>
+        <pin device-temperature="6|7" device-variant="q" position="111" name="PC12"/>
+        <pin device-temperature="6|7" device-variant="" position="111" name="PC10"/>
+        <pin device-temperature="6|7" device-variant="q" position="112" name="PD0"/>
+        <pin device-temperature="6|7" device-variant="" position="112" name="PC11"/>
+        <pin device-temperature="6|7" device-variant="q" position="113" name="PD1"/>
+        <pin device-temperature="6|7" device-variant="" position="113" name="PC12"/>
+        <pin device-temperature="6|7" device-variant="q" position="114" name="PD2"/>
+        <pin device-temperature="6|7" device-variant="" position="114" name="PD0"/>
+        <pin device-temperature="6|7" device-variant="q" position="115" name="PD3"/>
+        <pin device-temperature="6|7" device-variant="" position="115" name="PD1"/>
+        <pin device-temperature="6|7" device-variant="q" position="116" name="PD4"/>
+        <pin device-temperature="6|7" device-variant="" position="116" name="PD2"/>
+        <pin device-temperature="6|7" device-variant="q" position="117" name="PD5"/>
+        <pin device-temperature="6|7" device-variant="" position="117" name="PD3"/>
+        <pin device-temperature="6|7" device-variant="q" position="118" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="118" name="PD4"/>
+        <pin device-temperature="6|7" device-variant="q" position="119" name="VDDMMC" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="119" name="PD5"/>
+        <pin device-temperature="6|7" device-variant="q" position="120" name="PD6"/>
+        <pin device-temperature="6|7" device-variant="" position="120" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="121" name="PD7"/>
+        <pin device-temperature="6|7" device-variant="" position="121" name="VDDMMC" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="122" name="PG9"/>
+        <pin device-temperature="6|7" device-variant="" position="122" name="PD6"/>
+        <pin device-temperature="6|7" device-variant="q" position="123" name="PG10"/>
+        <pin device-temperature="6|7" device-variant="" position="123" name="PD7"/>
+        <pin device-temperature="6|7" device-variant="q" position="124" name="PG11"/>
+        <pin device-temperature="6|7" device-variant="" position="124" name="PG9"/>
+        <pin device-temperature="6|7" device-variant="q" position="125" name="PG12"/>
+        <pin device-temperature="6|7" device-variant="" position="125" name="PG10"/>
+        <pin device-temperature="6|7" device-variant="q" position="126" name="PG13"/>
+        <pin device-temperature="6|7" device-variant="" position="126" name="PG11"/>
+        <pin device-temperature="6|7" device-variant="q" position="127" name="PG14"/>
+        <pin device-temperature="6|7" device-variant="" position="127" name="PG12"/>
+        <pin device-temperature="6|7" device-variant="q" position="128" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="128" name="PG13"/>
+        <pin device-temperature="6|7" device-variant="q" position="129" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="129" name="PG14"/>
+        <pin device-temperature="6|7" device-variant="q" position="130" name="PB3"/>
+        <pin device-temperature="6|7" device-variant="" position="130" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="131" name="PB4"/>
+        <pin device-temperature="6|7" device-variant="" position="131" name="VDD" type="power"/>
+        <pin device-temperature="6|7" device-variant="q" position="132" name="PB5"/>
+        <pin device-temperature="6|7" device-variant="" position="132" name="PG15"/>
+        <pin device-temperature="6|7" device-variant="q" position="133" name="PB6"/>
+        <pin device-temperature="6|7" device-variant="" position="133" name="PB3"/>
+        <pin device-temperature="6|7" device-variant="q" position="134" name="PB7"/>
+        <pin device-temperature="6|7" device-variant="" position="134" name="PB4"/>
+        <pin device-temperature="6|7" device-variant="q" position="135" name="BOOT0" type="boot"/>
+        <pin device-temperature="6|7" device-variant="" position="135" name="PB5"/>
+        <pin device-temperature="6|7" device-variant="q" position="136" name="PB8"/>
+        <pin device-temperature="6|7" device-variant="" position="136" name="PB6"/>
+        <pin device-temperature="6|7" device-variant="q" position="137" name="PB9"/>
+        <pin device-temperature="6|7" device-variant="" position="137" name="PB7"/>
+        <pin device-temperature="6|7" device-variant="q" position="138" name="PE0"/>
+        <pin device-temperature="6|7" device-variant="" position="138" name="BOOT0" type="boot"/>
+        <pin device-temperature="6|7" device-variant="q" position="139" name="PE1"/>
+        <pin device-temperature="6|7" device-variant="" position="139" name="PB8"/>
+        <pin device-temperature="6|7" device-variant="q" position="140" name="VCAP" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="140" name="PB9"/>
+        <pin device-temperature="6|7" device-variant="q" position="141" name="VSS" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="141" name="PE0"/>
+        <pin device-temperature="6|7" device-variant="q" position="142" name="PDR_ON" type="reset"/>
+        <pin device-temperature="6|7" device-variant="" position="142" name="PE1"/>
+        <pin device-temperature="6|7" device-variant="q" position="143" name="VDDLDO" type="power"/>
+        <pin device-temperature="6|7" device-variant="" position="143" name="PDR_ON" type="reset"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="i" device-package="t" name="LQFP176">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin device-variant="" position="6" name="VBAT" type="power"/>
+        <pin device-variant="q" position="6" name="VSS" type="power"/>
+        <pin device-variant="" position="7" name="PI8"/>
+        <pin device-variant="q" position="7" name="VDD" type="power"/>
+        <pin device-variant="" position="8" name="PC13"/>
+        <pin device-variant="q" position="8" name="VBAT" type="power"/>
+        <pin device-variant="" position="9" name="PC14-OSC32_IN"/>
+        <pin device-variant="q" position="9" name="PC13"/>
+        <pin device-variant="" position="10" name="PC15-OSC32_OUT"/>
+        <pin device-variant="q" position="10" name="PC14-OSC32_IN"/>
+        <pin device-variant="" position="11" name="PI9"/>
+        <pin device-variant="q" position="11" name="PC15-OSC32_OUT"/>
+        <pin device-variant="" position="12" name="PI10"/>
+        <pin device-variant="q" position="12" name="VSS" type="power"/>
+        <pin device-variant="" position="13" name="PI11"/>
+        <pin device-variant="q" position="13" name="VDD" type="power"/>
+        <pin device-variant="" position="14" name="VSS" type="power"/>
+        <pin device-variant="q" position="14" name="VSSSMPS" type="power"/>
+        <pin device-variant="" position="15" name="VDD" type="power"/>
+        <pin device-variant="q" position="15" name="VLXSMPS" type="power"/>
+        <pin device-variant="" position="16" name="PF0"/>
+        <pin device-variant="q" position="16" name="VDDSMPS" type="power"/>
+        <pin device-variant="" position="17" name="PF1"/>
+        <pin device-variant="q" position="17" name="VFBSMPS" type="power"/>
+        <pin device-variant="" position="18" name="PF2"/>
+        <pin device-variant="q" position="18" name="PF0"/>
+        <pin device-variant="" position="19" name="PF3"/>
+        <pin device-variant="q" position="19" name="PF1"/>
+        <pin device-variant="" position="20" name="PF4"/>
+        <pin device-variant="q" position="20" name="PF2"/>
+        <pin device-variant="" position="21" name="PF5"/>
+        <pin device-variant="q" position="21" name="PF3"/>
+        <pin device-variant="" position="22" name="VSS" type="power"/>
+        <pin device-variant="q" position="22" name="PF4"/>
+        <pin device-variant="" position="23" name="VDD" type="power"/>
+        <pin device-variant="q" position="23" name="PF5"/>
+        <pin device-variant="" position="24" name="PF6"/>
+        <pin device-variant="q" position="24" name="VSS" type="power"/>
+        <pin device-variant="" position="25" name="PF7"/>
+        <pin device-variant="q" position="25" name="VDD" type="power"/>
+        <pin device-variant="" position="26" name="PF8"/>
+        <pin device-variant="q" position="26" name="PF6"/>
+        <pin device-variant="" position="27" name="PF9"/>
+        <pin device-variant="q" position="27" name="PF7"/>
+        <pin device-variant="" position="28" name="PF10"/>
+        <pin device-variant="q" position="28" name="PF8"/>
+        <pin device-variant="" position="29" name="PH0-OSC_IN"/>
+        <pin device-variant="q" position="29" name="PF9"/>
+        <pin device-variant="" position="30" name="PH1-OSC_OUT"/>
+        <pin device-variant="q" position="30" name="PF10"/>
+        <pin device-variant="" position="31" name="NRST" type="reset"/>
+        <pin device-variant="q" position="31" name="PH0-OSC_IN"/>
+        <pin device-variant="" position="32" name="PC0"/>
+        <pin device-variant="q" position="32" name="PH1-OSC_OUT"/>
+        <pin device-variant="" position="33" name="PC1"/>
+        <pin device-variant="q" position="33" name="NRST" type="reset"/>
+        <pin device-variant="" position="34" name="PC2_C"/>
+        <pin device-variant="q" position="34" name="PC0"/>
+        <pin device-variant="" position="35" name="PC3_C"/>
+        <pin device-variant="q" position="35" name="PC1"/>
+        <pin device-variant="" position="36" name="VDD" type="power"/>
+        <pin device-variant="q" position="36" name="PC2_C"/>
+        <pin device-variant="" position="37" name="VSSA" type="power"/>
+        <pin device-variant="q" position="37" name="PC3_C"/>
+        <pin device-variant="" position="38" name="VREF+" type="monoio"/>
+        <pin device-variant="q" position="38" name="VSSA" type="power"/>
+        <pin device-variant="" position="39" name="VDDA" type="power"/>
+        <pin device-variant="q" position="39" name="VREF+" type="monoio"/>
+        <pin device-variant="" position="40" name="PA0"/>
+        <pin device-variant="q" position="40" name="VDDA" type="power"/>
+        <pin device-variant="" position="41" name="PA1"/>
+        <pin device-variant="q" position="41" name="PA0"/>
+        <pin device-variant="" position="42" name="PA2"/>
+        <pin device-variant="q" position="42" name="PA1"/>
+        <pin device-variant="" position="43" name="PH2"/>
+        <pin device-variant="q" position="43" name="PA2"/>
+        <pin device-variant="" position="44" name="PH3"/>
+        <pin device-variant="q" position="44" name="VDD" type="power"/>
+        <pin device-variant="" position="45" name="PH4"/>
+        <pin device-variant="q" position="45" name="VSS" type="power"/>
+        <pin device-variant="" position="46" name="PH5"/>
+        <pin device-variant="q" position="46" name="PA3"/>
+        <pin device-variant="" position="47" name="PA3"/>
+        <pin device-variant="q" position="47" name="VSS" type="power"/>
+        <pin device-variant="" position="48" name="VSS" type="power"/>
+        <pin device-variant="q" position="48" name="VDD" type="power"/>
+        <pin device-variant="" position="49" name="VDD" type="power"/>
+        <pin device-variant="q" position="49" name="PA4"/>
+        <pin device-variant="" position="50" name="PA4"/>
+        <pin device-variant="q" position="50" name="PA5"/>
+        <pin device-variant="" position="51" name="PA5"/>
+        <pin device-variant="q" position="51" name="PA6"/>
+        <pin device-variant="" position="52" name="PA6"/>
+        <pin device-variant="q" position="52" name="PA7"/>
+        <pin device-variant="" position="53" name="PA7"/>
+        <pin device-variant="q" position="53" name="PC4"/>
+        <pin device-variant="" position="54" name="PC4"/>
+        <pin device-variant="q" position="54" name="PC5"/>
+        <pin device-variant="" position="55" name="PC5"/>
+        <pin device-variant="q" position="55" name="PB0"/>
+        <pin device-variant="" position="56" name="PB0"/>
+        <pin device-variant="q" position="56" name="PB1"/>
+        <pin device-variant="" position="57" name="PB1"/>
+        <pin device-variant="q" position="57" name="PB2"/>
+        <pin device-variant="" position="58" name="PB2"/>
+        <pin device-variant="q" position="58" name="PF11"/>
+        <pin device-variant="" position="59" name="PF11"/>
+        <pin device-variant="q" position="59" name="PF12"/>
+        <pin device-variant="" position="60" name="PF12"/>
+        <pin device-variant="q" position="60" name="PF13"/>
+        <pin device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-variant="q" position="61" name="PF14"/>
+        <pin device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-variant="q" position="62" name="PF15"/>
+        <pin device-variant="" position="63" name="PF13"/>
+        <pin device-variant="q" position="63" name="PG0"/>
+        <pin device-variant="" position="64" name="PF14"/>
+        <pin device-variant="q" position="64" name="VSS" type="power"/>
+        <pin device-variant="" position="65" name="PF15"/>
+        <pin device-variant="q" position="65" name="VDD" type="power"/>
+        <pin device-variant="" position="66" name="PG0"/>
+        <pin device-variant="q" position="66" name="PG1"/>
+        <pin device-variant="" position="67" name="PG1"/>
+        <pin device-variant="q" position="67" name="PE7"/>
+        <pin device-variant="" position="68" name="PE7"/>
+        <pin device-variant="q" position="68" name="PE8"/>
+        <pin device-variant="" position="69" name="PE8"/>
+        <pin device-variant="q" position="69" name="PE9"/>
+        <pin device-variant="" position="70" name="PE9"/>
+        <pin device-variant="q" position="70" name="VSS" type="power"/>
+        <pin device-variant="" position="71" name="VSS" type="power"/>
+        <pin device-variant="q" position="71" name="VDD" type="power"/>
+        <pin device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-variant="q" position="72" name="PE10"/>
+        <pin device-variant="" position="73" name="PE10"/>
+        <pin device-variant="q" position="73" name="PE11"/>
+        <pin device-variant="" position="74" name="PE11"/>
+        <pin device-variant="q" position="74" name="PE12"/>
+        <pin device-variant="" position="75" name="PE12"/>
+        <pin device-variant="q" position="75" name="PE13"/>
+        <pin device-variant="" position="76" name="PE13"/>
+        <pin device-variant="q" position="76" name="PE14"/>
+        <pin device-variant="" position="77" name="PE14"/>
+        <pin device-variant="q" position="77" name="PE15"/>
+        <pin device-variant="" position="78" name="PE15"/>
+        <pin device-variant="q" position="78" name="PB10"/>
+        <pin device-variant="" position="79" name="PB10"/>
+        <pin device-variant="q" position="79" name="PB11"/>
+        <pin device-variant="" position="80" name="PB11"/>
+        <pin device-variant="q" position="80" name="VCAP" type="power"/>
+        <pin device-variant="" position="81" name="VCAP" type="power"/>
+        <pin device-variant="q" position="81" name="VSS" type="power"/>
+        <pin device-variant="" position="82" name="VDD" type="power"/>
+        <pin device-variant="q" position="82" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="83" name="PH6"/>
+        <pin device-variant="q" position="83" name="VSS" type="power"/>
+        <pin device-variant="" position="84" name="PH7"/>
+        <pin device-variant="q" position="84" name="VDD" type="power"/>
+        <pin device-variant="" position="85" name="PH8"/>
+        <pin device-variant="q" position="85" name="PB12"/>
+        <pin device-variant="" position="86" name="PH9"/>
+        <pin device-variant="q" position="86" name="PB13"/>
+        <pin device-variant="" position="87" name="PH10"/>
+        <pin device-variant="q" position="87" name="PB14"/>
+        <pin device-variant="" position="88" name="PH11"/>
+        <pin device-variant="q" position="88" name="PB15"/>
+        <pin device-variant="" position="89" name="PH12"/>
+        <pin device-variant="q" position="89" name="PD8"/>
+        <pin device-variant="" position="90" name="VSS" type="power"/>
+        <pin device-variant="q" position="90" name="PD9"/>
+        <pin device-variant="" position="91" name="VDD" type="power"/>
+        <pin device-variant="q" position="91" name="PD10"/>
+        <pin device-variant="" position="92" name="PB12"/>
+        <pin device-variant="q" position="92" name="VDD" type="power"/>
+        <pin device-variant="" position="93" name="PB13"/>
+        <pin device-variant="q" position="93" name="VSS" type="power"/>
+        <pin device-variant="" position="94" name="PB14"/>
+        <pin device-variant="q" position="94" name="PD11"/>
+        <pin device-variant="" position="95" name="PB15"/>
+        <pin device-variant="q" position="95" name="PD12"/>
+        <pin device-variant="" position="96" name="PD8"/>
+        <pin device-variant="q" position="96" name="PD13"/>
+        <pin device-variant="" position="97" name="PD9"/>
+        <pin device-variant="q" position="97" name="PD14"/>
+        <pin device-variant="" position="98" name="PD10"/>
+        <pin device-variant="q" position="98" name="PD15"/>
+        <pin device-variant="" position="99" name="PD11"/>
+        <pin device-variant="q" position="99" name="VDD" type="power"/>
+        <pin device-variant="" position="100" name="PD12"/>
+        <pin device-variant="q" position="100" name="VSS" type="power"/>
+        <pin device-variant="" position="101" name="PD13"/>
+        <pin device-variant="q" position="101" name="PJ8"/>
+        <pin device-variant="" position="102" name="VSS" type="power"/>
+        <pin device-variant="q" position="102" name="PJ9"/>
+        <pin device-variant="" position="103" name="VDD" type="power"/>
+        <pin device-variant="q" position="103" name="PJ10"/>
+        <pin device-variant="" position="104" name="PD14"/>
+        <pin device-variant="q" position="104" name="PJ11"/>
+        <pin device-variant="" position="105" name="PD15"/>
+        <pin device-variant="q" position="105" name="VDD" type="power"/>
+        <pin device-variant="" position="106" name="PG2"/>
+        <pin device-variant="q" position="106" name="VSS" type="power"/>
+        <pin device-variant="" position="107" name="PG3"/>
+        <pin device-variant="q" position="107" name="PK0"/>
+        <pin device-variant="" position="108" name="PG4"/>
+        <pin device-variant="q" position="108" name="PK1"/>
+        <pin device-variant="" position="109" name="PG5"/>
+        <pin device-variant="q" position="109" name="PK2"/>
+        <pin device-variant="" position="110" name="PG6"/>
+        <pin device-variant="q" position="110" name="PG2"/>
+        <pin device-variant="" position="111" name="PG7"/>
+        <pin device-variant="q" position="111" name="PG3"/>
+        <pin device-variant="" position="112" name="PG8"/>
+        <pin device-variant="q" position="112" name="VSS" type="power"/>
+        <pin device-variant="" position="113" name="VSS" type="power"/>
+        <pin device-variant="q" position="113" name="VDD" type="power"/>
+        <pin device-variant="" position="114" name="VDD33_USB" type="power"/>
+        <pin device-variant="q" position="114" name="PG4"/>
+        <pin device-variant="" position="115" name="PC6"/>
+        <pin device-variant="q" position="115" name="PG5"/>
+        <pin device-variant="" position="116" name="PC7"/>
+        <pin device-variant="q" position="116" name="PG6"/>
+        <pin device-variant="" position="117" name="PC8"/>
+        <pin device-variant="q" position="117" name="PG7"/>
+        <pin device-variant="" position="118" name="PC9"/>
+        <pin device-variant="q" position="118" name="PG8"/>
+        <pin device-variant="" position="119" name="PA8"/>
+        <pin device-variant="q" position="119" name="VSS" type="power"/>
+        <pin device-variant="" position="120" name="PA9"/>
+        <pin device-variant="q" position="120" name="VDD50_USB" type="power"/>
+        <pin device-variant="" position="121" name="PA10"/>
+        <pin device-variant="q" position="121" name="VDD33_USB" type="power"/>
+        <pin device-variant="" position="122" name="PA11"/>
+        <pin device-variant="q" position="122" name="PC6"/>
+        <pin device-variant="" position="123" name="PA12"/>
+        <pin device-variant="q" position="123" name="PC7"/>
+        <pin device-variant="" position="124" name="PA13"/>
+        <pin device-variant="q" position="124" name="PC8"/>
+        <pin device-variant="" position="125" name="VCAP" type="power"/>
+        <pin device-variant="q" position="125" name="PC9"/>
+        <pin device-variant="" position="126" name="VSS" type="power"/>
+        <pin device-variant="q" position="126" name="VDD" type="power"/>
+        <pin device-variant="" position="127" name="VDD" type="power"/>
+        <pin device-variant="q" position="127" name="PA8"/>
+        <pin device-variant="" position="128" name="PH13"/>
+        <pin device-variant="q" position="128" name="PA9"/>
+        <pin device-variant="" position="129" name="PH14"/>
+        <pin device-variant="q" position="129" name="PA10"/>
+        <pin device-variant="" position="130" name="PH15"/>
+        <pin device-variant="q" position="130" name="PA11"/>
+        <pin device-variant="" position="131" name="PI0"/>
+        <pin device-variant="q" position="131" name="PA12"/>
+        <pin device-variant="" position="132" name="PI1"/>
+        <pin device-variant="q" position="132" name="PA13"/>
+        <pin device-variant="" position="133" name="PI2"/>
+        <pin device-variant="q" position="133" name="VCAP" type="power"/>
+        <pin device-variant="" position="134" name="PI3"/>
+        <pin device-variant="q" position="134" name="VSS" type="power"/>
+        <pin device-variant="" position="135" name="VSS" type="power"/>
+        <pin device-variant="q" position="135" name="VDDLDO" type="power"/>
+        <pin position="136" name="VDD" type="power"/>
+        <pin device-variant="" position="137" name="PA14"/>
+        <pin device-variant="q" position="137" name="VSS" type="power"/>
+        <pin device-variant="" position="138" name="PA15"/>
+        <pin device-variant="q" position="138" name="PA14"/>
+        <pin device-variant="" position="139" name="PC10"/>
+        <pin device-variant="q" position="139" name="PA15"/>
+        <pin device-variant="" position="140" name="PC11"/>
+        <pin device-variant="q" position="140" name="PC10"/>
+        <pin device-variant="" position="141" name="PC12"/>
+        <pin device-variant="q" position="141" name="PC11"/>
+        <pin device-variant="" position="142" name="PD0"/>
+        <pin device-variant="q" position="142" name="PC12"/>
+        <pin device-variant="" position="143" name="PD1"/>
+        <pin device-variant="q" position="143" name="PD0"/>
+        <pin device-variant="" position="144" name="PD2"/>
+        <pin device-variant="q" position="144" name="PD1"/>
+        <pin device-variant="" position="145" name="PD3"/>
+        <pin device-variant="q" position="145" name="PD2"/>
+        <pin device-variant="" position="146" name="PD4"/>
+        <pin device-variant="q" position="146" name="PD3"/>
+        <pin device-variant="" position="147" name="PD5"/>
+        <pin device-variant="q" position="147" name="PD4"/>
+        <pin device-variant="" position="148" name="VSS" type="power"/>
+        <pin device-variant="q" position="148" name="PD5"/>
+        <pin device-variant="" position="149" name="VDDMMC" type="power"/>
+        <pin device-variant="q" position="149" name="PD6"/>
+        <pin device-variant="" position="150" name="PD6"/>
+        <pin device-variant="q" position="150" name="PD7"/>
+        <pin device-variant="" position="151" name="PD7"/>
+        <pin device-variant="q" position="151" name="VSS" type="power"/>
+        <pin device-variant="" position="152" name="PG9"/>
+        <pin device-variant="q" position="152" name="VDDMMC" type="power"/>
+        <pin device-variant="" position="153" name="PG10"/>
+        <pin device-variant="q" position="153" name="PG9"/>
+        <pin device-variant="" position="154" name="PG11"/>
+        <pin device-variant="q" position="154" name="PG10"/>
+        <pin device-variant="" position="155" name="PG12"/>
+        <pin device-variant="q" position="155" name="PG11"/>
+        <pin device-variant="" position="156" name="PG13"/>
+        <pin device-variant="q" position="156" name="PG12"/>
+        <pin device-variant="" position="157" name="PG14"/>
+        <pin device-variant="q" position="157" name="PG13"/>
+        <pin device-variant="" position="158" name="VSS" type="power"/>
+        <pin device-variant="q" position="158" name="PG14"/>
+        <pin device-variant="" position="159" name="VDD" type="power"/>
+        <pin device-variant="q" position="159" name="VSS" type="power"/>
+        <pin device-variant="" position="160" name="PG15"/>
+        <pin device-variant="q" position="160" name="VDD" type="power"/>
+        <pin device-variant="" position="161" name="PB3"/>
+        <pin device-variant="q" position="161" name="PG15"/>
+        <pin device-variant="" position="162" name="PB4"/>
+        <pin device-variant="q" position="162" name="PB3"/>
+        <pin device-variant="" position="163" name="PB5"/>
+        <pin device-variant="q" position="163" name="PB4"/>
+        <pin device-variant="" position="164" name="PB6"/>
+        <pin device-variant="q" position="164" name="PB5"/>
+        <pin device-variant="" position="165" name="PB7"/>
+        <pin device-variant="q" position="165" name="PB6"/>
+        <pin device-variant="" position="166" name="BOOT0" type="boot"/>
+        <pin device-variant="q" position="166" name="PB7"/>
+        <pin device-variant="" position="167" name="PB8"/>
+        <pin device-variant="q" position="167" name="BOOT0" type="boot"/>
+        <pin device-variant="" position="168" name="PB9"/>
+        <pin device-variant="q" position="168" name="PB8"/>
+        <pin device-variant="" position="169" name="PE0"/>
+        <pin device-variant="q" position="169" name="PB9"/>
+        <pin device-variant="" position="170" name="PE1"/>
+        <pin device-variant="q" position="170" name="PE0"/>
+        <pin device-variant="" position="171" name="PDR_ON" type="reset"/>
+        <pin device-variant="q" position="171" name="PE1"/>
+        <pin device-variant="" position="172" name="VDD" type="power"/>
+        <pin device-variant="q" position="172" name="VCAP" type="power"/>
+        <pin device-variant="" position="173" name="PI4"/>
+        <pin device-variant="q" position="173" name="VSS" type="power"/>
+        <pin device-variant="" position="174" name="PI5"/>
+        <pin device-variant="q" position="174" name="PDR_ON" type="reset"/>
+        <pin device-variant="" position="175" name="PI6"/>
+        <pin device-variant="q" position="175" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="176" name="PI7"/>
+        <pin device-variant="q" position="176" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="VCAP" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC9"/>
+        <pin position="40" name="PA8"/>
+        <pin position="41" name="PA9"/>
+        <pin position="42" name="PA10"/>
+        <pin position="43" name="PA11"/>
+        <pin position="44" name="PA12"/>
+        <pin position="45" name="PA13"/>
+        <pin position="46" name="VCAP" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="TFBGA100">
+        <pin device-variant="" position="A1" name="PC14-OSC32_IN"/>
+        <pin device-variant="q" position="A1" name="PE6"/>
+        <pin device-variant="" position="A2" name="PC13"/>
+        <pin device-variant="q" position="A2" name="PE5"/>
+        <pin position="A3" name="PE2"/>
+        <pin device-variant="" position="A4" name="PB9"/>
+        <pin device-variant="q" position="A4" name="PB8"/>
+        <pin device-variant="" position="A5" name="PB7"/>
+        <pin device-variant="q" position="A5" name="BOOT0" type="boot"/>
+        <pin device-variant="" position="A6" name="PB4"/>
+        <pin device-variant="q" position="A6" name="PB5"/>
+        <pin device-variant="" position="A7" name="PB3"/>
+        <pin device-variant="q" position="A7" name="PD6"/>
+        <pin device-variant="" position="A8" name="PA15"/>
+        <pin device-variant="q" position="A8" name="PD3"/>
+        <pin device-variant="" position="A9" name="PA14"/>
+        <pin device-variant="q" position="A9" name="PD2"/>
+        <pin device-variant="" position="A10" name="PA13"/>
+        <pin device-variant="q" position="A10" name="PC12"/>
+        <pin device-variant="" position="B1" name="PC15-OSC32_OUT"/>
+        <pin device-variant="q" position="B1" name="PC14-OSC32_IN"/>
+        <pin device-variant="" position="B2" name="VBAT" type="power"/>
+        <pin device-variant="q" position="B2" name="PC15-OSC32_OUT"/>
+        <pin position="B3" name="PE3"/>
+        <pin device-variant="" position="B4" name="PB8"/>
+        <pin device-variant="q" position="B4" name="PE0"/>
+        <pin device-variant="" position="B5" name="PB6"/>
+        <pin device-variant="q" position="B5" name="PB7"/>
+        <pin device-variant="" position="B6" name="PD5"/>
+        <pin device-variant="q" position="B6" name="PB3"/>
+        <pin device-variant="" position="B7" name="PD2"/>
+        <pin device-variant="q" position="B7" name="PD4"/>
+        <pin device-variant="" position="B8" name="PC11"/>
+        <pin device-variant="q" position="B8" name="PD1"/>
+        <pin device-variant="" position="B9" name="PC10"/>
+        <pin device-variant="q" position="B9" name="PC11"/>
+        <pin device-variant="" position="B10" name="PA12"/>
+        <pin device-variant="q" position="B10" name="PC10"/>
+        <pin device-variant="" position="C1" name="PH0-OSC_IN"/>
+        <pin device-variant="q" position="C1" name="VSS" type="power"/>
+        <pin device-variant="" position="C2" name="VSS" type="power"/>
+        <pin device-variant="q" position="C2" name="VBAT" type="power"/>
+        <pin position="C3" name="PE4"/>
+        <pin position="C4" name="PE1"/>
+        <pin device-variant="" position="C5" name="PB5"/>
+        <pin device-variant="q" position="C5" name="PB4"/>
+        <pin device-variant="" position="C6" name="PD6"/>
+        <pin device-variant="q" position="C6" name="PD7"/>
+        <pin device-variant="" position="C7" name="PD3"/>
+        <pin device-variant="q" position="C7" name="PD0"/>
+        <pin device-variant="" position="C8" name="PC12"/>
+        <pin device-variant="q" position="C8" name="PA15"/>
+        <pin device-variant="" position="C9" name="PA9"/>
+        <pin device-variant="q" position="C9" name="PA14"/>
+        <pin device-variant="" position="C10" name="PA11"/>
+        <pin device-variant="q" position="C10" name="PA13"/>
+        <pin device-variant="" position="D1" name="PH1-OSC_OUT"/>
+        <pin device-variant="q" position="D1" name="VSSSMPS" type="power"/>
+        <pin device-variant="" position="D2" name="VDD" type="power"/>
+        <pin device-variant="q" position="D2" name="VLXSMPS" type="power"/>
+        <pin device-variant="" position="D3" name="PE5"/>
+        <pin device-variant="q" position="D3" name="PDR_ON" type="reset"/>
+        <pin device-variant="" position="D4" name="PE0"/>
+        <pin device-variant="q" position="D4" name="PB6"/>
+        <pin device-variant="" position="D5" name="BOOT0" type="boot"/>
+        <pin device-variant="q" position="D5" name="VSS" type="power"/>
+        <pin device-variant="" position="D6" name="PD7"/>
+        <pin device-variant="q" position="D6" name="VDD" type="power"/>
+        <pin device-variant="" position="D7" name="PD4"/>
+        <pin device-variant="q" position="D7" name="PD5"/>
+        <pin device-variant="" position="D8" name="PD0"/>
+        <pin device-variant="q" position="D8" name="VCAP" type="power"/>
+        <pin device-variant="" position="D9" name="PA8"/>
+        <pin device-variant="q" position="D9" name="PA12"/>
+        <pin device-variant="" position="D10" name="PA10"/>
+        <pin device-variant="q" position="D10" name="PA11"/>
+        <pin device-variant="" position="E1" name="NRST" type="reset"/>
+        <pin device-variant="q" position="E1" name="VDDSMPS" type="power"/>
+        <pin device-variant="" position="E2" name="PC2_C"/>
+        <pin device-variant="q" position="E2" name="VFBSMPS" type="power"/>
+        <pin device-variant="" position="E3" name="PE6"/>
+        <pin device-variant="q" position="E3" name="PB9"/>
+        <pin device-variant="" position="E4" name="VSS" type="power"/>
+        <pin device-variant="q" position="E4" name="PC13"/>
+        <pin device-variant="" position="E5" name="VSS" type="power"/>
+        <pin device-variant="q" position="E5" name="VDD" type="power"/>
+        <pin device-variant="" position="E6" name="VSS" type="power"/>
+        <pin device-variant="q" position="E6" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="E7" name="VCAP" type="power"/>
+        <pin device-variant="q" position="E7" name="VSS" type="power"/>
+        <pin device-variant="" position="E8" name="PD1"/>
+        <pin device-variant="q" position="E8" name="VDD33_USB" type="power"/>
+        <pin device-variant="" position="E9" name="PC9"/>
+        <pin device-variant="q" position="E9" name="PA9"/>
+        <pin device-variant="" position="E10" name="PC7"/>
+        <pin device-variant="q" position="E10" name="PA10"/>
+        <pin device-variant="" position="F1" name="PC0"/>
+        <pin device-variant="q" position="F1" name="PC1"/>
+        <pin device-variant="" position="F2" name="PC1"/>
+        <pin device-variant="q" position="F2" name="NRST" type="reset"/>
+        <pin device-variant="" position="F3" name="PC3_C"/>
+        <pin device-variant="q" position="F3" name="PC0"/>
+        <pin device-variant="" position="F4" name="VDD" type="power"/>
+        <pin device-variant="q" position="F4" name="PC2_C"/>
+        <pin device-variant="" position="F5" name="VDD" type="power"/>
+        <pin device-variant="q" position="F5" name="VSS" type="power"/>
+        <pin device-variant="" position="F6" name="VDD33_USB" type="power"/>
+        <pin device-variant="q" position="F6" name="VDD" type="power"/>
+        <pin device-variant="" position="F7" name="PDR_ON" type="reset"/>
+        <pin device-variant="q" position="F7" name="VDD50_USB" type="power"/>
+        <pin device-variant="" position="F8" name="VCAP" type="power"/>
+        <pin device-variant="q" position="F8" name="PC6"/>
+        <pin device-variant="" position="F9" name="PC8"/>
+        <pin device-variant="q" position="F9" name="PC9"/>
+        <pin device-variant="" position="F10" name="PC6"/>
+        <pin device-variant="q" position="F10" name="PA8"/>
+        <pin device-variant="" position="G1" name="VSSA" type="power"/>
+        <pin device-variant="q" position="G1" name="PH0-OSC_IN"/>
+        <pin device-variant="" position="G2" name="PA0"/>
+        <pin device-variant="q" position="G2" name="PH1-OSC_OUT"/>
+        <pin device-variant="" position="G3" name="PA4"/>
+        <pin device-variant="q" position="G3" name="PA0"/>
+        <pin device-variant="" position="G4" name="PC4"/>
+        <pin device-variant="q" position="G4" name="PC3_C"/>
+        <pin device-variant="" position="G5" name="PB2"/>
+        <pin device-variant="q" position="G5" name="PA3"/>
+        <pin device-variant="" position="G6" name="PE10"/>
+        <pin device-variant="q" position="G6" name="VCAP" type="power"/>
+        <pin device-variant="" position="G7" name="PE14"/>
+        <pin device-variant="q" position="G7" name="PD14"/>
+        <pin position="G8" name="PD15"/>
+        <pin device-variant="" position="G9" name="PD11"/>
+        <pin device-variant="q" position="G9" name="PC7"/>
+        <pin device-variant="" position="G10" name="PB15"/>
+        <pin device-variant="q" position="G10" name="PC8"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin device-variant="" position="H2" name="PA1"/>
+        <pin device-variant="q" position="H2" name="VSSA" type="power"/>
+        <pin device-variant="" position="H3" name="PA5"/>
+        <pin device-variant="q" position="H3" name="PA2"/>
+        <pin device-variant="" position="H4" name="PC5"/>
+        <pin device-variant="q" position="H4" name="PC4"/>
+        <pin position="H5" name="PE7"/>
+        <pin device-variant="" position="H6" name="PE11"/>
+        <pin device-variant="q" position="H6" name="PE10"/>
+        <pin device-variant="" position="H7" name="PE15"/>
+        <pin device-variant="q" position="H7" name="PD11"/>
+        <pin device-variant="" position="H8" name="PD14"/>
+        <pin device-variant="q" position="H8" name="PD9"/>
+        <pin device-variant="" position="H9" name="PD10"/>
+        <pin device-variant="q" position="H9" name="PD12"/>
+        <pin device-variant="" position="H10" name="PB14"/>
+        <pin device-variant="q" position="H10" name="PD13"/>
+        <pin device-variant="" position="J1" name="VSS" type="power"/>
+        <pin device-variant="q" position="J1" name="VREF+" type="monoio"/>
+        <pin device-variant="" position="J2" name="PA2"/>
+        <pin device-variant="q" position="J2" name="PA1"/>
+        <pin position="J3" name="PA6"/>
+        <pin device-variant="" position="J4" name="PB0"/>
+        <pin device-variant="q" position="J4" name="PC5"/>
+        <pin device-variant="" position="J5" name="PE8"/>
+        <pin device-variant="q" position="J5" name="PB2"/>
+        <pin device-variant="" position="J6" name="PE12"/>
+        <pin device-variant="q" position="J6" name="PE8"/>
+        <pin device-variant="" position="J7" name="PB10"/>
+        <pin device-variant="q" position="J7" name="PB11"/>
+        <pin position="J8" name="PB13"/>
+        <pin device-variant="" position="J9" name="PD9"/>
+        <pin device-variant="q" position="J9" name="PD8"/>
+        <pin device-variant="" position="J10" name="PD13"/>
+        <pin device-variant="q" position="J10" name="PD10"/>
+        <pin device-variant="" position="K1" name="VDD" type="power"/>
+        <pin device-variant="q" position="K1" name="PA4"/>
+        <pin device-variant="" position="K2" name="PA3"/>
+        <pin device-variant="q" position="K2" name="PA5"/>
+        <pin position="K3" name="PA7"/>
+        <pin device-variant="" position="K4" name="PB1"/>
+        <pin device-variant="q" position="K4" name="PB0"/>
+        <pin device-variant="" position="K5" name="PE9"/>
+        <pin device-variant="q" position="K5" name="PB1"/>
+        <pin device-variant="" position="K6" name="PE13"/>
+        <pin device-variant="q" position="K6" name="PE9"/>
+        <pin device-variant="" position="K7" name="PB11"/>
+        <pin device-variant="q" position="K7" name="PB10"/>
+        <pin position="K8" name="PB12"/>
+        <pin device-variant="" position="K9" name="PD8"/>
+        <pin device-variant="q" position="K9" name="PB14"/>
+        <pin device-variant="" position="K10" name="PD12"/>
+        <pin device-variant="q" position="K10" name="PB15"/>
+      </package>
+      <package device-pin="n" name="TFBGA216">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE3"/>
+        <pin position="A3" name="PE2"/>
+        <pin position="A4" name="PG14"/>
+        <pin position="A5" name="PE1"/>
+        <pin position="A6" name="PE0"/>
+        <pin position="A7" name="PB8"/>
+        <pin position="A8" name="PB5"/>
+        <pin position="A9" name="PB4"/>
+        <pin position="A10" name="PB3"/>
+        <pin position="A11" name="PD7"/>
+        <pin position="A12" name="PC12"/>
+        <pin position="A13" name="PA15"/>
+        <pin position="A14" name="PA14"/>
+        <pin position="A15" name="PA13"/>
+        <pin position="B1" name="PE5"/>
+        <pin position="B2" name="PE6"/>
+        <pin position="B3" name="PG13"/>
+        <pin position="B4" name="PB9"/>
+        <pin position="B5" name="PB7"/>
+        <pin position="B6" name="PB6"/>
+        <pin position="B7" name="PG15"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ13"/>
+        <pin position="B10" name="PJ12"/>
+        <pin position="B11" name="PD6"/>
+        <pin position="B12" name="PD0"/>
+        <pin position="B13" name="PC11"/>
+        <pin position="B14" name="PC10"/>
+        <pin position="B15" name="PA12"/>
+        <pin position="C1" name="VBAT" type="power"/>
+        <pin position="C2" name="PI8"/>
+        <pin position="C3" name="PI4"/>
+        <pin position="C4" name="PK7"/>
+        <pin position="C5" name="PK6"/>
+        <pin position="C6" name="PK5"/>
+        <pin position="C7" name="PG12"/>
+        <pin position="C8" name="PG10"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD3"/>
+        <pin position="C12" name="PD1"/>
+        <pin position="C13" name="PI3"/>
+        <pin position="C14" name="PI2"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC13"/>
+        <pin position="D2" name="PF0"/>
+        <pin position="D3" name="PI5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PI10"/>
+        <pin position="D6" name="PI6"/>
+        <pin position="D7" name="PK4"/>
+        <pin position="D8" name="PK3"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PJ15"/>
+        <pin position="D11" name="PD4"/>
+        <pin position="D12" name="PD2"/>
+        <pin position="D13" name="PH15"/>
+        <pin position="D14" name="PI1"/>
+        <pin position="D15" name="PA10"/>
+        <pin position="E1" name="PC14-OSC32_IN"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PI12"/>
+        <pin position="E4" name="PI9"/>
+        <pin position="E5" name="PDR_ON" type="reset"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VDD" type="power"/>
+        <pin position="E9" name="VDDMMC" type="power"/>
+        <pin position="E10" name="VDD" type="power"/>
+        <pin position="E11" name="VCAP" type="power"/>
+        <pin position="E12" name="PH13"/>
+        <pin position="E13" name="PH14"/>
+        <pin position="E14" name="PI0"/>
+        <pin position="E15" name="PA9"/>
+        <pin position="F1" name="PC15-OSC32_OUT"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PI11"/>
+        <pin position="F4" name="VDD" type="power"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VDD" type="power"/>
+        <pin position="F12" name="PK1"/>
+        <pin position="F13" name="PK2"/>
+        <pin position="F14" name="PC9"/>
+        <pin position="F15" name="PA8"/>
+        <pin position="G1" name="PH0-OSC_IN"/>
+        <pin position="G2" name="PF2"/>
+        <pin position="G3" name="PI13"/>
+        <pin position="G4" name="PI15"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin position="G11" name="VDD33_USB" type="power"/>
+        <pin position="G12" name="PJ11"/>
+        <pin position="G13" name="PK0"/>
+        <pin position="G14" name="PC8"/>
+        <pin position="G15" name="PC7"/>
+        <pin position="H1" name="PH1-OSC_OUT"/>
+        <pin position="H2" name="PF3"/>
+        <pin position="H3" name="PI14"/>
+        <pin position="H4" name="PH4"/>
+        <pin position="H5" name="VDD" type="power"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD" type="power"/>
+        <pin position="H12" name="PJ8"/>
+        <pin position="H13" name="PJ10"/>
+        <pin position="H14" name="PG8"/>
+        <pin position="H15" name="PC6"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PF4"/>
+        <pin position="J3" name="PH5"/>
+        <pin position="J4" name="PH3"/>
+        <pin position="J5" name="VDD" type="power"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin position="J11" name="VDD" type="power"/>
+        <pin position="J12" name="PJ7"/>
+        <pin position="J13" name="PJ9"/>
+        <pin position="J14" name="PG7"/>
+        <pin position="J15" name="PG6"/>
+        <pin position="K1" name="PF7"/>
+        <pin position="K2" name="PF6"/>
+        <pin position="K3" name="PF5"/>
+        <pin position="K4" name="PH2"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="VDD" type="power"/>
+        <pin position="K12" name="PJ6"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PB13"/>
+        <pin position="K15" name="PD10"/>
+        <pin position="L1" name="PF10"/>
+        <pin position="L2" name="PF9"/>
+        <pin position="L3" name="PF8"/>
+        <pin position="L4" name="PC3_C"/>
+        <pin position="L5" name="VSS" type="power"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="VDD" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="VCAP" type="power"/>
+        <pin position="L12" name="PD14"/>
+        <pin position="L13" name="PB12"/>
+        <pin position="L14" name="PD9"/>
+        <pin position="L15" name="PD8"/>
+        <pin position="M1" name="VSSA" type="power"/>
+        <pin position="M2" name="PC0"/>
+        <pin position="M3" name="PC1"/>
+        <pin position="M4" name="PC2_C"/>
+        <pin position="M5" name="PB2"/>
+        <pin position="M6" name="PF12"/>
+        <pin position="M7" name="PG1"/>
+        <pin position="M8" name="PF15"/>
+        <pin position="M9" name="PJ4"/>
+        <pin position="M10" name="PD12"/>
+        <pin position="M11" name="PD13"/>
+        <pin position="M12" name="PG3"/>
+        <pin position="M13" name="PG2"/>
+        <pin position="M14" name="PJ5"/>
+        <pin position="M15" name="PH12"/>
+        <pin position="N1" name="VREF-" type="power"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="PA0"/>
+        <pin position="N4" name="PA4"/>
+        <pin position="N5" name="PC4"/>
+        <pin position="N6" name="PF13"/>
+        <pin position="N7" name="PG0"/>
+        <pin position="N8" name="PJ3"/>
+        <pin position="N9" name="PE8"/>
+        <pin position="N10" name="PD11"/>
+        <pin position="N11" name="PG5"/>
+        <pin position="N12" name="PG4"/>
+        <pin position="N13" name="PH7"/>
+        <pin position="N14" name="PH9"/>
+        <pin position="N15" name="PH11"/>
+        <pin position="P1" name="VREF+" type="monoio"/>
+        <pin position="P2" name="PA2"/>
+        <pin position="P3" name="PA6"/>
+        <pin position="P4" name="PA5"/>
+        <pin position="P5" name="PC5"/>
+        <pin position="P6" name="PF14"/>
+        <pin position="P7" name="PJ2"/>
+        <pin position="P8" name="PF11"/>
+        <pin position="P9" name="PE9"/>
+        <pin position="P10" name="PE11"/>
+        <pin position="P11" name="PE14"/>
+        <pin position="P12" name="PB10"/>
+        <pin position="P13" name="PH6"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH10"/>
+        <pin position="R1" name="VDDA" type="power"/>
+        <pin position="R2" name="PA3"/>
+        <pin position="R3" name="PA7"/>
+        <pin position="R4" name="PB1"/>
+        <pin position="R5" name="PB0"/>
+        <pin position="R6" name="PJ0"/>
+        <pin position="R7" name="PJ1"/>
+        <pin position="R8" name="PE7"/>
+        <pin position="R9" name="PE10"/>
+        <pin position="R10" name="PE12"/>
+        <pin position="R11" name="PE15"/>
+        <pin position="R12" name="PE13"/>
+        <pin position="R13" name="PB11"/>
+        <pin position="R14" name="PB14"/>
+        <pin position="R15" name="PB15"/>
+      </package>
+      <package device-pin="l" name="TFBGA225">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PI4"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB6"/>
+        <pin position="A5" name="PG15"/>
+        <pin position="A6" name="PK5"/>
+        <pin position="A7" name="PG14"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PG9"/>
+        <pin position="A10" name="PD7"/>
+        <pin position="A11" name="PD4"/>
+        <pin position="A12" name="PD1"/>
+        <pin position="A13" name="PC10"/>
+        <pin position="A14" name="PI3"/>
+        <pin position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE3"/>
+        <pin position="B2" name="PI5"/>
+        <pin position="B3" name="PE0"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB4"/>
+        <pin position="B6" name="PK6"/>
+        <pin position="B7" name="PK3"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PJ15"/>
+        <pin position="B10" name="PD6"/>
+        <pin position="B11" name="PD2"/>
+        <pin position="B12" name="PC12"/>
+        <pin position="B13" name="PA14"/>
+        <pin position="B14" name="PH15"/>
+        <pin position="B15" name="PH14"/>
+        <pin position="C1" name="PI8"/>
+        <pin position="C2" name="PE4"/>
+        <pin position="C3" name="PI6"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="PB3"/>
+        <pin position="C7" name="PK4"/>
+        <pin position="C8" name="PG12"/>
+        <pin position="C9" name="PJ14"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C11" name="PD0"/>
+        <pin position="C12" name="PA15"/>
+        <pin position="C13" name="PI0"/>
+        <pin position="C14" name="PA12"/>
+        <pin position="C15" name="PA11"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PC15-OSC32_OUT"/>
+        <pin position="D3" name="PE5"/>
+        <pin position="D4" name="PI7"/>
+        <pin position="D5" name="PDR_ON" type="reset"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PK7"/>
+        <pin position="D8" name="PG13"/>
+        <pin position="D9" name="PJ13"/>
+        <pin position="D10" name="PD3"/>
+        <pin position="D11" name="PC11"/>
+        <pin position="D12" name="PI2"/>
+        <pin position="D13" name="PH13"/>
+        <pin position="D14" name="VSS" type="power"/>
+        <pin position="D15" name="VDD50_USB" type="power"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PI9"/>
+        <pin position="E4" name="PE6"/>
+        <pin position="E5" name="PE2"/>
+        <pin position="E6" name="VCAP" type="power"/>
+        <pin position="E7" name="PB5"/>
+        <pin position="E8" name="VDDMMC" type="power"/>
+        <pin position="E9" name="PJ12"/>
+        <pin position="E10" name="VDDLDO" type="power"/>
+        <pin position="E11" name="PI1"/>
+        <pin position="E12" name="PA13"/>
+        <pin position="E13" name="PA10"/>
+        <pin position="E14" name="PC9"/>
+        <pin position="E15" name="PC7"/>
+        <pin position="F1" name="VLXSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PI10"/>
+        <pin position="F4" name="PC13"/>
+        <pin position="F5" name="VDDLDO" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VDD" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VDD" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F11" name="VCAP" type="power"/>
+        <pin position="F12" name="PA9"/>
+        <pin position="F13" name="PC8"/>
+        <pin position="F14" name="PC6"/>
+        <pin position="F15" name="PG8"/>
+        <pin position="G1" name="VDDSMPS" type="power"/>
+        <pin position="G2" name="VSSSMPS" type="power"/>
+        <pin position="G3" name="PF1"/>
+        <pin position="G4" name="PF0"/>
+        <pin position="G5" name="PI11"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VDD" type="power"/>
+        <pin position="G10" name="VDD" type="power"/>
+        <pin position="G11" name="PA8"/>
+        <pin position="G12" name="PG7"/>
+        <pin position="G13" name="PG6"/>
+        <pin position="G14" name="PG5"/>
+        <pin position="G15" name="PG3"/>
+        <pin position="H1" name="PF2"/>
+        <pin position="H2" name="PI12"/>
+        <pin position="H3" name="PF4"/>
+        <pin position="H4" name="PI14"/>
+        <pin position="H5" name="PI13"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin position="H11" name="VDD33_USB" type="power"/>
+        <pin position="H12" name="PG4"/>
+        <pin position="H13" name="PG2"/>
+        <pin position="H14" name="PK2"/>
+        <pin position="H15" name="PK1"/>
+        <pin position="J1" name="PF3"/>
+        <pin position="J2" name="PF5"/>
+        <pin position="J3" name="PF6"/>
+        <pin position="J4" name="PF7"/>
+        <pin position="J5" name="PC2"/>
+        <pin position="J6" name="VDD" type="power"/>
+        <pin position="J7" name="VDD" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VDD" type="power"/>
+        <pin position="J10" name="VDD" type="power"/>
+        <pin position="J11" name="PJ11"/>
+        <pin position="J12" name="PK0"/>
+        <pin position="J13" name="PJ10"/>
+        <pin position="J14" name="PJ9"/>
+        <pin position="J15" name="PJ8"/>
+        <pin position="K1" name="PF8"/>
+        <pin position="K2" name="PF9"/>
+        <pin position="K3" name="NRST" type="reset"/>
+        <pin position="K4" name="VREF-" type="power"/>
+        <pin position="K5" name="VSSA" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VDD" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VDD" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin position="K11" name="PD13"/>
+        <pin position="K12" name="PD14"/>
+        <pin position="K13" name="PD15"/>
+        <pin position="K14" name="PJ6"/>
+        <pin position="K15" name="PJ7"/>
+        <pin position="L1" name="PH0-OSC_IN"/>
+        <pin position="L2" name="PH1-OSC_OUT"/>
+        <pin position="L3" name="PC0"/>
+        <pin position="L4" name="VREF+" type="monoio"/>
+        <pin position="L5" name="VDDA" type="power"/>
+        <pin position="L6" name="PA4"/>
+        <pin position="L7" name="PB1"/>
+        <pin position="L8" name="VCAP" type="power"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="VDDLDO" type="power"/>
+        <pin position="L11" name="PH12"/>
+        <pin position="L12" name="PD8"/>
+        <pin position="L13" name="PD10"/>
+        <pin position="L14" name="PD11"/>
+        <pin position="L15" name="PD12"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PC1"/>
+        <pin position="M3" name="PF10"/>
+        <pin position="M4" name="PH2"/>
+        <pin position="M5" name="PH4"/>
+        <pin position="M6" name="PC4"/>
+        <pin position="M7" name="PI15"/>
+        <pin position="M8" name="PF13"/>
+        <pin position="M9" name="PE7"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PH6"/>
+        <pin position="M12" name="PH10"/>
+        <pin position="M13" name="PB13"/>
+        <pin position="M14" name="PB14"/>
+        <pin position="M15" name="PB15"/>
+        <pin position="N1" name="PC2_C"/>
+        <pin position="N2" name="PC3_C"/>
+        <pin position="N3" name="PC3"/>
+        <pin position="N4" name="PH3"/>
+        <pin position="N5" name="PA5"/>
+        <pin position="N6" name="PC5"/>
+        <pin position="N7" name="PJ0"/>
+        <pin position="N8" name="PF11"/>
+        <pin position="N9" name="PF15"/>
+        <pin position="N10" name="PE14"/>
+        <pin position="N11" name="PE10"/>
+        <pin position="N12" name="PJ5"/>
+        <pin position="N13" name="PH9"/>
+        <pin position="N14" name="PB12"/>
+        <pin position="N15" name="PD9"/>
+        <pin position="P1" name="PA0"/>
+        <pin position="P2" name="PA1"/>
+        <pin position="P3" name="PA0_C"/>
+        <pin position="P4" name="PH5"/>
+        <pin position="P5" name="PA6"/>
+        <pin position="P6" name="PB0"/>
+        <pin position="P7" name="PJ1"/>
+        <pin position="P8" name="PJ4"/>
+        <pin position="P9" name="PF14"/>
+        <pin position="P10" name="PG1"/>
+        <pin position="P11" name="PE9"/>
+        <pin position="P12" name="PE15"/>
+        <pin position="P13" name="PB11"/>
+        <pin position="P14" name="PH8"/>
+        <pin position="P15" name="PH11"/>
+        <pin position="R1" name="VSS" type="power"/>
+        <pin position="R2" name="PA2"/>
+        <pin position="R3" name="PA1_C"/>
+        <pin position="R4" name="PA3"/>
+        <pin position="R5" name="PA7"/>
+        <pin position="R6" name="PB2"/>
+        <pin position="R7" name="PJ2"/>
+        <pin position="R8" name="PJ3"/>
+        <pin position="R9" name="PF12"/>
+        <pin position="R10" name="PG0"/>
+        <pin position="R11" name="PE8"/>
+        <pin position="R12" name="PE11"/>
+        <pin position="R13" name="PB10"/>
+        <pin position="R14" name="PH7"/>
+        <pin position="R15" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PE4"/>
+        <pin position="A2" name="PE2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="VCAP" type="power"/>
+        <pin position="A5" name="PB6"/>
+        <pin position="A6" name="VDDMMC" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PG10"/>
+        <pin position="A9" name="PD5"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="A11" name="PC12"/>
+        <pin position="A12" name="PC10"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="PE3"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="VDDLDO" type="power"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PB4"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="PG11"/>
+        <pin position="B9" name="PD6"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="PC11"/>
+        <pin position="B12" name="PA14"/>
+        <pin position="B13" name="PH13"/>
+        <pin position="C1" name="PC14-OSC32_IN"/>
+        <pin position="C2" name="PE6"/>
+        <pin position="C3" name="PE5"/>
+        <pin position="C4" name="PDR_ON" type="reset"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PB5"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PG9"/>
+        <pin position="C9" name="PD4"/>
+        <pin position="C10" name="PD1"/>
+        <pin position="C11" name="PA15"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PC13"/>
+        <pin position="D4" name="PE1"/>
+        <pin position="D5" name="PE0"/>
+        <pin position="D6" name="PB7"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PD7"/>
+        <pin position="D9" name="PD3"/>
+        <pin position="D10" name="PD0"/>
+        <pin position="D11" name="PA13"/>
+        <pin position="D12" name="VDDLDO" type="power"/>
+        <pin position="D13" name="VCAP" type="power"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="VSSSMPS" type="power"/>
+        <pin position="E3" name="VBAT" type="power"/>
+        <pin position="E4" name="PF1"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="BOOT0" type="boot"/>
+        <pin position="E7" name="PG15"/>
+        <pin position="E8" name="PG12"/>
+        <pin position="E9" name="PD2"/>
+        <pin position="E10" name="PA10"/>
+        <pin position="E11" name="PA9"/>
+        <pin position="E12" name="PA8"/>
+        <pin position="E13" name="PA12"/>
+        <pin position="F1" name="VDDSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PF0"/>
+        <pin position="F4" name="PF2"/>
+        <pin position="F5" name="PF5"/>
+        <pin position="F6" name="PF7"/>
+        <pin position="F7" name="PB3"/>
+        <pin position="F8" name="PG4"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F10" name="PC7"/>
+        <pin position="F11" name="PC9"/>
+        <pin position="F12" name="PC8"/>
+        <pin position="F13" name="PA11"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF4"/>
+        <pin position="G4" name="PF6"/>
+        <pin position="G5" name="PF9"/>
+        <pin position="G6" name="NRST" type="reset"/>
+        <pin position="G7" name="PF13"/>
+        <pin position="G8" name="PE7"/>
+        <pin position="G9" name="PG6"/>
+        <pin position="G10" name="PG7"/>
+        <pin position="G11" name="PG8"/>
+        <pin position="G12" name="VDD50_USB" type="power"/>
+        <pin position="G13" name="VDD33_USB" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN"/>
+        <pin position="H2" name="PH1-OSC_OUT"/>
+        <pin position="H3" name="PF10"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H5" name="PC2"/>
+        <pin position="H6" name="PA4"/>
+        <pin position="H7" name="PF14"/>
+        <pin position="H8" name="PE8"/>
+        <pin position="H9" name="PG2"/>
+        <pin position="H10" name="PG3"/>
+        <pin position="H11" name="PG5"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PC0"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="VSSA" type="power"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PA0"/>
+        <pin position="J6" name="PA7"/>
+        <pin position="J7" name="PF15"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PE14"/>
+        <pin position="J10" name="PD11"/>
+        <pin position="J11" name="PD13"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="J13" name="PD14"/>
+        <pin position="K1" name="PC3_C"/>
+        <pin position="K2" name="PC2_C"/>
+        <pin position="K3" name="PA0_C"/>
+        <pin position="K4" name="PA1"/>
+        <pin position="K5" name="PA6"/>
+        <pin position="K6" name="PC4"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE13"/>
+        <pin position="K9" name="PH10"/>
+        <pin position="K10" name="PH12"/>
+        <pin position="K11" name="PD9"/>
+        <pin position="K12" name="PD10"/>
+        <pin position="K13" name="PD12"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="VREF+" type="monoio"/>
+        <pin position="L3" name="PA1_C"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PG1"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PH11"/>
+        <pin position="L11" name="PB13"/>
+        <pin position="L12" name="VSS" type="power"/>
+        <pin position="L13" name="VDD" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VSS" type="power"/>
+        <pin position="M3" name="PH3"/>
+        <pin position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PF11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE10"/>
+        <pin position="M9" name="PB11"/>
+        <pin position="M10" name="VDDLDO" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PD8"/>
+        <pin position="M13" name="PB15"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PH2"/>
+        <pin position="N3" name="PA3"/>
+        <pin position="N4" name="VDD" type="power"/>
+        <pin position="N5" name="PC5"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PE15"/>
+        <pin position="N10" name="VCAP" type="power"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB14"/>
+      </package>
+      <package device-package="k" name="UFBGA176">
+        <pin device-variant="" position="A1" name="PE3"/>
+        <pin device-variant="q" position="A1" name="VSS" type="power"/>
+        <pin device-variant="" position="A2" name="PE2"/>
+        <pin device-variant="q" position="A2" name="PB8"/>
+        <pin device-variant="" position="A3" name="PE1"/>
+        <pin device-variant="q" position="A3" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="A4" name="PE0"/>
+        <pin device-variant="q" position="A4" name="VCAP" type="power"/>
+        <pin device-variant="" position="A5" name="PB8"/>
+        <pin device-variant="q" position="A5" name="PB6"/>
+        <pin device-variant="" position="A6" name="PB5"/>
+        <pin device-variant="q" position="A6" name="PB3"/>
+        <pin device-variant="" position="A7" name="PG14"/>
+        <pin device-variant="q" position="A7" name="PG11"/>
+        <pin device-variant="" position="A8" name="PG13"/>
+        <pin device-variant="q" position="A8" name="PG9"/>
+        <pin device-variant="" position="A9" name="PB4"/>
+        <pin device-variant="q" position="A9" name="PD3"/>
+        <pin device-variant="" position="A10" name="PB3"/>
+        <pin device-variant="q" position="A10" name="PD1"/>
+        <pin device-variant="" position="A11" name="PD7"/>
+        <pin device-variant="q" position="A11" name="PA15"/>
+        <pin device-variant="" position="A12" name="PC12"/>
+        <pin device-variant="q" position="A12" name="PA14"/>
+        <pin device-variant="" position="A13" name="PA15"/>
+        <pin device-variant="q" position="A13" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="A14" name="PA14"/>
+        <pin device-variant="q" position="A14" name="VCAP" type="power"/>
+        <pin device-variant="" position="A15" name="PA13"/>
+        <pin device-variant="q" position="A15" name="VSS" type="power"/>
+        <pin position="B1" name="PE4"/>
+        <pin device-variant="" position="B2" name="PE5"/>
+        <pin device-variant="q" position="B2" name="PE3"/>
+        <pin device-variant="" position="B3" name="PE6"/>
+        <pin device-variant="q" position="B3" name="PB9"/>
+        <pin device-variant="" position="B4" name="PB9"/>
+        <pin device-variant="q" position="B4" name="PE0"/>
+        <pin position="B5" name="PB7"/>
+        <pin device-variant="" position="B6" name="PB6"/>
+        <pin device-variant="q" position="B6" name="PB4"/>
+        <pin device-variant="" position="B7" name="PG15"/>
+        <pin device-variant="q" position="B7" name="PG13"/>
+        <pin device-variant="" position="B8" name="PG12"/>
+        <pin device-variant="q" position="B8" name="PD7"/>
+        <pin device-variant="" position="B9" name="PG11"/>
+        <pin device-variant="q" position="B9" name="PD5"/>
+        <pin device-variant="" position="B10" name="PG10"/>
+        <pin device-variant="q" position="B10" name="PD2"/>
+        <pin device-variant="" position="B11" name="PD6"/>
+        <pin device-variant="q" position="B11" name="PC12"/>
+        <pin device-variant="" position="B12" name="PD0"/>
+        <pin device-variant="q" position="B12" name="PH14"/>
+        <pin device-variant="" position="B13" name="PC11"/>
+        <pin device-variant="q" position="B13" name="PA13"/>
+        <pin device-variant="" position="B14" name="PC10"/>
+        <pin device-variant="q" position="B14" name="PA8"/>
+        <pin position="B15" name="PA12"/>
+        <pin device-variant="" position="C1" name="VBAT" type="power"/>
+        <pin device-variant="q" position="C1" name="PC13"/>
+        <pin device-variant="" position="C2" name="PI7"/>
+        <pin device-variant="q" position="C2" name="VSS" type="power"/>
+        <pin device-variant="" position="C3" name="PI6"/>
+        <pin device-variant="q" position="C3" name="PE2"/>
+        <pin device-variant="" position="C4" name="PI5"/>
+        <pin device-variant="q" position="C4" name="PE1"/>
+        <pin device-variant="" position="C5" name="VDD" type="power"/>
+        <pin device-variant="q" position="C5" name="BOOT0" type="boot"/>
+        <pin device-variant="" position="C6" name="PDR_ON" type="reset"/>
+        <pin device-variant="q" position="C6" name="PB5"/>
+        <pin device-variant="" position="C7" name="VDD" type="power"/>
+        <pin device-variant="q" position="C7" name="PG14"/>
+        <pin device-variant="" position="C8" name="VDDMMC" type="power"/>
+        <pin device-variant="q" position="C8" name="PG10"/>
+        <pin device-variant="" position="C9" name="VDD" type="power"/>
+        <pin device-variant="q" position="C9" name="PD4"/>
+        <pin device-variant="" position="C10" name="PG9"/>
+        <pin device-variant="q" position="C10" name="PD0"/>
+        <pin device-variant="" position="C11" name="PD5"/>
+        <pin device-variant="q" position="C11" name="PC11"/>
+        <pin device-variant="" position="C12" name="PD1"/>
+        <pin device-variant="q" position="C12" name="PC10"/>
+        <pin device-variant="" position="C13" name="PI3"/>
+        <pin device-variant="q" position="C13" name="PH13"/>
+        <pin device-variant="" position="C14" name="PI2"/>
+        <pin device-variant="q" position="C14" name="PA10"/>
+        <pin position="C15" name="PA11"/>
+        <pin device-variant="" position="D1" name="PC13"/>
+        <pin device-variant="q" position="D1" name="PC15-OSC32_OUT"/>
+        <pin device-variant="" position="D2" name="PI8"/>
+        <pin device-variant="q" position="D2" name="PC14-OSC32_IN"/>
+        <pin device-variant="" position="D3" name="PI9"/>
+        <pin device-variant="q" position="D3" name="PE5"/>
+        <pin device-variant="" position="D4" name="PI4"/>
+        <pin device-variant="q" position="D4" name="PDR_ON" type="reset"/>
+        <pin device-variant="" position="D5" name="VSS" type="power"/>
+        <pin device-variant="q" position="D5" name="VDDMMC" type="power"/>
+        <pin device-variant="" position="D6" name="BOOT0" type="boot"/>
+        <pin device-variant="q" position="D6" name="VSS" type="power"/>
+        <pin device-variant="" position="D7" name="VSS" type="power"/>
+        <pin device-variant="q" position="D7" name="PG15"/>
+        <pin device-variant="" position="D8" name="VSS" type="power"/>
+        <pin device-variant="q" position="D8" name="PG12"/>
+        <pin device-variant="" position="D9" name="VSS" type="power"/>
+        <pin device-variant="q" position="D9" name="PD6"/>
+        <pin device-variant="" position="D10" name="PD4"/>
+        <pin device-variant="q" position="D10" name="VSS" type="power"/>
+        <pin device-variant="" position="D11" name="PD3"/>
+        <pin device-variant="q" position="D11" name="VDD" type="power"/>
+        <pin device-variant="" position="D12" name="PD2"/>
+        <pin device-variant="q" position="D12" name="PH15"/>
+        <pin device-variant="" position="D13" name="PH15"/>
+        <pin device-variant="q" position="D13" name="PA9"/>
+        <pin device-variant="" position="D14" name="PI1"/>
+        <pin device-variant="q" position="D14" name="PC8"/>
+        <pin device-variant="" position="D15" name="PA10"/>
+        <pin device-variant="q" position="D15" name="PC7"/>
+        <pin device-variant="" position="E1" name="PC14-OSC32_IN"/>
+        <pin device-variant="q" position="E1" name="VSS" type="power"/>
+        <pin device-variant="" position="E2" name="PF0"/>
+        <pin device-variant="q" position="E2" name="VBAT" type="power"/>
+        <pin device-variant="" position="E3" name="PI10"/>
+        <pin device-variant="q" position="E3" name="PE6"/>
+        <pin device-variant="" position="E4" name="PI11"/>
+        <pin device-variant="q" position="E4" name="VDD" type="power"/>
+        <pin device-variant="" position="E12" name="PH13"/>
+        <pin device-variant="q" position="E12" name="VDD" type="power"/>
+        <pin device-variant="" position="E13" name="PH14"/>
+        <pin device-variant="q" position="E13" name="PC9"/>
+        <pin device-variant="" position="E14" name="PI0"/>
+        <pin device-variant="q" position="E14" name="PC6"/>
+        <pin device-variant="" position="E15" name="PA9"/>
+        <pin device-variant="q" position="E15" name="VDD50_USB" type="power"/>
+        <pin device-variant="" position="F1" name="PC15-OSC32_OUT"/>
+        <pin device-variant="q" position="F1" name="VLXSMPS" type="power"/>
+        <pin device-variant="" position="F2" name="VSS" type="power"/>
+        <pin device-variant="q" position="F2" name="VSSSMPS" type="power"/>
+        <pin device-variant="" position="F3" name="VDD" type="power"/>
+        <pin device-variant="q" position="F3" name="PF1"/>
+        <pin device-variant="" position="F4" name="PH2"/>
+        <pin device-variant="q" position="F4" name="PF0"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VSS" type="power"/>
+        <pin position="F9" name="VSS" type="power"/>
+        <pin position="F10" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin device-variant="" position="F13" name="VCAP" type="power"/>
+        <pin device-variant="q" position="F13" name="VDD33_USB" type="power"/>
+        <pin device-variant="" position="F14" name="PC9"/>
+        <pin device-variant="q" position="F14" name="PG6"/>
+        <pin device-variant="" position="F15" name="PA8"/>
+        <pin device-variant="q" position="F15" name="PG5"/>
+        <pin device-variant="" position="G1" name="PH0-OSC_IN"/>
+        <pin device-variant="q" position="G1" name="VDDSMPS" type="power"/>
+        <pin device-variant="" position="G2" name="VSS" type="power"/>
+        <pin device-variant="q" position="G2" name="VFBSMPS" type="power"/>
+        <pin device-variant="" position="G3" name="VDD" type="power"/>
+        <pin device-variant="q" position="G3" name="PF2"/>
+        <pin device-variant="" position="G4" name="PH3"/>
+        <pin device-variant="q" position="G4" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VSS" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G10" name="VSS" type="power"/>
+        <pin device-variant="" position="G12" name="VSS" type="power"/>
+        <pin device-variant="q" position="G12" name="PG8"/>
+        <pin device-variant="" position="G13" name="VDD" type="power"/>
+        <pin device-variant="q" position="G13" name="PG7"/>
+        <pin device-variant="" position="G14" name="PC8"/>
+        <pin device-variant="q" position="G14" name="PG4"/>
+        <pin device-variant="" position="G15" name="PC7"/>
+        <pin device-variant="q" position="G15" name="PG2"/>
+        <pin device-variant="" position="H1" name="PH1-OSC_OUT"/>
+        <pin device-variant="q" position="H1" name="PF6"/>
+        <pin device-variant="" position="H2" name="PF2"/>
+        <pin device-variant="q" position="H2" name="PF4"/>
+        <pin device-variant="" position="H3" name="PF1"/>
+        <pin device-variant="q" position="H3" name="PF5"/>
+        <pin device-variant="" position="H4" name="PH4"/>
+        <pin device-variant="q" position="H4" name="PF3"/>
+        <pin position="H6" name="VSS" type="power"/>
+        <pin position="H7" name="VSS" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VSS" type="power"/>
+        <pin device-variant="" position="H12" name="VSS" type="power"/>
+        <pin device-variant="q" position="H12" name="VDD" type="power"/>
+        <pin device-variant="" position="H13" name="VDD33_USB" type="power"/>
+        <pin device-variant="q" position="H13" name="PG3"/>
+        <pin device-variant="" position="H14" name="PG8"/>
+        <pin device-variant="q" position="H14" name="PD14"/>
+        <pin device-variant="" position="H15" name="PC6"/>
+        <pin device-variant="q" position="H15" name="PD13"/>
+        <pin device-variant="" position="J1" name="NRST" type="reset"/>
+        <pin device-variant="q" position="J1" name="PH0-OSC_IN"/>
+        <pin device-variant="" position="J2" name="PF3"/>
+        <pin device-variant="q" position="J2" name="PF8"/>
+        <pin device-variant="" position="J3" name="PF4"/>
+        <pin device-variant="q" position="J3" name="PF7"/>
+        <pin device-variant="" position="J4" name="PH5"/>
+        <pin device-variant="q" position="J4" name="PF9"/>
+        <pin position="J6" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J8" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VSS" type="power"/>
+        <pin device-variant="" position="J12" name="VDD" type="power"/>
+        <pin device-variant="q" position="J12" name="PD15"/>
+        <pin device-variant="" position="J13" name="VDD" type="power"/>
+        <pin device-variant="q" position="J13" name="PD11"/>
+        <pin device-variant="" position="J14" name="PG7"/>
+        <pin device-variant="q" position="J14" name="VSS" type="power"/>
+        <pin device-variant="" position="J15" name="PG6"/>
+        <pin device-variant="q" position="J15" name="PD12"/>
+        <pin device-variant="" position="K1" name="PF7"/>
+        <pin device-variant="q" position="K1" name="PH1-OSC_OUT"/>
+        <pin device-variant="" position="K2" name="PF6"/>
+        <pin device-variant="q" position="K2" name="VSS" type="power"/>
+        <pin device-variant="" position="K3" name="PF5"/>
+        <pin device-variant="q" position="K3" name="PF10"/>
+        <pin position="K4" name="VDD" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="VSS" type="power"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="VSS" type="power"/>
+        <pin position="K10" name="VSS" type="power"/>
+        <pin device-variant="" position="K12" name="PH12"/>
+        <pin device-variant="q" position="K12" name="VSS" type="power"/>
+        <pin device-variant="" position="K13" name="PG5"/>
+        <pin device-variant="q" position="K13" name="PD9"/>
+        <pin device-variant="" position="K14" name="PG4"/>
+        <pin device-variant="q" position="K14" name="PB15"/>
+        <pin device-variant="" position="K15" name="PG3"/>
+        <pin device-variant="q" position="K15" name="PB14"/>
+        <pin device-variant="" position="L1" name="PF10"/>
+        <pin device-variant="q" position="L1" name="NRST" type="reset"/>
+        <pin device-variant="" position="L2" name="PF9"/>
+        <pin device-variant="q" position="L2" name="PC0"/>
+        <pin device-variant="" position="L3" name="PF8"/>
+        <pin device-variant="q" position="L3" name="PC1"/>
+        <pin device-variant="" position="L4" name="VSS" type="power"/>
+        <pin device-variant="q" position="L4" name="VREF-" type="power"/>
+        <pin device-variant="" position="L12" name="PH11"/>
+        <pin device-variant="q" position="L12" name="VDD" type="power"/>
+        <pin device-variant="" position="L13" name="PH10"/>
+        <pin device-variant="q" position="L13" name="PD10"/>
+        <pin device-variant="" position="L14" name="PD15"/>
+        <pin device-variant="q" position="L14" name="PD8"/>
+        <pin device-variant="" position="L15" name="PG2"/>
+        <pin device-variant="q" position="L15" name="PB13"/>
+        <pin device-variant="" position="M1" name="VSSA" type="power"/>
+        <pin device-variant="q" position="M1" name="PC2"/>
+        <pin device-variant="" position="M2" name="PC0"/>
+        <pin device-variant="q" position="M2" name="PC3"/>
+        <pin device-variant="" position="M3" name="PC1"/>
+        <pin device-variant="q" position="M3" name="VREF+" type="monoio"/>
+        <pin device-variant="" position="M4" name="PC2_C"/>
+        <pin device-variant="q" position="M4" name="VDDA" type="power"/>
+        <pin device-variant="" position="M5" name="PC3_C"/>
+        <pin device-variant="q" position="M5" name="VDD" type="power"/>
+        <pin device-variant="" position="M6" name="PB2"/>
+        <pin device-variant="q" position="M6" name="VSS" type="power"/>
+        <pin device-variant="" position="M7" name="PG1"/>
+        <pin device-variant="q" position="M7" name="PC5"/>
+        <pin device-variant="" position="M8" name="VSS" type="power"/>
+        <pin device-variant="q" position="M8" name="PB1"/>
+        <pin device-variant="" position="M9" name="VSS" type="power"/>
+        <pin device-variant="q" position="M9" name="VDD" type="power"/>
+        <pin device-variant="" position="M10" name="VCAP" type="power"/>
+        <pin device-variant="q" position="M10" name="VSS" type="power"/>
+        <pin device-variant="" position="M11" name="PH6"/>
+        <pin device-variant="q" position="M11" name="PH7"/>
+        <pin device-variant="" position="M12" name="PH8"/>
+        <pin device-variant="q" position="M12" name="PE14"/>
+        <pin device-variant="" position="M13" name="PH9"/>
+        <pin device-variant="q" position="M13" name="PH11"/>
+        <pin device-variant="" position="M14" name="PD14"/>
+        <pin device-variant="q" position="M14" name="PH9"/>
+        <pin device-variant="" position="M15" name="PD13"/>
+        <pin device-variant="q" position="M15" name="PB12"/>
+        <pin device-variant="" position="N1" name="VREF-" type="power"/>
+        <pin device-variant="q" position="N1" name="PC2_C"/>
+        <pin device-variant="" position="N2" name="PA1"/>
+        <pin device-variant="q" position="N2" name="PC3_C"/>
+        <pin device-variant="" position="N3" name="PA0"/>
+        <pin device-variant="q" position="N3" name="VSSA" type="power"/>
+        <pin device-variant="" position="N4" name="PA4"/>
+        <pin device-variant="q" position="N4" name="PH2"/>
+        <pin device-variant="" position="N5" name="PC4"/>
+        <pin device-variant="q" position="N5" name="PA3"/>
+        <pin device-variant="" position="N6" name="PF13"/>
+        <pin device-variant="q" position="N6" name="PA7"/>
+        <pin device-variant="" position="N7" name="PG0"/>
+        <pin device-variant="q" position="N7" name="PF11"/>
+        <pin device-variant="" position="N8" name="VDD" type="power"/>
+        <pin device-variant="q" position="N8" name="PE8"/>
+        <pin device-variant="" position="N9" name="VDD" type="power"/>
+        <pin device-variant="q" position="N9" name="PG1"/>
+        <pin device-variant="" position="N10" name="VDD" type="power"/>
+        <pin device-variant="q" position="N10" name="PF15"/>
+        <pin device-variant="" position="N11" name="PE13"/>
+        <pin device-variant="q" position="N11" name="PF13"/>
+        <pin device-variant="" position="N12" name="PH7"/>
+        <pin device-variant="q" position="N12" name="PB10"/>
+        <pin device-variant="" position="N13" name="PD12"/>
+        <pin device-variant="q" position="N13" name="PH8"/>
+        <pin device-variant="" position="N14" name="PD11"/>
+        <pin device-variant="q" position="N14" name="PH10"/>
+        <pin device-variant="" position="N15" name="PD10"/>
+        <pin device-variant="q" position="N15" name="PH12"/>
+        <pin device-variant="" position="P1" name="VREF+" type="monoio"/>
+        <pin device-variant="q" position="P1" name="PA0"/>
+        <pin device-variant="" position="P2" name="PA2"/>
+        <pin device-variant="q" position="P2" name="PA1"/>
+        <pin device-variant="" position="P3" name="PA6"/>
+        <pin device-variant="q" position="P3" name="PA1_C"/>
+        <pin device-variant="" position="P4" name="PA5"/>
+        <pin device-variant="q" position="P4" name="PH4"/>
+        <pin device-variant="" position="P5" name="PC5"/>
+        <pin device-variant="q" position="P5" name="PA4"/>
+        <pin device-variant="" position="P6" name="PF12"/>
+        <pin device-variant="q" position="P6" name="PA5"/>
+        <pin device-variant="" position="P7" name="PF15"/>
+        <pin device-variant="q" position="P7" name="PB2"/>
+        <pin device-variant="" position="P8" name="PE8"/>
+        <pin device-variant="q" position="P8" name="PG0"/>
+        <pin device-variant="" position="P9" name="PE9"/>
+        <pin device-variant="q" position="P9" name="PE7"/>
+        <pin device-variant="" position="P10" name="PE11"/>
+        <pin device-variant="q" position="P10" name="PB11"/>
+        <pin device-variant="" position="P11" name="PE14"/>
+        <pin device-variant="q" position="P11" name="PF12"/>
+        <pin device-variant="" position="P12" name="PB12"/>
+        <pin device-variant="q" position="P12" name="PE12"/>
+        <pin device-variant="" position="P13" name="PB13"/>
+        <pin device-variant="q" position="P13" name="PE13"/>
+        <pin device-variant="" position="P14" name="PD9"/>
+        <pin device-variant="q" position="P14" name="PE15"/>
+        <pin device-variant="" position="P15" name="PD8"/>
+        <pin device-variant="q" position="P15" name="PH6"/>
+        <pin device-variant="" position="R1" name="VDDA" type="power"/>
+        <pin device-variant="q" position="R1" name="VSS" type="power"/>
+        <pin device-variant="" position="R2" name="PA3"/>
+        <pin device-variant="q" position="R2" name="PA2"/>
+        <pin device-variant="" position="R3" name="PA7"/>
+        <pin device-variant="q" position="R3" name="PA0_C"/>
+        <pin device-variant="" position="R4" name="PB1"/>
+        <pin device-variant="q" position="R4" name="PH3"/>
+        <pin device-variant="" position="R5" name="PB0"/>
+        <pin device-variant="q" position="R5" name="PH5"/>
+        <pin device-variant="" position="R6" name="PF11"/>
+        <pin device-variant="q" position="R6" name="PC4"/>
+        <pin device-variant="" position="R7" name="PF14"/>
+        <pin device-variant="q" position="R7" name="PA6"/>
+        <pin device-variant="" position="R8" name="PE7"/>
+        <pin device-variant="q" position="R8" name="PB0"/>
+        <pin position="R9" name="PE10"/>
+        <pin device-variant="" position="R10" name="PE12"/>
+        <pin device-variant="q" position="R10" name="PF14"/>
+        <pin device-variant="" position="R11" name="PE15"/>
+        <pin device-variant="q" position="R11" name="PE9"/>
+        <pin device-variant="" position="R12" name="PB10"/>
+        <pin device-variant="q" position="R12" name="PE11"/>
+        <pin device-variant="" position="R13" name="PB11"/>
+        <pin device-variant="q" position="R13" name="VCAP" type="power"/>
+        <pin device-variant="" position="R14" name="PB14"/>
+        <pin device-variant="q" position="R14" name="VDDLDO" type="power"/>
+        <pin device-variant="" position="R15" name="PB15"/>
+        <pin device-variant="q" position="R15" name="VSS" type="power"/>
+      </package>
+      <package device-pin="q" name="WLCSP132">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="VDD" type="power"/>
+        <pin position="A3" name="PC10"/>
+        <pin position="A4" name="PD3"/>
+        <pin position="A5" name="VSS" type="power"/>
+        <pin position="A6" name="PG10"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="BOOT0" type="boot"/>
+        <pin position="A10" name="VCAP" type="power"/>
+        <pin position="A11" name="VDDLDO" type="power"/>
+        <pin position="A12" name="VDD" type="power"/>
+        <pin position="B1" name="VDDLDO" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="PC12"/>
+        <pin position="B4" name="PD4"/>
+        <pin position="B5" name="VDDMMC" type="power"/>
+        <pin position="B6" name="PG11"/>
+        <pin position="B7" name="VSS" type="power"/>
+        <pin position="B8" name="VDDMMC" type="power"/>
+        <pin position="B9" name="PB8"/>
+        <pin position="B10" name="VSS" type="power"/>
+        <pin position="B11" name="VDD" type="power"/>
+        <pin position="B12" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="VCAP" type="power"/>
+        <pin position="C3" name="PA15"/>
+        <pin position="C4" name="PD0"/>
+        <pin position="C5" name="PD5"/>
+        <pin position="C6" name="PG12"/>
+        <pin position="C7" name="PG14"/>
+        <pin position="C8" name="PB6"/>
+        <pin position="C9" name="PE1"/>
+        <pin position="C10" name="PE6"/>
+        <pin position="C11" name="PC15-OSC32_OUT"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA13"/>
+        <pin position="D4" name="PC11"/>
+        <pin position="D5" name="PD2"/>
+        <pin position="D6" name="PG9"/>
+        <pin position="D7" name="PG13"/>
+        <pin position="D8" name="PB7"/>
+        <pin position="D9" name="PDR_ON" type="reset"/>
+        <pin position="D10" name="PE5"/>
+        <pin position="D11" name="VBAT" type="power"/>
+        <pin position="D12" name="VSSSMPS" type="power"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PA14"/>
+        <pin position="E5" name="PD1"/>
+        <pin position="E6" name="PD7"/>
+        <pin position="E7" name="PB4"/>
+        <pin position="E8" name="PB9"/>
+        <pin position="E9" name="PE3"/>
+        <pin position="E10" name="PC13"/>
+        <pin position="E11" name="VFBSMPS" type="power"/>
+        <pin position="E12" name="VLXSMPS" type="power"/>
+        <pin position="F1" name="VDD33_USB" type="power"/>
+        <pin position="F2" name="VDD50_USB" type="power"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F4" name="PA9"/>
+        <pin position="F5" name="PB10"/>
+        <pin position="F6" name="PD6"/>
+        <pin position="F7" name="PB5"/>
+        <pin position="F8" name="PE0"/>
+        <pin position="F9" name="PE4"/>
+        <pin position="F10" name="NRST" type="reset"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VDDSMPS" type="power"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PD12"/>
+        <pin position="G4" name="PD11"/>
+        <pin position="G5" name="PE15"/>
+        <pin position="G6" name="PE10"/>
+        <pin position="G7" name="PA6"/>
+        <pin position="G8" name="PA1"/>
+        <pin position="G9" name="PC3"/>
+        <pin position="G10" name="PC0"/>
+        <pin position="G11" name="PH0-OSC_IN"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PD15"/>
+        <pin position="H2" name="PD13"/>
+        <pin position="H3" name="PD8"/>
+        <pin position="H4" name="PB15"/>
+        <pin position="H5" name="PE14"/>
+        <pin position="H6" name="PE8"/>
+        <pin position="H7" name="PC4"/>
+        <pin position="H8" name="PA2"/>
+        <pin position="H9" name="VSS" type="power"/>
+        <pin position="H10" name="VDD" type="power"/>
+        <pin position="H11" name="PC1"/>
+        <pin position="H12" name="PH1-OSC_OUT"/>
+        <pin position="J1" name="PD14"/>
+        <pin position="J2" name="PD9"/>
+        <pin position="J3" name="PB14"/>
+        <pin position="J4" name="PB11"/>
+        <pin position="J5" name="PE11"/>
+        <pin position="J6" name="PE9"/>
+        <pin position="J7" name="PB1"/>
+        <pin position="J8" name="PC5"/>
+        <pin position="J9" name="PA3"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin position="J11" name="VREF+" type="monoio"/>
+        <pin position="J12" name="PC2"/>
+        <pin position="K1" name="PD10"/>
+        <pin position="K2" name="PB13"/>
+        <pin position="K3" name="VDDLDO" type="power"/>
+        <pin position="K4" name="VSS" type="power"/>
+        <pin position="K5" name="PE12"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K7" name="PF14"/>
+        <pin position="K8" name="PB0"/>
+        <pin position="K9" name="PA7"/>
+        <pin position="K10" name="PA4"/>
+        <pin position="K11" name="PA0"/>
+        <pin position="K12" name="VSSA" type="power"/>
+        <pin position="L1" name="VDD" type="power"/>
+        <pin position="L2" name="PB12"/>
+        <pin position="L3" name="VDD" type="power"/>
+        <pin position="L4" name="VCAP" type="power"/>
+        <pin position="L5" name="PE13"/>
+        <pin position="L6" name="VDD" type="power"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PB2"/>
+        <pin position="L9" name="VSS" type="power"/>
+        <pin position="L10" name="VDD" type="power"/>
+        <pin position="L11" name="PA5"/>
+        <pin position="L12" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l0-10.xml
+++ b/devices/stm32/stm32l0-10.xml
@@ -547,6 +547,180 @@
       <gpio device-pin="c|r" port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="k" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin device-size="4" position="6" name="PA0-CK_IN"/>
+        <pin device-size="8" position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin device-size="4" position="31" name="PB9-BOOT0"/>
+        <pin device-size="8" position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" name="LQFP48">
+        <pin position="1" name="PC0"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="PB9-BOOT0"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l0-11_21.xml
+++ b/devices/stm32/stm32l0-11_21.xml
@@ -499,6 +499,191 @@
       <gpio port="c" pin="15">
         <signal driver="rcc" name="osc32_out"/>
       </gpio>
+      <package device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB9-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="d" name="TSSOP14">
+        <pin position="1" name="PB9-BOOT0"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="PA0-CK_IN"/>
+        <pin position="6" name="PA1"/>
+        <pin position="7" name="PA4"/>
+        <pin position="8" name="PA7"/>
+        <pin position="9" name="VSS" type="power"/>
+        <pin position="10" name="VDD" type="power"/>
+        <pin position="11" name="PA9"/>
+        <pin position="12" name="PA10"/>
+        <pin position="13" name="PA13"/>
+        <pin position="14" name="PA14"/>
+      </package>
+      <package device-pin="f" device-package="p" name="TSSOP20">
+        <pin position="1" name="PB9-BOOT0"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
+      <package device-pin="f" device-package="u" name="UFQFPN20">
+        <pin position="1" name="PC14-OSC32_IN"/>
+        <pin position="2" name="PC15-OSC32_OUT"/>
+        <pin position="3" name="NRST" type="reset"/>
+        <pin position="4" name="VDDA" type="power"/>
+        <pin position="5" name="PA0-CK_IN"/>
+        <pin position="6" name="PA1"/>
+        <pin position="7" name="PA4"/>
+        <pin position="8" name="PA5"/>
+        <pin position="9" name="PA6"/>
+        <pin position="10" name="PA7"/>
+        <pin position="11" name="PB1"/>
+        <pin position="12" name="VSS" type="power"/>
+        <pin position="13" name="VDD" type="power"/>
+        <pin position="14" name="PA9"/>
+        <pin position="15" name="PA10"/>
+        <pin position="16" name="PA13"/>
+        <pin position="17" name="PA14"/>
+        <pin position="18" name="PB6"/>
+        <pin position="19" name="PB7"/>
+        <pin position="20" name="PB9-BOOT0"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin position="1" name="PB9-BOOT0"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin position="25" name="PB4"/>
+        <pin position="26" name="PB5"/>
+        <pin position="27" name="PB6"/>
+        <pin position="28" name="PB7"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PB9-BOOT0"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="e" name="WLCSP25">
+        <pin position="A1" name="PA13"/>
+        <pin position="A2" name="PA14"/>
+        <pin position="A3" name="PB6"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="PB9-BOOT0"/>
+        <pin position="B1" name="PA9"/>
+        <pin position="B2" name="PB3"/>
+        <pin position="B3" name="PA4"/>
+        <pin position="B4" name="PA1"/>
+        <pin position="B5" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA8"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA7"/>
+        <pin position="C4" name="VDDA" type="power"/>
+        <pin position="C5" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="PB1"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA2"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="E1" name="VSS" type="power"/>
+        <pin position="E2" name="PB0"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA0-CK_IN"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l0-31_41.xml
+++ b/devices/stm32/stm32l0-31_41.xml
@@ -487,6 +487,268 @@
       <gpio device-pin="c" port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="PC0"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="f" name="TSSOP20">
+        <pin position="1" name="BOOT0" type="boot"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB1"/>
+        <pin position="15" name="VSS" type="power"/>
+        <pin position="16" name="VDD" type="power"/>
+        <pin position="17" name="PA9"/>
+        <pin position="18" name="PA10"/>
+        <pin position="19" name="PA13"/>
+        <pin position="20" name="PA14"/>
+      </package>
+      <package device-pin="g" name="UFQFPN28">
+        <pin device-variant="s" position="1" name="BOOT0" type="boot"/>
+        <pin device-name="31" device-size="6" device-temperature="3|7" device-variant="" position="1" name="VDD" type="power"/>
+        <pin device-name="31" device-size="4|6" device-temperature="6" device-variant="" position="1" name="VDD" type="power"/>
+        <pin device-name="41" device-size="6" device-temperature="6|7" device-variant="" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA13"/>
+        <pin position="22" name="PA14"/>
+        <pin position="23" name="PA15"/>
+        <pin position="24" name="PB3"/>
+        <pin device-variant="s" position="25" name="PB4"/>
+        <pin device-name="31" device-size="6" device-temperature="3|7" device-variant="" position="25" name="PB6"/>
+        <pin device-name="31" device-size="4|6" device-temperature="6" device-variant="" position="25" name="PB6"/>
+        <pin device-name="41" device-size="6" device-temperature="6|7" device-variant="" position="25" name="PB6"/>
+        <pin device-variant="s" position="26" name="PB5"/>
+        <pin device-name="31" device-size="6" device-temperature="3|7" device-variant="" position="26" name="PB7"/>
+        <pin device-name="31" device-size="4|6" device-temperature="6" device-variant="" position="26" name="PB7"/>
+        <pin device-name="41" device-size="6" device-temperature="6|7" device-variant="" position="26" name="PB7"/>
+        <pin device-variant="s" position="27" name="PB6"/>
+        <pin device-name="31" device-size="6" device-temperature="3|7" device-variant="" position="27" name="BOOT0" type="boot"/>
+        <pin device-name="31" device-size="4|6" device-temperature="6" device-variant="" position="27" name="BOOT0" type="boot"/>
+        <pin device-name="41" device-size="6" device-temperature="6|7" device-variant="" position="27" name="BOOT0" type="boot"/>
+        <pin device-variant="s" position="28" name="PB7"/>
+        <pin device-name="31" device-size="6" device-temperature="3|7" device-variant="" position="28" name="VSS" type="power"/>
+        <pin device-name="31" device-size="4|6" device-temperature="6" device-variant="" position="28" name="VSS" type="power"/>
+        <pin device-name="41" device-size="6" device-temperature="6|7" device-variant="" position="28" name="VSS" type="power"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="PC0"/>
+        <pin position="2" name="PC13-ANTI_TAMP"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="e" name="WLCSP25">
+        <pin position="A1" name="PA13"/>
+        <pin position="A2" name="PA14"/>
+        <pin position="A3" name="PB6"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="B1" name="PA9"/>
+        <pin position="B2" name="PB3"/>
+        <pin position="B3" name="PA4"/>
+        <pin position="B4" name="PA1"/>
+        <pin position="B5" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA8"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA7"/>
+        <pin position="C4" name="VDDA" type="power"/>
+        <pin position="C5" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="VDD" type="power"/>
+        <pin position="D2" name="PB1"/>
+        <pin position="D3" name="PA5"/>
+        <pin position="D4" name="PA2"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="E1" name="VSSA" type="power"/>
+        <pin position="E2" name="PB0"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA0-CK_IN"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l0-51_52_53_62_63.xml
+++ b/devices/stm32/stm32l0-51_52_53_62_63.xml
@@ -798,6 +798,378 @@
       <gpio device-pin="c|r" port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin device-name="53" device-size="6|8" device-temperature="6|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="63" device-size="8" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="3|7" position="1" name="VDD" type="power"/>
+        <pin device-name="51|52" device-size="6|8" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="53" device-size="6|8" device-temperature="7" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="63" device-size="8" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="6|8" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="3|7" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="51" device-size="6|8" device-temperature="6" position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin device-name="53" device-size="8" device-temperature="3|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="53" device-size="6|8" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="63" device-size="8" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="51|52" device-size="8" device-temperature="7" position="1" name="VDD" type="power"/>
+        <pin device-name="51|52" device-size="6|8" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin device-name="53" device-size="8" device-temperature="3" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="63" device-size="8" device-temperature="6" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="8" device-temperature="7" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="6|8" device-temperature="6" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="7" position="48" name="VDDIO2" type="power"/>
+        <pin device-name="51" device-size="6|8" device-temperature="6" position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin device-name="53" device-size="8" device-temperature="3|7" position="B2" name="VLCD" type="power"/>
+        <pin device-name="53" device-size="6|8" device-temperature="6" position="B2" name="VLCD" type="power"/>
+        <pin device-name="51|52" device-size="8" device-temperature="7" position="B2" name="VDD" type="power"/>
+        <pin device-name="51|52" device-size="6|8" device-temperature="6" position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin device-name="53" device-size="8" device-temperature="3" position="E5" name="VDD" type="power"/>
+        <pin device-name="52|53" device-size="8" device-temperature="7" position="E5" name="VDD" type="power"/>
+        <pin device-name="52|53" device-size="6|8" device-temperature="6" position="E5" name="VDD" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="7" position="E5" name="VDDIO2" type="power"/>
+        <pin device-name="51" device-size="6|8" device-temperature="6" position="E5" name="VDDIO2" type="power"/>
+        <pin device-name="53" device-size="8" device-temperature="3" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="8" device-temperature="7" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="6|8" device-temperature="6" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="7" position="E6" name="VDD" type="power"/>
+        <pin device-name="51" device-size="6|8" device-temperature="6" position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="PB2"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="PB8"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin device-name="53" device-size="6|8" device-temperature="6|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="62|63" device-size="8" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="3|7" position="1" name="VDD" type="power"/>
+        <pin device-name="51|52" device-size="6|8" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="53" device-size="6|8" device-temperature="7" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="52|53" device-size="6|8" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="62|63" device-size="8" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="51" device-size="8" device-temperature="3|7" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="51" device-size="6|8" device-temperature="6" position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA13"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB4"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VDD" type="power"/>
+        <pin position="A6" name="PC14-OSC32_IN"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB3"/>
+        <pin position="B4" name="PB6"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="PC15-OSC32_OUT"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C3" name="PB1"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="BOOT0" type="boot"/>
+        <pin position="C6" name="NRST" type="reset"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PB11"/>
+        <pin position="D3" name="PB0"/>
+        <pin position="D4" name="PA0"/>
+        <pin position="D5" name="VDDA" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="E1" name="PA8"/>
+        <pin position="E2" name="PB10"/>
+        <pin position="E3" name="PA6"/>
+        <pin position="E4" name="PA4"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="VREF+" type="power"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin position="F2" name="PB2"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PA3"/>
+        <pin position="F6" name="PA1"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l0-71_72_73_81_82_83.xml
+++ b/devices/stm32/stm32l0-71_72_73_81_82_83.xml
@@ -1299,6 +1299,733 @@
       </gpio>
       <gpio device-pin="v" port="h" pin="9"/>
       <gpio device-pin="v" port="h" pin="10"/>
+      <package device-package="e" name="EWLCSP49">
+        <pin position="A1" name="VDD_USB" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PB9"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB4"/>
+        <pin position="B4" name="PB6"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VDD" type="power"/>
+        <pin position="B7" name="PC13"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PC1"/>
+        <pin position="C5" name="PC0"/>
+        <pin position="C6" name="PC14-OSC32_IN"/>
+        <pin position="C7" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PB1"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="PH0-OSC_IN"/>
+        <pin position="D7" name="PH1-OSC_OUT"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PA9"/>
+        <pin position="E3" name="PB2"/>
+        <pin position="E4" name="PA1"/>
+        <pin position="E5" name="PA0"/>
+        <pin position="E6" name="VREF+" type="power"/>
+        <pin position="E7" name="PC2"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="PB13"/>
+        <pin position="F3" name="PB11"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA4"/>
+        <pin position="F6" name="PA2"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="G1" name="PB12"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PB0"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="PA5"/>
+        <pin position="G7" name="PA3"/>
+      </package>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin device-name="73" device-size="8|b|z" device-temperature="6|7" position="6" name="VLCD" type="power"/>
+        <pin device-name="73" device-size="z" device-temperature="3" position="6" name="VLCD" type="power"/>
+        <pin device-name="83" device-size="8|b|z" device-temperature="6" position="6" name="VLCD" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="7" position="6" name="VDD" type="power"/>
+        <pin device-name="71|72" device-size="8|b|z" device-temperature="6" position="6" name="VDD" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PH9"/>
+        <pin position="11" name="PH10"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin device-name="73" device-size="8|b|z" device-temperature="7" position="75" name="VDD_USB" type="power"/>
+        <pin device-name="73" device-size="z" device-temperature="3" position="75" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|83" device-size="8|b|z" device-temperature="6" position="75" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6" position="75" name="VDDIO2" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="7" position="75" name="VDDIO2" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin position="24" name="PA14"/>
+        <pin position="25" name="PA15"/>
+        <pin position="26" name="PB3"/>
+        <pin position="27" name="PB4"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="BOOT0" type="boot"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="73|83" device-size="b|z" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6|7" position="1" name="VDD" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="3" position="1" name="VDD" type="power"/>
+        <pin device-name="72" device-size="z" device-temperature="3|7" position="1" name="VDD" type="power"/>
+        <pin device-name="72|81" device-size="b|z" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="72|73" device-size="z" device-temperature="3|7" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|83" device-size="b|z" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6|7" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="3" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="81" device-size="b|z" device-temperature="6" position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="73|83" device-size="b|z" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="6|7" position="1" name="VDD" type="power"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="1" name="VDD" type="power"/>
+        <pin device-name="72" device-size="z" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|83" device-size="b|z" device-temperature="6" position="48" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="6|7" position="48" name="VDDIO2" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="B2" name="VLCD" type="power"/>
+        <pin device-name="73|83" device-size="b|z" device-temperature="6" position="B2" name="VLCD" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="6|7" position="B2" name="VDD" type="power"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="B2" name="VDD" type="power"/>
+        <pin device-name="72" device-size="z" device-temperature="6" position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|83" device-size="b|z" device-temperature="6" position="E6" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="6|7" position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDD" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin device-name="73" device-size="b|z" device-temperature="3|7" position="E2" name="VLCD" type="power"/>
+        <pin device-name="73|83" device-size="8|b|z" device-temperature="6" position="E2" name="VLCD" type="power"/>
+        <pin device-name="71|72" device-size="8|b|z" device-temperature="6" position="E2" name="VDD" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN"/>
+        <pin position="F2" name="PH9"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT"/>
+        <pin position="G2" name="PH10"/>
+        <pin device-name="73" device-size="b|z" device-temperature="3|7" position="G11" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|83" device-size="8|b|z" device-temperature="6" position="G11" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6" position="G11" name="VDDIO2" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin device-name="73" device-size="z" device-temperature="3|6|7" position="B2" name="VLCD" type="power"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="B2" name="VDD" type="power"/>
+        <pin device-name="72" device-size="z" device-temperature="6" position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD_USB" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="PC14-OSC32_IN"/>
+        <pin position="2" name="PC15-OSC32_OUT"/>
+        <pin position="3" name="NRST" type="reset"/>
+        <pin position="4" name="VSSA" type="power"/>
+        <pin position="5" name="VDDA" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13"/>
+        <pin device-name="72" device-size="b" device-temperature="3|6|7" position="24" name="VDD_USB" type="power"/>
+        <pin device-name="72" device-size="z" device-temperature="6|7" position="24" name="VDD_USB" type="power"/>
+        <pin device-name="82" device-size="b|z" device-temperature="6" position="24" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="3|6|7" position="24" name="VDDIO2" type="power"/>
+        <pin device-name="81" device-size="z" device-temperature="6" position="24" name="VDDIO2" type="power"/>
+        <pin position="25" name="PA14"/>
+        <pin position="26" name="PB4"/>
+        <pin position="27" name="PB5"/>
+        <pin position="28" name="PB6"/>
+        <pin position="29" name="PB7"/>
+        <pin position="30" name="BOOT0" type="boot"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin device-name="73" device-size="b|z" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="73" device-size="z" device-temperature="3|7" position="1" name="VLCD" type="power"/>
+        <pin device-name="83" device-size="z" device-temperature="6" position="1" name="VLCD" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6|7" position="1" name="VDD" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="3" position="1" name="VDD" type="power"/>
+        <pin device-name="72" device-size="b|z" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin device-name="81" device-size="z" device-temperature="6" position="1" name="VDD" type="power"/>
+        <pin device-name="72|82" device-size="z" device-temperature="3|6|7" position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="83" device-size="z" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="72|73" device-size="b|z" device-temperature="6" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="72|73|82" device-size="z" device-temperature="3|6|7" position="36" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="8|b|z" device-temperature="6|7" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="3" position="36" name="VDDIO2" type="power"/>
+        <pin device-name="81" device-size="z" device-temperature="6" position="36" name="VDDIO2" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP49">
+        <pin device-name="72" device-size="b|z" device-temperature="6" position="A1" name="VDD_USB" type="power"/>
+        <pin device-name="72|82" device-size="z" device-temperature="3|6|7" position="A1" name="VDD_USB" type="power"/>
+        <pin device-name="71" device-size="b|z" device-temperature="3|6|7" position="A1" name="VDDIO2" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PB3"/>
+        <pin position="A4" name="PB5"/>
+        <pin position="A5" name="BOOT0" type="boot"/>
+        <pin position="A6" name="PB9"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PB4"/>
+        <pin position="B4" name="PB6"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VDD" type="power"/>
+        <pin position="B7" name="PC13"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PC1"/>
+        <pin position="C5" name="PC0"/>
+        <pin position="C6" name="PC14-OSC32_IN"/>
+        <pin position="C7" name="PC15-OSC32_OUT"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PB1"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="PH0-OSC_IN"/>
+        <pin position="D7" name="PH1-OSC_OUT"/>
+        <pin position="E1" name="PB15"/>
+        <pin position="E2" name="PA9"/>
+        <pin position="E3" name="PB2"/>
+        <pin position="E4" name="PA1"/>
+        <pin position="E5" name="PA0"/>
+        <pin position="E6" name="VREF+" type="power"/>
+        <pin position="E7" name="PC2"/>
+        <pin position="F1" name="PB14"/>
+        <pin position="F2" name="PB13"/>
+        <pin position="F3" name="PB11"/>
+        <pin position="F4" name="PA7"/>
+        <pin position="F5" name="PA4"/>
+        <pin position="F6" name="PA2"/>
+        <pin position="F7" name="VDDA" type="power"/>
+        <pin position="G1" name="PB12"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PB0"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="PA5"/>
+        <pin position="G7" name="PA3"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l1-00.xml
+++ b/devices/stm32/stm32l1-00.xml
@@ -560,6 +560,122 @@
       <gpio port="h" pin="1">
         <signal af="0" driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP1"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP1"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l1-51_52-6_8_b.xml
+++ b/devices/stm32/stm32l1-51_52-6_8_b.xml
@@ -774,6 +774,442 @@
         <signal af="0" driver="rcc" name="osc_out"/>
       </gpio>
       <gpio device-pin="v" port="h" pin="2"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6-WKUP3"/>
+        <pin position="6" name="VLCD" type="power"/>
+        <pin position="7" name="PC13-WKUP2"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP1"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PH2"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP1"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP1"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="h" name="TFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN"/>
+        <pin position="A2" name="PC13-WKUP2"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4"/>
+        <pin position="A5" name="PB3"/>
+        <pin position="A6" name="PA15"/>
+        <pin position="A7" name="PA14"/>
+        <pin position="A8" name="PA13"/>
+        <pin position="B1" name="PC15-OSC32_OUT"/>
+        <pin position="B2" name="VLCD" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="BOOT0" type="boot"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="VREF+" type="power"/>
+        <pin position="G2" name="PA0-WKUP1"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13-WKUP2"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PH2"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6-WKUP3"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VLCD" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0-WKUP1"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP1"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l1-51_52_62-c_d_e.xml
+++ b/devices/stm32/stm32l1-51_52_62-c_d_e.xml
@@ -1196,6 +1196,896 @@
       <gpio device-pin="q|v|z" port="h" pin="2">
         <signal device-pin="q|v|z" device-size="d" device-variant="" af="12" driver="fsmc" name="a22"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6-WKUP3"/>
+        <pin position="6" name="VLCD" type="power"/>
+        <pin position="7" name="PC13-WKUP2"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN"/>
+        <pin position="13" name="PH1-OSC_OUT"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="power"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0-WKUP1"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13"/>
+        <pin position="73" name="PH2"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14"/>
+        <pin position="77" name="PA15"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3"/>
+        <pin position="90" name="PB4"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6-WKUP3"/>
+        <pin position="6" name="VLCD" type="power"/>
+        <pin position="7" name="PC13-WKUP2"/>
+        <pin position="8" name="PC14-OSC32_IN"/>
+        <pin position="9" name="PC15-OSC32_OUT"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN"/>
+        <pin position="24" name="PH1-OSC_OUT"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="power"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0-WKUP1"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDD" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13"/>
+        <pin position="106" name="PH2"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14"/>
+        <pin position="110" name="PA15"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDD" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3"/>
+        <pin position="134" name="PB4"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP1"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA" type="power"/>
+        <pin position="13" name="VDDA" type="power"/>
+        <pin position="14" name="PA0-WKUP1"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14"/>
+        <pin position="50" name="PA15"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3"/>
+        <pin position="56" name="PB4"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="h" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13-WKUP2"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PH2"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6-WKUP3"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VLCD" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0-WKUP1"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4"/>
+        <pin position="A8" name="PB3"/>
+        <pin position="A9" name="PA15"/>
+        <pin position="A10" name="PA14"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13-WKUP2"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="PH2"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN"/>
+        <pin position="D2" name="PE6-WKUP3"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT"/>
+        <pin position="E2" name="VLCD" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF6"/>
+        <pin position="G4" name="PF7"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PF8"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PF9"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin device-name="51|52|62" device-size="c|d" position="K1" name="OPAMP3_VINM"/>
+        <pin device-name="51|52" device-size="e" position="K1" name="NC" type="nc"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="power"/>
+        <pin position="L2" name="PA0-WKUP1"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin device-name="51|52|62" device-size="c|d" position="M3" name="OPAMP1_VINM"/>
+        <pin device-name="51|52" device-size="e" position="M3" name="AOP1_INN"/>
+        <pin device-name="51|52|62" device-size="c|d" position="M4" name="OPAMP2_VINM"/>
+        <pin device-name="51|52" device-size="e" position="M4" name="AOP2_INN"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VLCD" type="power"/>
+        <pin position="2" name="PC13-WKUP2"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH0-OSC_IN"/>
+        <pin position="6" name="PH1-OSC_OUT"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA" type="power"/>
+        <pin position="9" name="VDDA" type="power"/>
+        <pin position="10" name="PA0-WKUP1"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14"/>
+        <pin position="38" name="PA15"/>
+        <pin position="39" name="PB3"/>
+        <pin position="40" name="PB4"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="BOOT0" type="boot"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="y" name="WLCSP104">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PD0"/>
+        <pin position="A3" name="PD4"/>
+        <pin position="A4" name="PD7"/>
+        <pin position="A5" name="PB4"/>
+        <pin position="A6" name="PB5"/>
+        <pin position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="PE1"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="PA15"/>
+        <pin position="B2" name="PC12"/>
+        <pin position="B3" name="PD5"/>
+        <pin position="B4" name="PD6"/>
+        <pin position="B5" name="PB3"/>
+        <pin position="B6" name="PB7"/>
+        <pin position="B7" name="PE0"/>
+        <pin position="B8" name="VDD" type="power"/>
+        <pin position="B9" name="PE5"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="PC11"/>
+        <pin position="C3" name="PD2"/>
+        <pin position="C4" name="PD3"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="VSS" type="power"/>
+        <pin position="C8" name="PE4"/>
+        <pin position="C9" name="PC13-WKUP2"/>
+        <pin position="D1" name="PH2"/>
+        <pin position="D2" name="VSS" type="power"/>
+        <pin position="D3" name="PA14"/>
+        <pin position="D4" name="PD1"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PE2"/>
+        <pin position="D7" name="PE3"/>
+        <pin position="D8" name="PC14-OSC32_IN"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="E1" name="PA11"/>
+        <pin position="E2" name="PA12"/>
+        <pin position="E3" name="PA13"/>
+        <pin position="E4" name="PC10"/>
+        <pin position="E6" name="PE6-WKUP3"/>
+        <pin position="E7" name="VLCD" type="power"/>
+        <pin position="E8" name="VSS" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="F1" name="PA9"/>
+        <pin position="F2" name="PA10"/>
+        <pin position="F3" name="PA8"/>
+        <pin position="F4" name="PC9"/>
+        <pin position="F6" name="PC0"/>
+        <pin position="F7" name="NRST" type="reset"/>
+        <pin position="F8" name="PH0-OSC_IN"/>
+        <pin position="F9" name="PH1-OSC_OUT"/>
+        <pin position="G1" name="PC7"/>
+        <pin position="G2" name="PC8"/>
+        <pin position="G3" name="PD15"/>
+        <pin position="G4" name="PD11"/>
+        <pin position="G6" name="VDDA" type="power"/>
+        <pin position="G7" name="VREF+" type="power"/>
+        <pin position="G8" name="PC3"/>
+        <pin position="G9" name="PC2"/>
+        <pin position="H1" name="PC6"/>
+        <pin position="H2" name="PD13"/>
+        <pin position="H3" name="PD12"/>
+        <pin position="H4" name="PD8"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="VREF-" type="power"/>
+        <pin position="H9" name="PC1"/>
+        <pin position="J1" name="PD14"/>
+        <pin position="J2" name="PD9"/>
+        <pin position="J3" name="PB13"/>
+        <pin position="J4" name="PB12"/>
+        <pin position="J5" name="PE10"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA4"/>
+        <pin position="J8" name="PA2"/>
+        <pin position="J9" name="VSSA" type="power"/>
+        <pin position="K1" name="PD10"/>
+        <pin position="K2" name="PB15"/>
+        <pin position="K3" name="VDD" type="power"/>
+        <pin position="K4" name="PE15"/>
+        <pin position="K5" name="PE13"/>
+        <pin position="K6" name="PB1"/>
+        <pin position="K7" name="PA7"/>
+        <pin position="K8" name="VSS" type="power"/>
+        <pin position="K9" name="PA0-WKUP1"/>
+        <pin position="L1" name="PB14"/>
+        <pin position="L2" name="VSS" type="power"/>
+        <pin position="L3" name="PB11"/>
+        <pin position="L4" name="PE14"/>
+        <pin position="L5" name="PE11"/>
+        <pin position="L6" name="PE7"/>
+        <pin position="L7" name="PC4"/>
+        <pin position="L8" name="VDD" type="power"/>
+        <pin position="L9" name="PA1"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PB10"/>
+        <pin position="M3" name="PE12"/>
+        <pin position="M4" name="PE9"/>
+        <pin position="M5" name="PE8"/>
+        <pin position="M6" name="PB2"/>
+        <pin position="M7" name="PC5"/>
+        <pin position="M8" name="PA5"/>
+        <pin position="M9" name="VDD" type="power"/>
+      </package>
+      <package device-pin="u" name="WLCSP63">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PA15"/>
+        <pin position="A3" name="PC11"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="BOOT0" type="boot"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="B1" name="PA11"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PC10"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB8"/>
+        <pin position="B7" name="VDD" type="power"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PA13"/>
+        <pin position="C3" name="PA14"/>
+        <pin position="C4" name="PB3"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="VLCD" type="power"/>
+        <pin position="D1" name="PC8"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA12"/>
+        <pin position="D4" name="PB4"/>
+        <pin position="D5" name="PC13-WKUP2"/>
+        <pin position="D6" name="PC15-OSC32_OUT"/>
+        <pin position="D7" name="PC14-OSC32_IN"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PA0-WKUP1"/>
+        <pin position="E5" name="PC1"/>
+        <pin position="E6" name="PC0"/>
+        <pin position="E7" name="NRST" type="reset"/>
+        <pin position="F1" name="PC6"/>
+        <pin position="F2" name="PB15"/>
+        <pin position="F3" name="PB14"/>
+        <pin position="F4" name="PC4"/>
+        <pin position="F5" name="VSSA" type="power"/>
+        <pin position="F6" name="PH0-OSC_IN"/>
+        <pin position="F7" name="PH1-OSC_OUT"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB12"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PA1"/>
+        <pin position="G6" name="PC3"/>
+        <pin position="G7" name="PC2"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="PB11"/>
+        <pin position="H3" name="PB1"/>
+        <pin position="H4" name="PA5"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="PA2"/>
+        <pin position="H7" name="VDDA" type="power"/>
+        <pin position="J1" name="VSS" type="power"/>
+        <pin position="J2" name="PB10"/>
+        <pin position="J3" name="PB0"/>
+        <pin position="J4" name="PC5"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PA4"/>
+        <pin position="J7" name="PA3"/>
+      </package>
+      <package device-pin="r" device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PC10"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PB3"/>
+        <pin position="A5" name="PB5"/>
+        <pin position="A6" name="BOOT0" type="boot"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB4"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="PC15-OSC32_OUT"/>
+        <pin position="B8" name="PC14-OSC32_IN"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA12"/>
+        <pin position="C3" name="PA15"/>
+        <pin position="C4" name="PC12"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="VLCD" type="power"/>
+        <pin position="C7" name="NRST" type="reset"/>
+        <pin position="C8" name="PC13-WKUP2"/>
+        <pin position="D1" name="PC9"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PA10"/>
+        <pin position="D4" name="PA13"/>
+        <pin position="D5" name="PB8"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="PH1-OSC_OUT"/>
+        <pin position="D8" name="PH0-OSC_IN"/>
+        <pin position="E1" name="PC6"/>
+        <pin position="E2" name="PC7"/>
+        <pin position="E3" name="PC8"/>
+        <pin position="E4" name="PA8"/>
+        <pin position="E5" name="PA5"/>
+        <pin position="E6" name="PA1"/>
+        <pin position="E7" name="VSSA" type="power"/>
+        <pin position="E8" name="PC0"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PB14"/>
+        <pin position="F3" name="PB11"/>
+        <pin position="F4" name="PB1"/>
+        <pin position="F5" name="VSS" type="power"/>
+        <pin position="F6" name="PA0-WKUP1"/>
+        <pin position="F7" name="PC3"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="G1" name="PB13"/>
+        <pin position="G2" name="PB12"/>
+        <pin position="G3" name="PB10"/>
+        <pin position="G4" name="PA7"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="PA3"/>
+        <pin position="G8" name="VDDA" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB2"/>
+        <pin position="H4" name="PB0"/>
+        <pin position="H5" name="PC5"/>
+        <pin position="H6" name="PC4"/>
+        <pin position="H7" name="PA4"/>
+        <pin position="H8" name="PA2"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-12_22.xml
+++ b/devices/stm32/stm32l4-12_22.xml
@@ -734,6 +734,414 @@
         <signal driver="rcc" name="osc_out"/>
       </gpio>
       <gpio port="h" pin="3"/>
+      <package device-pin="k" device-package="t" name="LQFP32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="24" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="25" name="PA15 (JTDI)"/>
+        <pin position="26" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="27" name="PB4 (NJTRST)"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="22" name="PB11"/>
+        <pin device-name="22" device-size="b" device-variant="" position="22" name="PB11"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="22" name="VDD12" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="45" name="PB8"/>
+        <pin device-name="22" device-size="b" device-variant="" position="45" name="PB8"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="45" name="PB9"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="46" name="PB9"/>
+        <pin device-name="22" device-size="b" device-variant="" position="46" name="PB9"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="46" name="VDD12" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="25" name="PC5"/>
+        <pin device-name="22" device-size="b" device-variant="" position="25" name="PC5"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="25" name="PB0"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="26" name="PB0"/>
+        <pin device-name="22" device-size="b" device-variant="" position="26" name="PB0"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="26" name="PB1"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="27" name="PB1"/>
+        <pin device-name="22" device-size="b" device-variant="" position="27" name="PB1"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="27" name="PB2"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="28" name="PB2"/>
+        <pin device-name="22" device-size="b" device-variant="" position="28" name="PB2"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="28" name="PB10"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="29" name="PB10"/>
+        <pin device-name="22" device-size="b" device-variant="" position="29" name="PB10"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="29" name="PB11"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="30" name="PB11"/>
+        <pin device-name="22" device-size="b" device-variant="" position="30" name="PB11"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="54" name="PD2"/>
+        <pin device-name="22" device-size="b" device-variant="" position="54" name="PD2"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="54" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="22" device-size="b" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="22" device-size="b" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="56" name="PB5"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="57" name="PB5"/>
+        <pin device-name="22" device-size="b" device-variant="" position="57" name="PB5"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="57" name="PB6"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="58" name="PB6"/>
+        <pin device-name="22" device-size="b" device-variant="" position="58" name="PB6"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="58" name="PB7"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="59" name="PB7"/>
+        <pin device-name="22" device-size="b" device-variant="" position="59" name="PB7"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="59" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="22" device-size="b" device-variant="" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="60" name="PB8"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="61" name="PB8"/>
+        <pin device-name="22" device-size="b" device-variant="" position="61" name="PB8"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="61" name="PB9"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="62" name="PB9"/>
+        <pin device-name="22" device-size="b" device-variant="" position="62" name="PB9"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A6" name="PA15 (JTDI)"/>
+        <pin position="A7" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A8" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="B5" name="PD2"/>
+        <pin device-name="22" device-size="b" device-variant="" position="B5" name="PD2"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="B5" name="VDD12" type="power"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDDUSB" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA/VREF-" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA/VREF+" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="H6" name="PC5"/>
+        <pin device-name="22" device-size="b" device-variant="" position="H6" name="PC5"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="H6" name="VDD12" type="power"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="k" device-package="u" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0-CK_IN"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="24" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="25" name="PA15 (JTDI)"/>
+        <pin position="26" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="27" name="PB4 (NJTRST)"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="22" name="PB11"/>
+        <pin device-name="22" device-size="b" device-variant="" position="22" name="PB11"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="22" name="VDD12" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="45" name="PB8"/>
+        <pin device-name="22" device-size="b" device-variant="" position="45" name="PB8"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="45" name="PB9"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="46" name="PB9"/>
+        <pin device-name="22" device-size="b" device-variant="" position="46" name="PB9"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="46" name="VDD12" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="t" name="WLCSP36">
+        <pin position="A1" name="PA12"/>
+        <pin position="A2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A3" name="PB4 (NJTRST)"/>
+        <pin position="A4" name="PB7"/>
+        <pin position="A5" name="VSS" type="power"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="B1" name="PA11"/>
+        <pin position="B2" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B3" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B4" name="PB6"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="B5" name="PB8"/>
+        <pin device-name="22" device-size="b" device-variant="" position="B5" name="PB8"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="B5" name="VDD12" type="power"/>
+        <pin position="B6" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="C1" name="PA9"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA15 (JTDI)"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="C6" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PB1"/>
+        <pin position="D3" name="PA6"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="D4" name="PA1"/>
+        <pin device-name="22" device-size="b" device-variant="" position="D4" name="PA1"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="D4" name="PA2"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="D5" name="PA0-CK_IN"/>
+        <pin device-name="22" device-size="b" device-variant="" position="D5" name="PA0-CK_IN"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="D5" name="PA1"/>
+        <pin position="D6" name="NRST" type="reset"/>
+        <pin position="E1" name="VDD" type="power"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="E2" name="PB2"/>
+        <pin device-name="22" device-size="b" device-variant="" position="E2" name="PB2"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="E2" name="PB10"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="E3" name="PA7"/>
+        <pin device-name="22" device-size="b" device-variant="" position="E3" name="PA7"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="E3" name="PB0"/>
+        <pin position="E4" name="PA5"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="E5" name="PA2"/>
+        <pin device-name="22" device-size="b" device-variant="" position="E5" name="PA2"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="E5" name="PA3"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="E6" name="VREF+" type="power"/>
+        <pin device-name="22" device-size="b" device-variant="" position="E6" name="VREF+" type="power"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="E6" name="VDDA/VREF+" type="power"/>
+        <pin position="F1" name="VSS" type="power"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="F2" name="PB10"/>
+        <pin device-name="22" device-size="b" device-variant="" position="F2" name="PB10"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="F2" name="VDD12" type="power"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="F3" name="PB0"/>
+        <pin device-name="22" device-size="b" device-variant="" position="F3" name="PB0"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="F3" name="PB2"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="F4" name="PA4"/>
+        <pin device-name="22" device-size="b" device-variant="" position="F4" name="PA4"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="F4" name="PA7"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="F5" name="PA3"/>
+        <pin device-name="22" device-size="b" device-variant="" position="F5" name="PA3"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="F5" name="PA4"/>
+        <pin device-name="12" device-size="8|b" device-variant="" position="F6" name="VDDA" type="power"/>
+        <pin device-name="22" device-size="b" device-variant="" position="F6" name="VDDA" type="power"/>
+        <pin device-name="12" device-size="b" device-variant="p" position="F6" name="PA0-CK_IN"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-31_33_43.xml
+++ b/devices/stm32/stm32l4-31_33_43.xml
@@ -1110,6 +1110,664 @@
         <signal driver="rcc" name="osc_out"/>
       </gpio>
       <gpio port="h" pin="3"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="33" device-temperature="3|6|7" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-temperature="6" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-temperature="6" position="73" name="VDD" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PH3-BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="33" device-size="b|c" device-temperature="6|7" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="33" device-size="c" device-temperature="3" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-size="c" device-temperature="6" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="6|7" position="36" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="25" name="PC5"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="25" name="PC5"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="25" name="PC5"/>
+        <pin device-variant="p" position="25" name="PB0"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="26" name="PB0"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="26" name="PB0"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="26" name="PB0"/>
+        <pin device-variant="p" position="26" name="PB1"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="27" name="PB1"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="27" name="PB1"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="27" name="PB1"/>
+        <pin device-variant="p" position="27" name="PB2"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="28" name="PB2"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="28" name="PB2"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="28" name="PB2"/>
+        <pin device-variant="p" position="28" name="PB10"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="29" name="PB10"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="29" name="PB10"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="29" name="PB10"/>
+        <pin device-variant="p" position="29" name="PB11"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="30" name="PB11"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="30" name="PB11"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="30" name="PB11"/>
+        <pin device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin device-name="33" device-size="b|c" device-temperature="6" device-variant="" position="48" name="VDDUSB" type="power"/>
+        <pin device-name="33" device-size="c" device-temperature="3|6|7" device-variant="|p" position="48" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-size="c" device-temperature="3|6|7" device-variant="" position="48" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="48" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" device-variant="" position="48" name="VDD" type="power"/>
+        <pin position="49" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="54" name="PD2"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="54" name="PD2"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="54" name="PD2"/>
+        <pin device-variant="p" position="54" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-variant="p" position="56" name="PB5"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="57" name="PB5"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="57" name="PB5"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="57" name="PB5"/>
+        <pin device-variant="p" position="57" name="PB6"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="58" name="PB6"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="58" name="PB6"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="58" name="PB6"/>
+        <pin device-variant="p" position="58" name="PB7"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="59" name="PB7"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="59" name="PB7"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="59" name="PB7"/>
+        <pin device-variant="p" position="59" name="PH3-BOOT0"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-variant="p" position="60" name="PB8"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="61" name="PB8"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="61" name="PB8"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="61" name="PB8"/>
+        <pin device-variant="p" position="61" name="PB9"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" device-variant="" position="62" name="PB9"/>
+        <pin device-name="31|33" device-size="b|c" device-temperature="6" device-variant="" position="62" name="PB9"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" device-variant="" position="62" name="PB9"/>
+        <pin device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin device-name="33" device-temperature="3|6|7" position="C11" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-temperature="6" position="C11" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-temperature="6" position="C11" name="VDD" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A6" name="PA15 (JTDI)"/>
+        <pin position="A7" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="A8" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PH3-BOOT0"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin device-name="33" device-size="b|c" device-temperature="6" position="E5" name="VDDUSB" type="power"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" position="E5" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" position="E5" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA/VREF-" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA/VREF+" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="k" name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="24" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="25" name="PA15 (JTDI)"/>
+        <pin position="26" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="27" name="PB4 (NJTRST)"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PH3-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
+      <package device-pin="c" device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin device-name="33" device-size="b|c" device-temperature="6|7" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="33" device-size="c" device-temperature="3" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-size="c" device-temperature="6" position="36" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="6|7" position="36" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="y" name="WLCSP49">
+        <pin device-name="33" device-size="b|c" device-temperature="6|7" position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="33" device-size="c" device-temperature="3" position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="43" device-size="c" device-temperature="6" position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="6|7" position="A1" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="A3" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PH3-BOOT0"/>
+        <pin position="A6" name="VSS" type="power"/>
+        <pin position="A7" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="B3" name="PA15 (JTDI)"/>
+        <pin position="B4" name="PB5"/>
+        <pin position="B5" name="PB8"/>
+        <pin position="B6" name="VBAT" type="power"/>
+        <pin position="B7" name="PC13"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA10"/>
+        <pin position="C3" name="PA12"/>
+        <pin position="C4" name="PB6"/>
+        <pin position="C5" name="PB9"/>
+        <pin position="C6" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C7" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA8"/>
+        <pin position="D2" name="PA9"/>
+        <pin position="D3" name="PB15"/>
+        <pin position="D4" name="PB7"/>
+        <pin position="D5" name="NRST" type="reset"/>
+        <pin position="D6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D7" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PB14"/>
+        <pin position="E2" name="PB13"/>
+        <pin position="E3" name="PB10"/>
+        <pin position="E4" name="PA3"/>
+        <pin position="E5" name="PA2"/>
+        <pin position="E6" name="PC3"/>
+        <pin position="E7" name="VSSA/VREF-" type="power"/>
+        <pin position="F1" name="PB12"/>
+        <pin position="F2" name="PB11"/>
+        <pin position="F3" name="PA7"/>
+        <pin position="F4" name="PA6"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA0"/>
+        <pin position="F7" name="VDDA/VREF+" type="power"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PB2"/>
+        <pin position="G4" name="PB1"/>
+        <pin position="G5" name="PB0"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA1"/>
+      </package>
+      <package device-pin="r" device-package="y" name="WLCSP64">
+        <pin device-name="33" device-size="b|c" device-temperature="6" position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="33|43" device-size="c" device-temperature="3|6|7" position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="31" device-size="b" device-temperature="3|6|7" position="A1" name="VDD" type="power"/>
+        <pin device-name="31" device-size="c" device-temperature="6" position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PD2"/>
+        <pin position="A5" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A6" name="PB7"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB4 (NJTRST)"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PB9"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="C3" name="PC10"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PH3-BOOT0"/>
+        <pin position="C6" name="PB8"/>
+        <pin position="C7" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA11"/>
+        <pin position="D4" name="PC4"/>
+        <pin position="D5" name="PC0"/>
+        <pin position="D6" name="NRST" type="reset"/>
+        <pin position="D7" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D8" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PC5"/>
+        <pin position="E5" name="PA4"/>
+        <pin position="E6" name="PC3"/>
+        <pin position="E7" name="PC2"/>
+        <pin position="E8" name="PC1"/>
+        <pin position="F1" name="PC6"/>
+        <pin position="F2" name="PB15"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F4" name="PB0"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA2"/>
+        <pin position="F7" name="PA0"/>
+        <pin position="F8" name="VSSA/VREF-" type="power"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB13"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PB2"/>
+        <pin position="G5" name="PA6"/>
+        <pin position="G6" name="PA3"/>
+        <pin position="G7" name="PA1"/>
+        <pin position="G8" name="VDDA/VREF+" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PB1"/>
+        <pin position="H6" name="PA7"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-32_42.xml
+++ b/devices/stm32/stm32l4-32_42.xml
@@ -583,6 +583,40 @@
         <signal driver="rcc" name="osc32_out"/>
       </gpio>
       <gpio port="h" pin="3"/>
+      <package name="UFQFPN32">
+        <pin position="1" name="VDD" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="3" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="4" name="NRST" type="reset"/>
+        <pin position="5" name="VDDA/VREF+" type="power"/>
+        <pin position="6" name="PA0"/>
+        <pin position="7" name="PA1"/>
+        <pin position="8" name="PA2"/>
+        <pin position="9" name="PA3"/>
+        <pin position="10" name="PA4"/>
+        <pin position="11" name="PA5"/>
+        <pin position="12" name="PA6"/>
+        <pin position="13" name="PA7"/>
+        <pin position="14" name="PB0"/>
+        <pin position="15" name="PB1"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PA8"/>
+        <pin position="19" name="PA9"/>
+        <pin position="20" name="PA10"/>
+        <pin position="21" name="PA11"/>
+        <pin position="22" name="PA12"/>
+        <pin position="23" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="24" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="25" name="PA15 (JTDI)"/>
+        <pin position="26" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="27" name="PB4 (NJTRST)"/>
+        <pin position="28" name="PB5"/>
+        <pin position="29" name="PB6"/>
+        <pin position="30" name="PB7"/>
+        <pin position="31" name="PH3-BOOT0"/>
+        <pin position="32" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-51_71.xml
+++ b/devices/stm32/stm32l4-51_71.xml
@@ -1476,6 +1476,904 @@
         <signal driver="rcc" name="osc_out"/>
       </gpio>
       <gpio device-name="51" port="h" pin="3"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin device-name="71" device-size="e|g" device-temperature="6" position="72" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="71" device-size="g" device-temperature="3|7" position="72" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="51" device-size="c|e" device-temperature="6" position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VDD" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin device-name="71" device-size="e|g" device-temperature="6" position="76" name="PA14 (JTCK-SWCLK)"/>
+        <pin device-name="71" device-size="g" device-temperature="3|7" position="76" name="PA14 (JTCK-SWCLK)"/>
+        <pin device-name="51" device-size="c|e" device-temperature="6" position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin device-name="71" device-size="e|g" device-temperature="6" position="89" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="71" device-size="g" device-temperature="3|7" position="89" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="51" device-size="c|e" device-temperature="6" position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin device-name="71" device-size="e|g" device-temperature="6" position="94" name="BOOT0" type="boot"/>
+        <pin device-name="71" device-size="g" device-temperature="3|7" position="94" name="BOOT0" type="boot"/>
+        <pin device-name="51" device-size="c|e" device-temperature="6" position="94" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDIO2" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="106" name="VDD" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="BOOT0" type="boot"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin device-name="71" device-size="e" device-temperature="3|6|7" position="46" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="71" device-size="g" device-temperature="6" position="46" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="51" device-size="c" device-temperature="3|6|7" position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="51" device-size="e" device-temperature="6" position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+        <pin device-name="71" device-size="e" device-temperature="3|6|7" position="49" name="PA14 (JTCK-SWCLK)"/>
+        <pin device-name="71" device-size="g" device-temperature="6" position="49" name="PA14 (JTCK-SWCLK)"/>
+        <pin device-name="51" device-size="c" device-temperature="3|6|7" position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="51" device-size="e" device-temperature="6" position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin device-name="71" device-size="e" device-temperature="3|6|7" position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="71" device-size="g" device-temperature="6" position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="51" device-size="c" device-temperature="3|6|7" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="51" device-size="e" device-temperature="6" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="56" name="PB4 (NJTRST)"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin device-name="71" device-size="e" device-temperature="3|6|7" position="60" name="BOOT0" type="boot"/>
+        <pin device-name="71" device-size="g" device-temperature="6" position="60" name="BOOT0" type="boot"/>
+        <pin device-name="51" device-size="c" device-temperature="3|6|7" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="51" device-size="e" device-temperature="6" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDD" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDD" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PE0"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PG14"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="PD6"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PD0"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PG15"/>
+        <pin position="B7" name="PG11"/>
+        <pin position="B8" name="PD5"/>
+        <pin position="B9" name="PC12"/>
+        <pin position="B10" name="PC10"/>
+        <pin position="B11" name="PA12"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PB9"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="C7" name="PG9"/>
+        <pin position="C8" name="PD4"/>
+        <pin position="C9" name="PC11"/>
+        <pin position="C10" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="C11" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PF4"/>
+        <pin position="D2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D3" name="PE6"/>
+        <pin position="D4" name="PC13"/>
+        <pin position="D5" name="PB4 (NJTRST)"/>
+        <pin position="D6" name="PG13"/>
+        <pin position="D7" name="PG10"/>
+        <pin position="D8" name="PD3"/>
+        <pin position="D9" name="PD2"/>
+        <pin position="D10" name="PA15 (JTDI)"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA8"/>
+        <pin position="E1" name="PF6"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PF0"/>
+        <pin position="E4" name="PF2"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VSS" type="power"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PC6"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PC8"/>
+        <pin position="F1" name="PF8"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF5"/>
+        <pin position="F4" name="PF3"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VDDIO2" type="power"/>
+        <pin position="F9" name="PG7"/>
+        <pin position="F10" name="PG6"/>
+        <pin position="F11" name="PG8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G3" name="PF10"/>
+        <pin position="G4" name="PF9"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VDD" type="power"/>
+        <pin position="G9" name="PG4"/>
+        <pin position="G10" name="PD13"/>
+        <pin position="G11" name="PG3"/>
+        <pin position="G12" name="PG5"/>
+        <pin position="H1" name="PC2"/>
+        <pin position="H2" name="PC0"/>
+        <pin position="H3" name="PC1"/>
+        <pin position="H4" name="NRST" type="reset"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VDD" type="power"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="PD12"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PG2"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="VREF-" type="power"/>
+        <pin position="J3" name="PA0"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PC4"/>
+        <pin position="J6" name="PF11"/>
+        <pin position="J7" name="PG1"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PB13"/>
+        <pin position="J10" name="PB14"/>
+        <pin position="J11" name="PD10"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="K1" name="VREF+" type="monoio"/>
+        <pin position="K2" name="VDDA" type="power"/>
+        <pin position="K3" name="PA1"/>
+        <pin position="K4" name="PA6"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K6" name="PF12"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE11"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB12"/>
+        <pin position="K11" name="PD8"/>
+        <pin position="K12" name="PD9"/>
+        <pin position="L1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="L5" name="PB0"/>
+        <pin position="L6" name="PF13"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PE13"/>
+        <pin position="L10" name="PE14"/>
+        <pin position="L11" name="PB10"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA5"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PC5"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PF14"/>
+        <pin position="M8" name="PE7"/>
+        <pin position="M9" name="PF15"/>
+        <pin position="M10" name="PE10"/>
+        <pin position="M11" name="PE15"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
+      <package device-pin="r" device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A6" name="PA15 (JTDI)"/>
+        <pin position="A7" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A8" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDD" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA/VREF-" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA/VREF+" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDD" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDD" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB8"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C3" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="C4" name="PD2"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PA12"/>
+        <pin position="D4" name="PC10"/>
+        <pin position="D5" name="PC1"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="PC0"/>
+        <pin position="D8" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PC4"/>
+        <pin position="E5" name="PA7"/>
+        <pin position="E6" name="PA1"/>
+        <pin position="E7" name="PC3"/>
+        <pin position="E8" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PC6"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F4" name="PB1"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA3"/>
+        <pin position="F7" name="VDDA/VREF+" type="power"/>
+        <pin position="F8" name="NRST" type="reset"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB13"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PB2"/>
+        <pin position="G5" name="PC5"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA2"/>
+        <pin position="G8" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PB0"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-52_62.xml
+++ b/devices/stm32/stm32l4-52_62.xml
@@ -1062,6 +1062,503 @@
         <signal driver="rcc" name="osc_out"/>
       </gpio>
       <gpio port="h" pin="3"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" device-package="t" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="25" name="PC5"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="25" name="PC5"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="25" name="PC5"/>
+        <pin device-variant="p" position="25" name="PB0"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="26" name="PB0"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="26" name="PB0"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="26" name="PB0"/>
+        <pin device-variant="p" position="26" name="PB1"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="27" name="PB1"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="27" name="PB1"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="27" name="PB1"/>
+        <pin device-variant="p" position="27" name="PB2"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="28" name="PB2"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="28" name="PB2"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="28" name="PB2"/>
+        <pin device-variant="p" position="28" name="PB10"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="29" name="PB10"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="29" name="PB10"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="29" name="PB10"/>
+        <pin device-variant="p" position="29" name="PB11"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="30" name="PB11"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="30" name="PB11"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="30" name="PB11"/>
+        <pin device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="54" name="PD2"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="54" name="PD2"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="54" name="PD2"/>
+        <pin device-variant="p" position="54" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-variant="p" position="56" name="PB5"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="57" name="PB5"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="57" name="PB5"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="57" name="PB5"/>
+        <pin device-variant="p" position="57" name="PB6"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="58" name="PB6"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="58" name="PB6"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="58" name="PB6"/>
+        <pin device-variant="p" position="58" name="PB7"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="59" name="PB7"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="59" name="PB7"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="59" name="PB7"/>
+        <pin device-variant="p" position="59" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="60" name="PH3-BOOT0 (BOOT0)"/>
+        <pin device-variant="p" position="60" name="PB8"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="61" name="PB8"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="61" name="PB8"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="61" name="PB8"/>
+        <pin device-variant="p" position="61" name="PB9"/>
+        <pin device-name="52" device-size="c|e" device-temperature="6" device-variant="" position="62" name="PB9"/>
+        <pin device-name="52" device-size="e" device-temperature="3|7" device-variant="" position="62" name="PB9"/>
+        <pin device-name="62" device-size="e" device-temperature="6" device-variant="" position="62" name="PB9"/>
+        <pin device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="v" device-package="i" name="UFBGA100">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="VREF-" type="power"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="PA4"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="r" device-package="i" name="UFBGA64">
+        <pin position="A1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="A2" name="PC13"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A6" name="PA15 (JTDI)"/>
+        <pin position="A7" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A8" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="B2" name="VBAT" type="power"/>
+        <pin position="B3" name="PB8"/>
+        <pin position="B4" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PC10"/>
+        <pin position="B8" name="PA12"/>
+        <pin position="C1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB5"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PA10"/>
+        <pin position="C7" name="PA9"/>
+        <pin position="C8" name="PA11"/>
+        <pin position="D1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D2" name="VDD" type="power"/>
+        <pin position="D3" name="PB6"/>
+        <pin position="D4" name="VSS" type="power"/>
+        <pin position="D5" name="VSS" type="power"/>
+        <pin position="D6" name="VSS" type="power"/>
+        <pin position="D7" name="PA8"/>
+        <pin position="D8" name="PC9"/>
+        <pin position="E1" name="NRST" type="reset"/>
+        <pin position="E2" name="PC1"/>
+        <pin position="E3" name="PC0"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="VDDUSB" type="power"/>
+        <pin position="E6" name="VDD" type="power"/>
+        <pin position="E7" name="PC7"/>
+        <pin position="E8" name="PC8"/>
+        <pin position="F1" name="VSSA/VREF-" type="power"/>
+        <pin position="F2" name="PC2"/>
+        <pin position="F3" name="PA2"/>
+        <pin position="F4" name="PA5"/>
+        <pin position="F5" name="PB0"/>
+        <pin position="F6" name="PC6"/>
+        <pin position="F7" name="PB15"/>
+        <pin position="F8" name="PB14"/>
+        <pin position="G1" name="PC3"/>
+        <pin position="G2" name="PA0"/>
+        <pin position="G3" name="PA3"/>
+        <pin position="G4" name="PA6"/>
+        <pin position="G5" name="PB1"/>
+        <pin position="G6" name="PB2"/>
+        <pin position="G7" name="PB10"/>
+        <pin position="G8" name="PB13"/>
+        <pin position="H1" name="VDDA/VREF+" type="power"/>
+        <pin position="H2" name="PA1"/>
+        <pin position="H3" name="PA4"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PC5"/>
+        <pin position="H7" name="PB11"/>
+        <pin position="H8" name="PB12"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP64">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PC12"/>
+        <pin position="A4" name="PB4 (NJTRST)"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PB8"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PC11"/>
+        <pin position="B4" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PH3-BOOT0 (BOOT0)"/>
+        <pin position="B7" name="VBAT" type="power"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="C1" name="PA10"/>
+        <pin position="C2" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C3" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="C4" name="PD2"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PB9"/>
+        <pin position="C7" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D2" name="PA11"/>
+        <pin position="D3" name="PA12"/>
+        <pin position="D4" name="PC10"/>
+        <pin position="D5" name="PC1"/>
+        <pin position="D6" name="PC2"/>
+        <pin position="D7" name="PC0"/>
+        <pin position="D8" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC7"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PC4"/>
+        <pin position="E5" name="PA7"/>
+        <pin position="E6" name="PA1"/>
+        <pin position="E7" name="PC3"/>
+        <pin position="E8" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="F1" name="PB15"/>
+        <pin position="F2" name="PC6"/>
+        <pin position="F3" name="PC8"/>
+        <pin position="F4" name="PB1"/>
+        <pin position="F5" name="PA5"/>
+        <pin position="F6" name="PA3"/>
+        <pin position="F7" name="VDDA/VREF+" type="power"/>
+        <pin position="F8" name="NRST" type="reset"/>
+        <pin position="G1" name="PB14"/>
+        <pin position="G2" name="PB13"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PB2"/>
+        <pin position="G5" name="PC5"/>
+        <pin position="G6" name="PA4"/>
+        <pin position="G7" name="PA2"/>
+        <pin position="G8" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="VDD" type="power"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="PB11"/>
+        <pin position="H4" name="PB10"/>
+        <pin position="H5" name="PB0"/>
+        <pin position="H6" name="PA6"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="PA0"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-75_85.xml
+++ b/devices/stm32/stm32l4-75_85.xml
@@ -1260,6 +1260,248 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="56" name="PB4 (NJTRST)"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-name="85" name="WLCSP72">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PG9"/>
+        <pin position="A5" name="PG14"/>
+        <pin position="A6" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A7" name="PB7"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="B3" name="PC12"/>
+        <pin position="B4" name="PG10"/>
+        <pin position="B5" name="PG13"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PB6"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="C3" name="PC11"/>
+        <pin position="C4" name="PG11"/>
+        <pin position="C5" name="PG12"/>
+        <pin position="C6" name="PB4 (NJTRST)"/>
+        <pin position="C7" name="PB5"/>
+        <pin position="C8" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C9" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PC10"/>
+        <pin position="D7" name="BOOT0" type="boot"/>
+        <pin position="D8" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D9" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC9"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA9"/>
+        <pin position="E7" name="PB8"/>
+        <pin position="E8" name="PB9"/>
+        <pin position="E9" name="NRST" type="reset"/>
+        <pin position="F1" name="PC7"/>
+        <pin position="F2" name="PC8"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F7" name="PC2"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PC0"/>
+        <pin position="G1" name="PB15"/>
+        <pin position="G2" name="PB14"/>
+        <pin position="G3" name="PB11"/>
+        <pin position="G4" name="PA1"/>
+        <pin position="G5" name="PA4"/>
+        <pin position="G6" name="PA2"/>
+        <pin position="G7" name="PC3"/>
+        <pin position="G8" name="VREF+" type="monoio"/>
+        <pin position="G9" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="PB12"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PA6"/>
+        <pin position="H6" name="PA5"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="PA0"/>
+        <pin position="H9" name="VDDA" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PB2"/>
+        <pin position="J4" name="PB1"/>
+        <pin position="J5" name="PB0"/>
+        <pin position="J6" name="PC5"/>
+        <pin position="J7" name="PC4"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-76_86.xml
+++ b/devices/stm32/stm32l4-76_86.xml
@@ -1494,6 +1494,874 @@
       <gpio port="h" pin="1">
         <signal driver="rcc" name="osc_out"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="BOOT0" type="boot"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="70" name="PB11"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="70" name="PB11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="70" name="VDD12" type="power"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDIO2" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="106" name="VDDUSB" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="132" name="PG15"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="132" name="PG15"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="132" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="133" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="133" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="133" name="PB4 (NJTRST)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="134" name="PB5"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="135" name="PB5"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="135" name="PB5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="135" name="PB6"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="136" name="PB6"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="136" name="PB6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="136" name="PB7"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="137" name="PB7"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="137" name="PB7"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="137" name="BOOT0" type="boot"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="138" name="BOOT0" type="boot"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="138" name="BOOT0" type="boot"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="138" name="PB8"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="139" name="PB8"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="139" name="PB8"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="139" name="PB9"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="140" name="PB9"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="140" name="PB9"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="140" name="PE0"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="141" name="PE0"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="141" name="PE0"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="141" name="PE1"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="142" name="PE1"/>
+        <pin device-name="76|86" device-size="g" device-temperature="3|6|7" device-variant="" position="142" name="PE1"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="142" name="VDD12" type="power"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="56" name="PB4 (NJTRST)"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="BOOT0" type="boot"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PE0"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="BOOT0" type="boot"/>
+        <pin position="A5" name="PB7"/>
+        <pin position="A6" name="PG14"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="PD6"/>
+        <pin position="A10" name="PD1"/>
+        <pin position="A11" name="PD0"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="PE4"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PG15"/>
+        <pin position="B7" name="PG11"/>
+        <pin position="B8" name="PD5"/>
+        <pin position="B9" name="PC12"/>
+        <pin position="B10" name="PC10"/>
+        <pin position="B11" name="PA12"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PB9"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="C7" name="PG9"/>
+        <pin position="C8" name="PD4"/>
+        <pin position="C9" name="PC11"/>
+        <pin position="C10" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="C11" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PF4"/>
+        <pin position="D2" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D3" name="PE6"/>
+        <pin position="D4" name="PC13"/>
+        <pin position="D5" name="PB4 (NJTRST)"/>
+        <pin position="D6" name="PG13"/>
+        <pin position="D7" name="PG10"/>
+        <pin position="D8" name="PD3"/>
+        <pin position="D9" name="PD2"/>
+        <pin position="D10" name="PA15 (JTDI)"/>
+        <pin position="D11" name="PA9"/>
+        <pin position="D12" name="PA8"/>
+        <pin position="E1" name="PF6"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PF0"/>
+        <pin position="E4" name="PF2"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E6" name="VDDIO2" type="power"/>
+        <pin position="E7" name="VDD" type="power"/>
+        <pin position="E8" name="VSS" type="power"/>
+        <pin position="E9" name="VDDUSB" type="power"/>
+        <pin position="E10" name="PC6"/>
+        <pin position="E11" name="PC9"/>
+        <pin position="E12" name="PC8"/>
+        <pin position="F1" name="PF8"/>
+        <pin position="F2" name="PF7"/>
+        <pin position="F3" name="PF5"/>
+        <pin position="F4" name="PF3"/>
+        <pin position="F5" name="VDD" type="power"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F8" name="VDDIO2" type="power"/>
+        <pin position="F9" name="PG7"/>
+        <pin position="F10" name="PG6"/>
+        <pin position="F11" name="PG8"/>
+        <pin position="F12" name="PC7"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G3" name="PF10"/>
+        <pin position="G4" name="PF9"/>
+        <pin position="G5" name="VDD" type="power"/>
+        <pin position="G6" name="VSS" type="power"/>
+        <pin position="G7" name="VSS" type="power"/>
+        <pin position="G8" name="VDD" type="power"/>
+        <pin position="G9" name="PG4"/>
+        <pin position="G10" name="PD13"/>
+        <pin position="G11" name="PG3"/>
+        <pin position="G12" name="PG5"/>
+        <pin position="H1" name="PC2"/>
+        <pin position="H2" name="PC0"/>
+        <pin position="H3" name="PC1"/>
+        <pin position="H4" name="NRST" type="reset"/>
+        <pin position="H5" name="VSS" type="power"/>
+        <pin position="H6" name="VDD" type="power"/>
+        <pin position="H7" name="VDD" type="power"/>
+        <pin position="H8" name="VSS" type="power"/>
+        <pin position="H9" name="PD12"/>
+        <pin position="H10" name="PD11"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PG2"/>
+        <pin position="J1" name="VSSA" type="power"/>
+        <pin position="J2" name="VREF-" type="power"/>
+        <pin position="J3" name="PA0"/>
+        <pin position="J4" name="PC3"/>
+        <pin position="J5" name="PC4"/>
+        <pin position="J6" name="PF11"/>
+        <pin position="J7" name="PG1"/>
+        <pin position="J8" name="PE9"/>
+        <pin position="J9" name="PB13"/>
+        <pin position="J10" name="PB14"/>
+        <pin position="J11" name="PD10"/>
+        <pin position="J12" name="PD15"/>
+        <pin position="K1" name="VREF+" type="monoio"/>
+        <pin position="K2" name="VDDA" type="power"/>
+        <pin position="K3" name="PA1"/>
+        <pin position="K4" name="PA6"/>
+        <pin position="K5" name="PB2"/>
+        <pin position="K6" name="PF12"/>
+        <pin position="K7" name="PG0"/>
+        <pin position="K8" name="PE11"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB12"/>
+        <pin position="K11" name="PD8"/>
+        <pin position="K12" name="PD9"/>
+        <pin position="L1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="L2" name="PA2"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="L5" name="PB0"/>
+        <pin position="L6" name="PF13"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE12"/>
+        <pin position="L9" name="PE13"/>
+        <pin position="L10" name="PE14"/>
+        <pin position="L11" name="PB10"/>
+        <pin position="L12" name="PB15"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA5"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PC5"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PF14"/>
+        <pin position="M8" name="PE7"/>
+        <pin position="M9" name="PF15"/>
+        <pin position="M10" name="PE10"/>
+        <pin position="M11" name="PE15"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
+      <package device-pin="j" name="WLCSP72">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="A2" name="PA15 (JTDI)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="A2" name="PA15 (JTDI)"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="A2" name="PA15 (JTDI)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="A2" name="PC10"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PG9"/>
+        <pin position="A5" name="PG14"/>
+        <pin position="A6" name="PB3 (JTDO-TRACESWO)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="A7" name="PB7"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="A7" name="PB7"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="A7" name="PB7"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="A7" name="BOOT0" type="boot"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="B3" name="PC12"/>
+        <pin position="B4" name="PG10"/>
+        <pin position="B5" name="PG13"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="B7" name="PB6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="B7" name="PB6"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="B7" name="PB6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="B7" name="PB7"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="B8" name="PC13"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="B8" name="PC13"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="B8" name="PC13"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="B8" name="VDD12" type="power"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS-SWDIO)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="C3" name="PC11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="C3" name="PC11"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="C3" name="PC11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="C3" name="PA15 (JTDI)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="C4" name="PG11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="C4" name="PG11"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="C4" name="PG11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="C4" name="PG12"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="C5" name="PG12"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="C5" name="PG12"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="C5" name="PG12"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="C5" name="PB4 (NJTRST)"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="C6" name="PB4 (NJTRST)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="C6" name="PB4 (NJTRST)"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="C6" name="PB4 (NJTRST)"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="C6" name="PB8"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="C7" name="PB5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="C7" name="PB5"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="C7" name="PB5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="C7" name="PC13"/>
+        <pin position="C8" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C9" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="D3" name="PC10"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="D3" name="PC10"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="D3" name="PC10"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="D3" name="PC11"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="D7" name="BOOT0" type="boot"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="D7" name="BOOT0" type="boot"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="D7" name="BOOT0" type="boot"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="D7" name="PB9"/>
+        <pin position="D8" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D9" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC9"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA9"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="E7" name="PB8"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="E7" name="PB8"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="E7" name="PB8"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="E7" name="PB5"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="E8" name="PB9"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="E8" name="PB9"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="E8" name="PB9"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="E8" name="PB6"/>
+        <pin position="E9" name="NRST" type="reset"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="F1" name="PC7"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="F1" name="PC7"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="F1" name="PC7"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="F1" name="VDD" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="F2" name="PC8"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="F2" name="PC8"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="F2" name="PC8"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="F2" name="PC7"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="F3" name="PC6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="F3" name="PC6"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="F3" name="PC6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="F3" name="PC8"/>
+        <pin position="F7" name="PC2"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PC0"/>
+        <pin position="G1" name="PB15"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="G2" name="PB14"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="G2" name="PB14"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="G2" name="PB14"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="G2" name="PC6"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="G3" name="PB11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="G3" name="PB11"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="G3" name="PB11"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="G3" name="PB14"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="G4" name="PA1"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="G4" name="PA1"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="G4" name="PA1"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="G4" name="PA2"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="G5" name="PA4"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="G5" name="PA4"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="G5" name="PA4"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="G5" name="PA0"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="G6" name="PA2"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="G6" name="PA2"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="G6" name="PA2"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="G6" name="PA1"/>
+        <pin position="G7" name="PC3"/>
+        <pin position="G8" name="VREF+" type="monoio"/>
+        <pin position="G9" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="PB12"/>
+        <pin position="H2" name="PB13"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="H3" name="PB10"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="H3" name="PB10"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="H3" name="PB10"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="H3" name="PB11"/>
+        <pin position="H4" name="PA7"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="H5" name="PA6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="H5" name="PA6"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="H5" name="PA6"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="H5" name="PA5"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="H6" name="PA5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="H6" name="PA5"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="H6" name="PA5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="H6" name="PA4"/>
+        <pin position="H7" name="PA3"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="H8" name="PA0"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="H8" name="PA0"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="H8" name="PA0"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="H8" name="VDD" type="power"/>
+        <pin position="H9" name="VDDA" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J1" name="VDD" type="power"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J1" name="VDD" type="power"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J1" name="VDD" type="power"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J1" name="VDD12" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J3" name="PB2"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J3" name="PB2"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J3" name="PB2"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J3" name="PB10"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J4" name="PB1"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J4" name="PB1"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J4" name="PB1"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J4" name="PB0"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J5" name="PB0"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J5" name="PB0"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J5" name="PB0"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J5" name="PB1"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J6" name="PC5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J6" name="PC5"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J6" name="PC5"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J6" name="PB2"/>
+        <pin position="J7" name="PC4"/>
+        <pin device-name="76" device-size="e|g" device-temperature="6" device-variant="" position="J8" name="VDD" type="power"/>
+        <pin device-name="76" device-size="g" device-temperature="3|7" device-variant="" position="J8" name="VDD" type="power"/>
+        <pin device-name="86" device-size="g" device-temperature="6" device-variant="" position="J8" name="VDD" type="power"/>
+        <pin device-name="76" device-size="g" device-temperature="3|6|7" device-variant="p" position="J8" name="PA6"/>
+        <pin position="J9" name="VSS" type="power"/>
+      </package>
+      <package device-pin="m" name="WLCSP81">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PD2"/>
+        <pin position="A4" name="PG9"/>
+        <pin position="A5" name="PG14"/>
+        <pin position="A6" name="PB3 (JTDO-TRACESWO)"/>
+        <pin position="A7" name="PB7"/>
+        <pin position="A8" name="VSS" type="power"/>
+        <pin position="A9" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK-SWCLK)"/>
+        <pin position="B3" name="PC12"/>
+        <pin position="B4" name="PG10"/>
+        <pin position="B5" name="PG13"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PB6"/>
+        <pin position="B8" name="PC13"/>
+        <pin position="B9" name="VBAT" type="power"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS-SWDIO)"/>
+        <pin position="C3" name="PC11"/>
+        <pin position="C4" name="PG11"/>
+        <pin position="C5" name="PG12"/>
+        <pin position="C6" name="PB4 (NJTRST)"/>
+        <pin position="C7" name="PB5"/>
+        <pin position="C8" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="C9" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PC10"/>
+        <pin position="D4" name="PD5"/>
+        <pin position="D5" name="PD6"/>
+        <pin position="D6" name="PD7"/>
+        <pin position="D7" name="BOOT0" type="boot"/>
+        <pin position="D8" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="D9" name="PH0-OSC_IN (PH0)"/>
+        <pin position="E1" name="PC9"/>
+        <pin position="E2" name="PA8"/>
+        <pin position="E3" name="PA9"/>
+        <pin position="E4" name="VDD" type="power"/>
+        <pin position="E5" name="PD4"/>
+        <pin position="E6" name="PE7"/>
+        <pin position="E7" name="PB8"/>
+        <pin position="E8" name="PB9"/>
+        <pin position="E9" name="NRST" type="reset"/>
+        <pin position="F1" name="PC7"/>
+        <pin position="F2" name="PC8"/>
+        <pin position="F3" name="PC6"/>
+        <pin position="F4" name="PD9"/>
+        <pin position="F5" name="PD8"/>
+        <pin position="F6" name="PE8"/>
+        <pin position="F7" name="PC2"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PC0"/>
+        <pin position="G1" name="PB15"/>
+        <pin position="G2" name="PB14"/>
+        <pin position="G3" name="PB11"/>
+        <pin position="G4" name="PA1"/>
+        <pin position="G5" name="PA4"/>
+        <pin position="G6" name="PA2"/>
+        <pin position="G7" name="PC3"/>
+        <pin position="G8" name="VREF+" type="monoio"/>
+        <pin position="G9" name="VSSA/VREF-" type="power"/>
+        <pin position="H1" name="PB12"/>
+        <pin position="H2" name="PB13"/>
+        <pin position="H3" name="PB10"/>
+        <pin position="H4" name="PA7"/>
+        <pin position="H5" name="PA6"/>
+        <pin position="H6" name="PA5"/>
+        <pin position="H7" name="PA3"/>
+        <pin position="H8" name="PA0"/>
+        <pin position="H9" name="VDDA" type="power"/>
+        <pin position="J1" name="VDD" type="power"/>
+        <pin position="J2" name="VSS" type="power"/>
+        <pin position="J3" name="PB2"/>
+        <pin position="J4" name="PB1"/>
+        <pin position="J5" name="PB0"/>
+        <pin position="J6" name="PC5"/>
+        <pin position="J7" name="PC4"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-96_a6.xml
+++ b/devices/stm32/stm32l4-96_a6.xml
@@ -2020,6 +2020,1132 @@
       </gpio>
       <gpio device-pin="a" port="i" pin="10"/>
       <gpio device-pin="a" port="i" pin="11"/>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="48" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="48" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="48" name="PB11"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="48" name="PB11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PH3-BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="98" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="98" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="98" name="PE1"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="98" name="PE1"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="70" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="70" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="70" name="PB11"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="70" name="PB11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDIO2" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VDDUSB" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="132" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="132" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="132" name="PG15"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="132" name="PG15"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="132" name="PG15"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="133" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="133" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="134" name="PB5"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="134" name="PB5"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="135" name="PB6"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="135" name="PB6"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="135" name="PB5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="135" name="PB5"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="135" name="PB5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="136" name="PB7"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="136" name="PB7"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="136" name="PB6"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="136" name="PB6"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="136" name="PB6"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="137" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="137" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="137" name="PB7"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="137" name="PB7"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="137" name="PB7"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="138" name="PB8"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="138" name="PB8"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="139" name="PB9"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="139" name="PB9"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="139" name="PB8"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="139" name="PB8"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="139" name="PB8"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="140" name="PE0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="140" name="PE0"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="140" name="PB9"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="140" name="PB9"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="140" name="PB9"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="141" name="PE1"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="141" name="PE1"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="141" name="PE0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="141" name="PE0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="141" name="PE0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="142" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="142" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="142" name="PE1"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="142" name="PE1"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="25" name="PB0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="25" name="PB0"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="25" name="PC5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="25" name="PC5"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="25" name="PC5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="26" name="PB1"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="26" name="PB1"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="26" name="PB0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="26" name="PB0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="26" name="PB0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="27" name="PB2"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="27" name="PB2"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="27" name="PB1"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="27" name="PB1"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="27" name="PB1"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="28" name="PB10"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="28" name="PB10"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="28" name="PB2"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="28" name="PB2"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="28" name="PB2"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="29" name="PB11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="29" name="PB11"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="29" name="PB10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="29" name="PB10"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="29" name="PB10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="30" name="PB11"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="30" name="PB11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="54" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="54" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="54" name="PD2"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="54" name="PD2"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="54" name="PD2"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="56" name="PB5"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="56" name="PB5"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="57" name="PB6"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="57" name="PB6"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="57" name="PB5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="57" name="PB5"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="57" name="PB5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="58" name="PB7"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="58" name="PB7"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="58" name="PB6"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="58" name="PB6"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="58" name="PB6"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="59" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="59" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="59" name="PB7"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="59" name="PB7"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="59" name="PB7"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="60" name="PB8"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="60" name="PB8"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="61" name="PB9"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="61" name="PB9"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="61" name="PB8"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="61" name="PB8"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="61" name="PB8"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="62" name="PB9"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="62" name="PB9"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="C6" name="PG14"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="C6" name="PG14"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="L11" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="L11" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="L11" name="PB11"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="L11" name="PB11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PI10"/>
+        <pin position="A2" name="PH2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PI0"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PI9"/>
+        <pin position="B2" name="PI7"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PG9"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PI6"/>
+        <pin position="B10" name="PI2"/>
+        <pin position="B11" name="PI1"/>
+        <pin position="B12" name="PH15"/>
+        <pin position="B13" name="PH12"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI11"/>
+        <pin position="C4" name="PB8"/>
+        <pin position="C5" name="PB6"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="C6" name="PG15"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="C6" name="PG15"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="C6" name="PG15"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD1"/>
+        <pin position="C9" name="PH13"/>
+        <pin position="C10" name="PI3"/>
+        <pin position="C11" name="PI8"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="PE4"/>
+        <pin position="D2" name="PE3"/>
+        <pin position="D3" name="PE2"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB7"/>
+        <pin position="D6" name="PG10"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC10"/>
+        <pin position="D10" name="PI4"/>
+        <pin position="D11" name="PH9"/>
+        <pin position="D12" name="PH7"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="PC13"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PH3-BOOT0"/>
+        <pin position="E6" name="PG11"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PD3"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PI5"/>
+        <pin position="E11" name="PH6"/>
+        <pin position="E12" name="VDDUSB" type="power"/>
+        <pin position="E13" name="PA11"/>
+        <pin position="F1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF2"/>
+        <pin position="F4" name="PF1"/>
+        <pin position="F5" name="PF0"/>
+        <pin position="F6" name="PG12"/>
+        <pin position="F7" name="PD7"/>
+        <pin position="F8" name="PC12"/>
+        <pin position="F9" name="PA10"/>
+        <pin position="F10" name="PA9"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDDIO2" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF3"/>
+        <pin position="G4" name="PF4"/>
+        <pin position="G5" name="PF5"/>
+        <pin position="G6" name="PG14"/>
+        <pin position="G7" name="PG13"/>
+        <pin position="G8" name="PA8"/>
+        <pin position="G9" name="PC9"/>
+        <pin position="G10" name="PC8"/>
+        <pin position="G11" name="PG6"/>
+        <pin position="G12" name="PC7"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="NRST" type="reset"/>
+        <pin position="H4" name="PF10"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PG1"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PG8"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PD15"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PC0"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC2"/>
+        <pin position="J5" name="PC5"/>
+        <pin position="J6" name="PG0"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE15"/>
+        <pin position="J9" name="PG5"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="J13" name="PD10"/>
+        <pin position="K1" name="PC3"/>
+        <pin position="K2" name="VSSA/VREF-" type="power"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PB0"/>
+        <pin position="K6" name="PF15"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE14"/>
+        <pin position="K9" name="PH4"/>
+        <pin position="K10" name="PD14"/>
+        <pin position="K11" name="PD12"/>
+        <pin position="K12" name="PD11"/>
+        <pin position="K13" name="PD13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="PA7"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE13"/>
+        <pin position="L9" name="PH5"/>
+        <pin position="L10" name="PD9"/>
+        <pin position="L11" name="PD8"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="VSS" type="power"/>
+        <pin position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin position="M4" name="PA6"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE12"/>
+        <pin position="M9" name="PH10"/>
+        <pin device-name="96" device-size="g" device-temperature="3|6|7" device-variant="p" position="M10" name="VDD12" type="power"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="p" position="M10" name="VDD12" type="power"/>
+        <pin device-name="96" device-size="e|g" device-temperature="6" device-variant="" position="M10" name="PH11"/>
+        <pin device-name="96" device-size="g" device-temperature="3|7" device-variant="" position="M10" name="PH11"/>
+        <pin device-name="a6" device-size="g" device-temperature="6" device-variant="" position="M10" name="PH11"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PB15"/>
+        <pin position="M13" name="PB14"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="VDD" type="power"/>
+        <pin position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="N5" name="PB2"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PB10"/>
+        <pin position="N10" name="PH8"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB13"/>
+      </package>
+      <package device-pin="v" device-package="y" name="WLCSP100">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PD1"/>
+        <pin position="A4" name="VDD" type="power"/>
+        <pin position="A5" name="PG10"/>
+        <pin position="A6" name="VDDIO2" type="power"/>
+        <pin position="A7" name="PB6"/>
+        <pin position="A8" name="PB9"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="A9" name="VDD12" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="A9" name="VDD12" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="A9" name="VSS" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="A9" name="VSS" type="power"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B3" name="PD0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="B4" name="PD5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="B4" name="PD5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="B4" name="PD4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="B4" name="PD4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="B5" name="PD6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="B5" name="PD6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="B5" name="PG9"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="B5" name="PG9"/>
+        <pin position="B6" name="PG12"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="B7" name="PB7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="B7" name="PB7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="B7" name="PB5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="B7" name="PB5"/>
+        <pin position="B8" name="PB8"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="B9" name="VSS" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="B9" name="VSS" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="B9" name="PE2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="B9" name="PE2"/>
+        <pin position="B10" name="PE3"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="C3" name="PC10"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="C3" name="PC10"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="C3" name="PC11"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="C3" name="PC11"/>
+        <pin position="C4" name="PC12"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="C5" name="PD4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="C5" name="PD4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="C5" name="PD7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="C5" name="PD7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="C6" name="PD7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="C6" name="PD7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="C7" name="PB5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="C7" name="PB5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="C7" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="C7" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="C8" name="PE2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="C8" name="PE2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="C8" name="PE4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="C8" name="PE4"/>
+        <pin position="C9" name="PC13"/>
+        <pin position="C10" name="VBAT" type="power"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA9"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D4" name="PC11"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D4" name="PC11"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D4" name="PC10"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D4" name="PC10"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D5" name="PD2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D5" name="PD2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D5" name="PD6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D5" name="PD6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D6" name="PG9"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D6" name="PG9"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D6" name="PG11"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D6" name="PG11"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D7" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D7" name="PH3-BOOT0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D7" name="PB7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D7" name="PB7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D8" name="PE6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D8" name="PE6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D8" name="PE5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D8" name="PE5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="D9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="D9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="D9" name="VSS" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E1" name="PC8"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E4" name="PC7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E4" name="PC7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E4" name="PD2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E4" name="PD2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E5" name="PG11"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E5" name="PG11"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E5" name="PD5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E5" name="PD5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E6" name="PB4 (NJTRST)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E6" name="PB4 (NJTRST)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E6" name="PH3-BOOT0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E6" name="PH3-BOOT0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E7" name="PE4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E7" name="PE4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E7" name="PE6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E7" name="PE6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E8" name="PE5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E8" name="PE5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E8" name="NRST" type="reset"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E8" name="NRST" type="reset"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="E10" name="VSS" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="E10" name="VSS" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="E10" name="PC15-OSC32_OUT (PC15)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="E10" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F2" name="PD15"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F2" name="PD15"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F2" name="PC6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F2" name="PC6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F3" name="PD14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F3" name="PD14"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F3" name="PC7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F3" name="PC7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F4" name="PC6"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F4" name="PC6"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F4" name="PD15"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F4" name="PD15"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F5" name="PB2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F5" name="PB2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F6" name="PC3"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F6" name="PC3"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F6" name="PA4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F6" name="PA4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F7" name="PC1"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F7" name="PC1"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F7" name="PC3"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F7" name="PC3"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F8" name="NRST" type="reset"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F8" name="NRST" type="reset"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F8" name="PC1"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F8" name="PC1"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="F9" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="F9" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="F9" name="PC0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="F9" name="PC0"/>
+        <pin position="F10" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G1" name="PD10"/>
+        <pin position="G2" name="PD9"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G3" name="PD8"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G3" name="PD8"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G3" name="PD14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G3" name="PD14"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G4" name="PE14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G4" name="PE14"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G4" name="PE13"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G4" name="PE13"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G5" name="PE13"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G5" name="PE13"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G5" name="PE12"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G5" name="PE12"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G6" name="PA7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G6" name="PA7"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G6" name="PA5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G6" name="PA5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G7" name="PA1"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G7" name="PA1"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G7" name="VREF+" type="monoio"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G7" name="VREF+" type="monoio"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G8" name="PA0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G8" name="PA0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G8" name="VREF-" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G8" name="VREF-" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G9" name="PC2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G9" name="PC2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G9" name="PA0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G9" name="PA0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="G10" name="PC0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="G10" name="PC0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="G10" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="G10" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H1" name="PB14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H1" name="PB14"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H1" name="PB15"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H1" name="PB15"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H2" name="PB13"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H2" name="PB13"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H2" name="PB14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H2" name="PB14"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H3" name="PB15"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H3" name="PB15"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H3" name="PD8"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H3" name="PD8"/>
+        <pin position="H4" name="PE15"/>
+        <pin position="H5" name="PE10"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H6" name="PB0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H6" name="PB0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H6" name="PC4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H6" name="PC4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H7" name="PA4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H7" name="PA4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H7" name="PA2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H7" name="PA2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H8" name="PA2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H8" name="PA2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H8" name="PA1"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H8" name="PA1"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H9" name="VSSA/VREF-" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H9" name="VSSA/VREF-" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H9" name="VSSA" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H9" name="VSSA" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="H10" name="VREF+" type="monoio"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="H10" name="VREF+" type="monoio"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="H10" name="PC2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="H10" name="PC2"/>
+        <pin position="J1" name="PB12"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="J2" name="VDD" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="J2" name="VDD" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="J2" name="PB13"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="J2" name="PB13"/>
+        <pin position="J3" name="PB11"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="J4" name="PE12"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="J4" name="PE12"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="J4" name="PE14"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="J4" name="PE14"/>
+        <pin position="J5" name="PE9"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="J6" name="PB2"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="J6" name="PB2"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="J6" name="PB0"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="J6" name="PB0"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="J7" name="PA5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="J7" name="PA5"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="J7" name="PA7"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="J7" name="PA7"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PA3"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="K1" name="VDD12" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="K1" name="VDD12" type="power"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="K1" name="VDD" type="power"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PB10"/>
+        <pin position="K4" name="PE11"/>
+        <pin position="K5" name="PE8"/>
+        <pin position="K6" name="PE7"/>
+        <pin position="K7" name="PB1"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="p" position="K8" name="PC4"/>
+        <pin device-name="a6" device-temperature="6" device-variant="p" position="K8" name="PC4"/>
+        <pin device-name="96" device-temperature="3|6|7" device-variant="" position="K8" name="PC5"/>
+        <pin device-name="a6" device-temperature="6" device-variant="" position="K8" name="PC5"/>
+        <pin position="K9" name="PA6"/>
+        <pin position="K10" name="VSS" type="power"/>
+      </package>
+      <package device-pin="w" name="WLCSP115">
+        <pin position="A2" name="VDD" type="power"/>
+        <pin position="A4" name="PC11"/>
+        <pin position="A6" name="PD2"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A10" name="PG10"/>
+        <pin position="A12" name="PG14"/>
+        <pin position="A14" name="PB5"/>
+        <pin position="A16" name="PB9"/>
+        <pin position="A18" name="VSS" type="power"/>
+        <pin position="A20" name="VDD" type="power"/>
+        <pin position="B1" name="PA12"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B5" name="PC10"/>
+        <pin position="B7" name="PD1"/>
+        <pin position="B9" name="VSS" type="power"/>
+        <pin position="B11" name="PG11"/>
+        <pin position="B13" name="VDDIO2" type="power"/>
+        <pin position="B15" name="PB7"/>
+        <pin position="B17" name="VDD12" type="power"/>
+        <pin position="B19" name="PE3"/>
+        <pin position="B21" name="PE5"/>
+        <pin position="C2" name="PA11"/>
+        <pin position="C4" name="VDDUSB" type="power"/>
+        <pin position="C6" name="PA15 (JTDI)"/>
+        <pin position="C8" name="PD0"/>
+        <pin position="C10" name="PD5"/>
+        <pin position="C12" name="PG12"/>
+        <pin position="C14" name="PB4 (NJTRST)"/>
+        <pin position="C16" name="PE2"/>
+        <pin position="C18" name="PE4"/>
+        <pin position="C20" name="VBAT" type="power"/>
+        <pin position="D1" name="PA9"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D5" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="D7" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="D9" name="PC12"/>
+        <pin position="D11" name="PD7"/>
+        <pin position="D13" name="PG13"/>
+        <pin position="D15" name="PH3-BOOT0"/>
+        <pin position="D17" name="PC13"/>
+        <pin position="D19" name="PE6"/>
+        <pin position="D21" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E2" name="PC7"/>
+        <pin position="E4" name="PC8"/>
+        <pin position="E6" name="PC9"/>
+        <pin position="E8" name="PA10"/>
+        <pin position="E10" name="PD4"/>
+        <pin position="E12" name="PG9"/>
+        <pin position="E14" name="PB6"/>
+        <pin position="E16" name="NRST" type="reset"/>
+        <pin position="E18" name="VSS" type="power"/>
+        <pin position="E20" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="F1" name="VDDIO2" type="power"/>
+        <pin position="F3" name="VSS" type="power"/>
+        <pin position="F5" name="PG8"/>
+        <pin position="F7" name="PG7"/>
+        <pin position="F9" name="PC6"/>
+        <pin position="F11" name="PD6"/>
+        <pin position="F13" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="F15" name="PA2"/>
+        <pin position="F17" name="PC0"/>
+        <pin position="F19" name="VDD" type="power"/>
+        <pin position="F21" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G2" name="PG5"/>
+        <pin position="G4" name="PG4"/>
+        <pin position="G6" name="PG3"/>
+        <pin position="G8" name="PG2"/>
+        <pin position="G10" name="PG6"/>
+        <pin position="G12" name="PG1"/>
+        <pin position="G14" name="PC5"/>
+        <pin position="G16" name="PA1"/>
+        <pin position="G18" name="PC2"/>
+        <pin position="G20" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H1" name="PD15"/>
+        <pin position="H3" name="PD14"/>
+        <pin position="H5" name="PD10"/>
+        <pin position="H7" name="PD9"/>
+        <pin position="H9" name="PE13"/>
+        <pin position="H11" name="PE9"/>
+        <pin position="H13" name="PB2"/>
+        <pin position="H15" name="PA6"/>
+        <pin position="H17" name="PA0"/>
+        <pin position="H19" name="PC3"/>
+        <pin position="H21" name="PC1"/>
+        <pin position="J2" name="PD8"/>
+        <pin position="J4" name="PB14"/>
+        <pin position="J6" name="PB13"/>
+        <pin position="J8" name="PB10"/>
+        <pin position="J10" name="PE12"/>
+        <pin position="J12" name="PG0"/>
+        <pin position="J14" name="PB0"/>
+        <pin position="J16" name="PA5"/>
+        <pin position="J18" name="VSSA" type="power"/>
+        <pin position="J20" name="VREF+" type="monoio"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K3" name="VSS" type="power"/>
+        <pin position="K5" name="PB12"/>
+        <pin position="K7" name="PE14"/>
+        <pin position="K9" name="PE10"/>
+        <pin position="K11" name="PE7"/>
+        <pin position="K13" name="VSS" type="power"/>
+        <pin position="K15" name="PC4"/>
+        <pin position="K17" name="VDD" type="power"/>
+        <pin position="K19" name="VSS" type="power"/>
+        <pin position="K21" name="VDDA" type="power"/>
+        <pin position="L2" name="VDD12" type="power"/>
+        <pin position="L4" name="PB11"/>
+        <pin position="L6" name="PE15"/>
+        <pin position="L8" name="PE11"/>
+        <pin position="L10" name="PE8"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L14" name="PB1"/>
+        <pin position="L16" name="PA7"/>
+        <pin position="L18" name="PA4"/>
+        <pin position="L20" name="PA3"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-p5.xml
+++ b/devices/stm32/stm32l4-p5.xml
@@ -1993,6 +1993,918 @@
         <signal af="5" driver="octospim" name="p2_io0"/>
         <signal af="10" driver="pssi" name="d15"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="48" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="48" name="VDD12" type="power"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PH3-BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin device-size="e|g" device-variant="" position="98" name="PE1"/>
+        <pin device-size="g" device-variant="p" position="98" name="VDD12" type="power"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="70" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="70" name="VDD12" type="power"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDIO2" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VDDUSB" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin device-size="e|g" device-variant="" position="132" name="PG15"/>
+        <pin device-size="g" device-variant="p" position="132" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="e|g" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="g" device-variant="p" position="133" name="PB4 (NJTRST)"/>
+        <pin device-size="e|g" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-size="g" device-variant="p" position="134" name="PB5"/>
+        <pin device-size="e|g" device-variant="" position="135" name="PB5"/>
+        <pin device-size="g" device-variant="p" position="135" name="PB6"/>
+        <pin device-size="e|g" device-variant="" position="136" name="PB6"/>
+        <pin device-size="g" device-variant="p" position="136" name="PB7"/>
+        <pin device-size="e|g" device-variant="" position="137" name="PB7"/>
+        <pin device-size="g" device-variant="p" position="137" name="PH3-BOOT0"/>
+        <pin device-size="e|g" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-size="g" device-variant="p" position="138" name="PB8"/>
+        <pin device-size="e|g" device-variant="" position="139" name="PB8"/>
+        <pin device-size="g" device-variant="p" position="139" name="PB9"/>
+        <pin device-size="e|g" device-variant="" position="140" name="PB9"/>
+        <pin device-size="g" device-variant="p" position="140" name="PE0"/>
+        <pin device-size="e|g" device-variant="" position="141" name="PE0"/>
+        <pin device-size="g" device-variant="p" position="141" name="PE1"/>
+        <pin device-size="e|g" device-variant="" position="142" name="PE1"/>
+        <pin device-size="g" device-variant="p" position="142" name="VDD12" type="power"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="22" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="22" name="VDD12" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin device-size="e|g" device-variant="" position="45" name="PB8"/>
+        <pin device-size="g" device-variant="p" position="45" name="PB9"/>
+        <pin device-size="e|g" device-variant="" position="46" name="PB9"/>
+        <pin device-size="g" device-variant="p" position="46" name="VDD12" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin device-size="e|g" device-variant="" position="25" name="PC5"/>
+        <pin device-size="g" device-variant="p" position="25" name="PB0"/>
+        <pin device-size="e|g" device-variant="" position="26" name="PB0"/>
+        <pin device-size="g" device-variant="p" position="26" name="PB1"/>
+        <pin device-size="e|g" device-variant="" position="27" name="PB1"/>
+        <pin device-size="g" device-variant="p" position="27" name="PB2"/>
+        <pin device-size="e|g" device-variant="" position="28" name="PB2"/>
+        <pin device-size="g" device-variant="p" position="28" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="29" name="PB10"/>
+        <pin device-size="g" device-variant="p" position="29" name="PB11"/>
+        <pin device-size="e|g" device-variant="" position="30" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="30" name="VDD12" type="power"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin device-size="e|g" device-variant="" position="54" name="PD2"/>
+        <pin device-size="g" device-variant="p" position="54" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="e|g" device-variant="" position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="g" device-variant="p" position="55" name="PB4 (NJTRST)"/>
+        <pin device-size="e|g" device-variant="" position="56" name="PB4 (NJTRST)"/>
+        <pin device-size="g" device-variant="p" position="56" name="PB5"/>
+        <pin device-size="e|g" device-variant="" position="57" name="PB5"/>
+        <pin device-size="g" device-variant="p" position="57" name="PB6"/>
+        <pin device-size="e|g" device-variant="" position="58" name="PB6"/>
+        <pin device-size="g" device-variant="p" position="58" name="PB7"/>
+        <pin device-size="e|g" device-variant="" position="59" name="PB7"/>
+        <pin device-size="g" device-variant="p" position="59" name="PH3-BOOT0"/>
+        <pin device-size="e|g" device-variant="" position="60" name="PH3-BOOT0"/>
+        <pin device-size="g" device-variant="p" position="60" name="PB8"/>
+        <pin device-size="e|g" device-variant="" position="61" name="PB8"/>
+        <pin device-size="g" device-variant="p" position="61" name="PB9"/>
+        <pin device-size="e|g" device-variant="" position="62" name="PB9"/>
+        <pin device-size="g" device-variant="p" position="62" name="VDD12" type="power"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin device-size="e|g" device-variant="" position="C6" name="PG14"/>
+        <pin device-size="g" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="L11" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="L11" name="VDD12" type="power"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PI10"/>
+        <pin position="A2" name="PH2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PI0"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PI9"/>
+        <pin position="B2" name="PI7"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PG9"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PI6"/>
+        <pin position="B10" name="PI2"/>
+        <pin position="B11" name="PI1"/>
+        <pin position="B12" name="PH15"/>
+        <pin position="B13" name="PH12"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI11"/>
+        <pin position="C4" name="PB8"/>
+        <pin position="C5" name="PB6"/>
+        <pin device-size="e|g" device-variant="" position="C6" name="PG15"/>
+        <pin device-size="g" device-variant="p" position="C6" name="VDD12" type="power"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD1"/>
+        <pin position="C9" name="PH13"/>
+        <pin position="C10" name="PI3"/>
+        <pin position="C11" name="PI8"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="PE4"/>
+        <pin position="D2" name="PE3"/>
+        <pin position="D3" name="PE2"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB7"/>
+        <pin position="D6" name="PG10"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC10"/>
+        <pin position="D10" name="PI4"/>
+        <pin position="D11" name="PH9"/>
+        <pin position="D12" name="PH7"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="PC13"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PH3-BOOT0"/>
+        <pin position="E6" name="PG11"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PD3"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PI5"/>
+        <pin position="E11" name="PH6"/>
+        <pin position="E12" name="VDDUSB" type="power"/>
+        <pin position="E13" name="PA11"/>
+        <pin position="F1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF2"/>
+        <pin position="F4" name="PF1"/>
+        <pin position="F5" name="PF0"/>
+        <pin position="F6" name="PG12"/>
+        <pin position="F7" name="PD7"/>
+        <pin position="F8" name="PC12"/>
+        <pin position="F9" name="PA10"/>
+        <pin position="F10" name="PA9"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDDIO2" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF3"/>
+        <pin position="G4" name="PF4"/>
+        <pin position="G5" name="PF5"/>
+        <pin position="G6" name="PG14"/>
+        <pin position="G7" name="PG13"/>
+        <pin position="G8" name="PA8"/>
+        <pin position="G9" name="PC9"/>
+        <pin position="G10" name="PC8"/>
+        <pin position="G11" name="PG6"/>
+        <pin position="G12" name="PC7"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="NRST" type="reset"/>
+        <pin position="H4" name="PF10"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PG1"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PG8"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PD15"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PC0"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC2"/>
+        <pin position="J5" name="PC5"/>
+        <pin position="J6" name="PG0"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE15"/>
+        <pin position="J9" name="PG5"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="J13" name="PD10"/>
+        <pin position="K1" name="PC3"/>
+        <pin position="K2" name="VSSA/VREF-" type="power"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PB0"/>
+        <pin position="K6" name="PF15"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE14"/>
+        <pin position="K9" name="PH4"/>
+        <pin position="K10" name="PD14"/>
+        <pin position="K11" name="PD12"/>
+        <pin position="K12" name="PD11"/>
+        <pin position="K13" name="PD13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="PA7"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE13"/>
+        <pin position="L9" name="PH5"/>
+        <pin position="L10" name="PD9"/>
+        <pin position="L11" name="PD8"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="VSS" type="power"/>
+        <pin position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin position="M4" name="PA6"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE12"/>
+        <pin position="M9" name="PH10"/>
+        <pin device-size="e|g" device-variant="" position="M10" name="PH11"/>
+        <pin device-size="g" device-variant="p" position="M10" name="VDD12" type="power"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PB15"/>
+        <pin position="M13" name="PB14"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="VDD" type="power"/>
+        <pin position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="N5" name="PB2"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PB10"/>
+        <pin position="N10" name="PH8"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB13"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin device-size="e|g" device-variant="" position="22" name="PB11"/>
+        <pin device-size="g" device-variant="p" position="22" name="VDD12" type="power"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin device-size="e|g" device-variant="" position="45" name="PB8"/>
+        <pin device-size="g" device-variant="p" position="45" name="PB9"/>
+        <pin device-size="e|g" device-variant="" position="46" name="PB9"/>
+        <pin device-size="g" device-variant="p" position="46" name="VDD12" type="power"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PD1"/>
+        <pin position="A4" name="VDD" type="power"/>
+        <pin position="A5" name="PG10"/>
+        <pin position="A6" name="VDDIO2" type="power"/>
+        <pin position="A7" name="PB6"/>
+        <pin position="A8" name="PB9"/>
+        <pin device-size="e|g" device-variant="" position="A9" name="VSS" type="power"/>
+        <pin device-size="g" device-variant="p" position="A9" name="VDD12" type="power"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B3" name="PD0"/>
+        <pin device-size="e|g" device-variant="" position="B4" name="PD4"/>
+        <pin device-size="g" device-variant="p" position="B4" name="PD5"/>
+        <pin device-size="e|g" device-variant="" position="B5" name="PG9"/>
+        <pin device-size="g" device-variant="p" position="B5" name="PD6"/>
+        <pin position="B6" name="PG12"/>
+        <pin device-size="e|g" device-variant="" position="B7" name="PB5"/>
+        <pin device-size="g" device-variant="p" position="B7" name="PB7"/>
+        <pin position="B8" name="PB8"/>
+        <pin device-size="e|g" device-variant="" position="B9" name="PE2"/>
+        <pin device-size="g" device-variant="p" position="B9" name="VSS" type="power"/>
+        <pin position="B10" name="PE3"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-size="e|g" device-variant="" position="C3" name="PC11"/>
+        <pin device-size="g" device-variant="p" position="C3" name="PC10"/>
+        <pin position="C4" name="PC12"/>
+        <pin device-size="e|g" device-variant="" position="C5" name="PD7"/>
+        <pin device-size="g" device-variant="p" position="C5" name="PD4"/>
+        <pin device-size="e|g" device-variant="" position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="g" device-variant="p" position="C6" name="PD7"/>
+        <pin device-size="e|g" device-variant="" position="C7" name="PB4 (NJTRST)"/>
+        <pin device-size="g" device-variant="p" position="C7" name="PB5"/>
+        <pin device-size="e|g" device-variant="" position="C8" name="PE4"/>
+        <pin device-size="g" device-variant="p" position="C8" name="PE2"/>
+        <pin position="C9" name="PC13"/>
+        <pin position="C10" name="VBAT" type="power"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA9"/>
+        <pin device-size="e|g" device-variant="" position="D4" name="PC10"/>
+        <pin device-size="g" device-variant="p" position="D4" name="PC11"/>
+        <pin device-size="e|g" device-variant="" position="D5" name="PD6"/>
+        <pin device-size="g" device-variant="p" position="D5" name="PD2"/>
+        <pin device-size="e|g" device-variant="" position="D6" name="PG11"/>
+        <pin device-size="g" device-variant="p" position="D6" name="PG9"/>
+        <pin device-size="e|g" device-variant="" position="D7" name="PB7"/>
+        <pin device-size="g" device-variant="p" position="D7" name="PH3-BOOT0"/>
+        <pin device-size="e|g" device-variant="" position="D8" name="PE5"/>
+        <pin device-size="g" device-variant="p" position="D8" name="PE6"/>
+        <pin device-size="e|g" device-variant="" position="D9" name="VSS" type="power"/>
+        <pin device-size="g" device-variant="p" position="D9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="D10" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E1" name="PC8"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin device-size="e|g" device-variant="" position="E4" name="PD2"/>
+        <pin device-size="g" device-variant="p" position="E4" name="PC7"/>
+        <pin device-size="e|g" device-variant="" position="E5" name="PD5"/>
+        <pin device-size="g" device-variant="p" position="E5" name="PG11"/>
+        <pin device-size="e|g" device-variant="" position="E6" name="PH3-BOOT0"/>
+        <pin device-size="g" device-variant="p" position="E6" name="PB4 (NJTRST)"/>
+        <pin device-size="e|g" device-variant="" position="E7" name="PE6"/>
+        <pin device-size="g" device-variant="p" position="E7" name="PE4"/>
+        <pin device-size="e|g" device-variant="" position="E8" name="NRST" type="reset"/>
+        <pin device-size="g" device-variant="p" position="E8" name="PE5"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin device-size="e|g" device-variant="" position="E10" name="PC15-OSC32_OUT (PC15)"/>
+        <pin device-size="g" device-variant="p" position="E10" name="VSS" type="power"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin device-size="e|g" device-variant="" position="F2" name="PC6"/>
+        <pin device-size="g" device-variant="p" position="F2" name="PD15"/>
+        <pin device-size="e|g" device-variant="" position="F3" name="PC7"/>
+        <pin device-size="g" device-variant="p" position="F3" name="PD14"/>
+        <pin device-size="e|g" device-variant="" position="F4" name="PD15"/>
+        <pin device-size="g" device-variant="p" position="F4" name="PC6"/>
+        <pin device-size="e|g" device-variant="" position="F5" name="PB2"/>
+        <pin device-size="g" device-variant="p" position="F5" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-size="e|g" device-variant="" position="F6" name="PA4"/>
+        <pin device-size="g" device-variant="p" position="F6" name="PC3"/>
+        <pin device-size="e|g" device-variant="" position="F7" name="PC3"/>
+        <pin device-size="g" device-variant="p" position="F7" name="PC1"/>
+        <pin device-size="e|g" device-variant="" position="F8" name="PC1"/>
+        <pin device-size="g" device-variant="p" position="F8" name="NRST" type="reset"/>
+        <pin device-size="e|g" device-variant="" position="F9" name="PC0"/>
+        <pin device-size="g" device-variant="p" position="F9" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="F10" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G1" name="PD10"/>
+        <pin position="G2" name="PD9"/>
+        <pin device-size="e|g" device-variant="" position="G3" name="PD14"/>
+        <pin device-size="g" device-variant="p" position="G3" name="PD8"/>
+        <pin device-size="e|g" device-variant="" position="G4" name="PE13"/>
+        <pin device-size="g" device-variant="p" position="G4" name="PE14"/>
+        <pin device-size="e|g" device-variant="" position="G5" name="PE12"/>
+        <pin device-size="g" device-variant="p" position="G5" name="PE13"/>
+        <pin device-size="e|g" device-variant="" position="G6" name="PA5"/>
+        <pin device-size="g" device-variant="p" position="G6" name="PA7"/>
+        <pin device-size="e|g" device-variant="" position="G7" name="VREF+" type="monoio"/>
+        <pin device-size="g" device-variant="p" position="G7" name="PA1"/>
+        <pin device-size="e|g" device-variant="" position="G8" name="VREF-" type="power"/>
+        <pin device-size="g" device-variant="p" position="G8" name="PA0"/>
+        <pin device-size="e|g" device-variant="" position="G9" name="PA0"/>
+        <pin device-size="g" device-variant="p" position="G9" name="PC2"/>
+        <pin device-size="e|g" device-variant="" position="G10" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-size="g" device-variant="p" position="G10" name="PC0"/>
+        <pin device-size="e|g" device-variant="" position="H1" name="PB15"/>
+        <pin device-size="g" device-variant="p" position="H1" name="PB14"/>
+        <pin device-size="e|g" device-variant="" position="H2" name="PB14"/>
+        <pin device-size="g" device-variant="p" position="H2" name="PB13"/>
+        <pin device-size="e|g" device-variant="" position="H3" name="PD8"/>
+        <pin device-size="g" device-variant="p" position="H3" name="PB15"/>
+        <pin position="H4" name="PE15"/>
+        <pin position="H5" name="PE10"/>
+        <pin device-size="e|g" device-variant="" position="H6" name="PC4"/>
+        <pin device-size="g" device-variant="p" position="H6" name="PB0"/>
+        <pin device-size="e|g" device-variant="" position="H7" name="PA2"/>
+        <pin device-size="g" device-variant="p" position="H7" name="PA4"/>
+        <pin device-size="e|g" device-variant="" position="H8" name="PA1"/>
+        <pin device-size="g" device-variant="p" position="H8" name="PA2"/>
+        <pin device-size="e|g" device-variant="" position="H9" name="VSSA" type="power"/>
+        <pin device-size="g" device-variant="p" position="H9" name="VSSA/VREF-" type="power"/>
+        <pin device-size="e|g" device-variant="" position="H10" name="PC2"/>
+        <pin device-size="g" device-variant="p" position="H10" name="VREF+" type="monoio"/>
+        <pin position="J1" name="PB12"/>
+        <pin device-size="e|g" device-variant="" position="J2" name="PB13"/>
+        <pin device-size="g" device-variant="p" position="J2" name="VDD" type="power"/>
+        <pin position="J3" name="PB11"/>
+        <pin device-size="e|g" device-variant="" position="J4" name="PE14"/>
+        <pin device-size="g" device-variant="p" position="J4" name="PE12"/>
+        <pin position="J5" name="PE9"/>
+        <pin device-size="e|g" device-variant="" position="J6" name="PB0"/>
+        <pin device-size="g" device-variant="p" position="J6" name="PB2"/>
+        <pin device-size="e|g" device-variant="" position="J7" name="PA7"/>
+        <pin device-size="g" device-variant="p" position="J7" name="PA5"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PA3"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin device-size="e|g" device-variant="" position="K1" name="VDD" type="power"/>
+        <pin device-size="g" device-variant="p" position="K1" name="VDD12" type="power"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PB10"/>
+        <pin position="K4" name="PE11"/>
+        <pin position="K5" name="PE8"/>
+        <pin position="K6" name="PE7"/>
+        <pin position="K7" name="PB1"/>
+        <pin device-size="e|g" device-variant="" position="K8" name="PC5"/>
+        <pin device-size="g" device-variant="p" position="K8" name="PC4"/>
+        <pin position="K9" name="PA6"/>
+        <pin position="K10" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-q5.xml
+++ b/devices/stm32/stm32l4-q5.xml
@@ -1851,6 +1851,827 @@
         <signal af="5" driver="octospim" name="p2_io0"/>
         <signal af="10" driver="pssi" name="d15"/>
       </gpio>
+      <package device-pin="v" device-package="t" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin position="19" name="VSSA" type="power"/>
+        <pin position="20" name="VREF-" type="power"/>
+        <pin position="21" name="VREF+" type="monoio"/>
+        <pin position="22" name="VDDA" type="power"/>
+        <pin position="23" name="PA0"/>
+        <pin position="24" name="PA1"/>
+        <pin position="25" name="PA2"/>
+        <pin position="26" name="PA3"/>
+        <pin position="27" name="VSS" type="power"/>
+        <pin position="28" name="VDD" type="power"/>
+        <pin position="29" name="PA4"/>
+        <pin position="30" name="PA5"/>
+        <pin position="31" name="PA6"/>
+        <pin position="32" name="PA7"/>
+        <pin position="33" name="PC4"/>
+        <pin position="34" name="PC5"/>
+        <pin position="35" name="PB0"/>
+        <pin position="36" name="PB1"/>
+        <pin position="37" name="PB2"/>
+        <pin position="38" name="PE7"/>
+        <pin position="39" name="PE8"/>
+        <pin position="40" name="PE9"/>
+        <pin position="41" name="PE10"/>
+        <pin position="42" name="PE11"/>
+        <pin position="43" name="PE12"/>
+        <pin position="44" name="PE13"/>
+        <pin position="45" name="PE14"/>
+        <pin position="46" name="PE15"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB11"/>
+        <pin position="49" name="VSS" type="power"/>
+        <pin position="50" name="VDD" type="power"/>
+        <pin position="51" name="PB12"/>
+        <pin position="52" name="PB13"/>
+        <pin position="53" name="PB14"/>
+        <pin position="54" name="PB15"/>
+        <pin position="55" name="PD8"/>
+        <pin position="56" name="PD9"/>
+        <pin position="57" name="PD10"/>
+        <pin position="58" name="PD11"/>
+        <pin position="59" name="PD12"/>
+        <pin position="60" name="PD13"/>
+        <pin position="61" name="PD14"/>
+        <pin position="62" name="PD15"/>
+        <pin position="63" name="PC6"/>
+        <pin position="64" name="PC7"/>
+        <pin position="65" name="PC8"/>
+        <pin position="66" name="PC9"/>
+        <pin position="67" name="PA8"/>
+        <pin position="68" name="PA9"/>
+        <pin position="69" name="PA10"/>
+        <pin position="70" name="PA11"/>
+        <pin position="71" name="PA12"/>
+        <pin position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="73" name="VDDUSB" type="power"/>
+        <pin position="74" name="VSS" type="power"/>
+        <pin position="75" name="VDD" type="power"/>
+        <pin position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="77" name="PA15 (JTDI)"/>
+        <pin position="78" name="PC10"/>
+        <pin position="79" name="PC11"/>
+        <pin position="80" name="PC12"/>
+        <pin position="81" name="PD0"/>
+        <pin position="82" name="PD1"/>
+        <pin position="83" name="PD2"/>
+        <pin position="84" name="PD3"/>
+        <pin position="85" name="PD4"/>
+        <pin position="86" name="PD5"/>
+        <pin position="87" name="PD6"/>
+        <pin position="88" name="PD7"/>
+        <pin position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="90" name="PB4 (NJTRST)"/>
+        <pin position="91" name="PB5"/>
+        <pin position="92" name="PB6"/>
+        <pin position="93" name="PB7"/>
+        <pin position="94" name="PH3-BOOT0"/>
+        <pin position="95" name="PB8"/>
+        <pin position="96" name="PB9"/>
+        <pin position="97" name="PE0"/>
+        <pin position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin position="20" name="PF8"/>
+        <pin position="21" name="PF9"/>
+        <pin position="22" name="PF10"/>
+        <pin position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="25" name="NRST" type="reset"/>
+        <pin position="26" name="PC0"/>
+        <pin position="27" name="PC1"/>
+        <pin position="28" name="PC2"/>
+        <pin position="29" name="PC3"/>
+        <pin position="30" name="VSSA" type="power"/>
+        <pin position="31" name="VREF-" type="power"/>
+        <pin position="32" name="VREF+" type="monoio"/>
+        <pin position="33" name="VDDA" type="power"/>
+        <pin position="34" name="PA0"/>
+        <pin position="35" name="PA1"/>
+        <pin position="36" name="PA2"/>
+        <pin position="37" name="PA3"/>
+        <pin position="38" name="VSS" type="power"/>
+        <pin position="39" name="VDD" type="power"/>
+        <pin position="40" name="PA4"/>
+        <pin position="41" name="PA5"/>
+        <pin position="42" name="PA6"/>
+        <pin position="43" name="PA7"/>
+        <pin position="44" name="PC4"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB0"/>
+        <pin position="47" name="PB1"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PF11"/>
+        <pin position="50" name="PF12"/>
+        <pin position="51" name="VSS" type="power"/>
+        <pin position="52" name="VDD" type="power"/>
+        <pin position="53" name="PF13"/>
+        <pin position="54" name="PF14"/>
+        <pin position="55" name="PF15"/>
+        <pin position="56" name="PG0"/>
+        <pin position="57" name="PG1"/>
+        <pin position="58" name="PE7"/>
+        <pin position="59" name="PE8"/>
+        <pin position="60" name="PE9"/>
+        <pin position="61" name="VSS" type="power"/>
+        <pin position="62" name="VDD" type="power"/>
+        <pin position="63" name="PE10"/>
+        <pin position="64" name="PE11"/>
+        <pin position="65" name="PE12"/>
+        <pin position="66" name="PE13"/>
+        <pin position="67" name="PE14"/>
+        <pin position="68" name="PE15"/>
+        <pin position="69" name="PB10"/>
+        <pin position="70" name="PB11"/>
+        <pin position="71" name="VSS" type="power"/>
+        <pin position="72" name="VDD" type="power"/>
+        <pin position="73" name="PB12"/>
+        <pin position="74" name="PB13"/>
+        <pin position="75" name="PB14"/>
+        <pin position="76" name="PB15"/>
+        <pin position="77" name="PD8"/>
+        <pin position="78" name="PD9"/>
+        <pin position="79" name="PD10"/>
+        <pin position="80" name="PD11"/>
+        <pin position="81" name="PD12"/>
+        <pin position="82" name="PD13"/>
+        <pin position="83" name="VSS" type="power"/>
+        <pin position="84" name="VDD" type="power"/>
+        <pin position="85" name="PD14"/>
+        <pin position="86" name="PD15"/>
+        <pin position="87" name="PG2"/>
+        <pin position="88" name="PG3"/>
+        <pin position="89" name="PG4"/>
+        <pin position="90" name="PG5"/>
+        <pin position="91" name="PG6"/>
+        <pin position="92" name="PG7"/>
+        <pin position="93" name="PG8"/>
+        <pin position="94" name="VSS" type="power"/>
+        <pin position="95" name="VDDIO2" type="power"/>
+        <pin position="96" name="PC6"/>
+        <pin position="97" name="PC7"/>
+        <pin position="98" name="PC8"/>
+        <pin position="99" name="PC9"/>
+        <pin position="100" name="PA8"/>
+        <pin position="101" name="PA9"/>
+        <pin position="102" name="PA10"/>
+        <pin position="103" name="PA11"/>
+        <pin position="104" name="PA12"/>
+        <pin position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="106" name="VDDUSB" type="power"/>
+        <pin position="107" name="VSS" type="power"/>
+        <pin position="108" name="VDD" type="power"/>
+        <pin position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="110" name="PA15 (JTDI)"/>
+        <pin position="111" name="PC10"/>
+        <pin position="112" name="PC11"/>
+        <pin position="113" name="PC12"/>
+        <pin position="114" name="PD0"/>
+        <pin position="115" name="PD1"/>
+        <pin position="116" name="PD2"/>
+        <pin position="117" name="PD3"/>
+        <pin position="118" name="PD4"/>
+        <pin position="119" name="PD5"/>
+        <pin position="120" name="VSS" type="power"/>
+        <pin position="121" name="VDD" type="power"/>
+        <pin position="122" name="PD6"/>
+        <pin position="123" name="PD7"/>
+        <pin position="124" name="PG9"/>
+        <pin position="125" name="PG10"/>
+        <pin position="126" name="PG11"/>
+        <pin position="127" name="PG12"/>
+        <pin position="128" name="PG13"/>
+        <pin position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="PH3-BOOT0"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="c" device-package="t" name="LQFP48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="LQFP64">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="PC0"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="PC2"/>
+        <pin position="11" name="PC3"/>
+        <pin position="12" name="VSSA/VREF-" type="power"/>
+        <pin position="13" name="VDDA/VREF+" type="power"/>
+        <pin position="14" name="PA0"/>
+        <pin position="15" name="PA1"/>
+        <pin position="16" name="PA2"/>
+        <pin position="17" name="PA3"/>
+        <pin position="18" name="VSS" type="power"/>
+        <pin position="19" name="VDD" type="power"/>
+        <pin position="20" name="PA4"/>
+        <pin position="21" name="PA5"/>
+        <pin position="22" name="PA6"/>
+        <pin position="23" name="PA7"/>
+        <pin position="24" name="PC4"/>
+        <pin position="25" name="PC5"/>
+        <pin position="26" name="PB0"/>
+        <pin position="27" name="PB1"/>
+        <pin position="28" name="PB2"/>
+        <pin position="29" name="PB10"/>
+        <pin position="30" name="PB11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDD" type="power"/>
+        <pin position="33" name="PB12"/>
+        <pin position="34" name="PB13"/>
+        <pin position="35" name="PB14"/>
+        <pin position="36" name="PB15"/>
+        <pin position="37" name="PC6"/>
+        <pin position="38" name="PC7"/>
+        <pin position="39" name="PC8"/>
+        <pin position="40" name="PC9"/>
+        <pin position="41" name="PA8"/>
+        <pin position="42" name="PA9"/>
+        <pin position="43" name="PA10"/>
+        <pin position="44" name="PA11"/>
+        <pin position="45" name="PA12"/>
+        <pin position="46" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDDUSB" type="power"/>
+        <pin position="49" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="50" name="PA15 (JTDI)"/>
+        <pin position="51" name="PC10"/>
+        <pin position="52" name="PC11"/>
+        <pin position="53" name="PC12"/>
+        <pin position="54" name="PD2"/>
+        <pin position="55" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="56" name="PB4 (NJTRST)"/>
+        <pin position="57" name="PB5"/>
+        <pin position="58" name="PB6"/>
+        <pin position="59" name="PB7"/>
+        <pin position="60" name="PH3-BOOT0"/>
+        <pin position="61" name="PB8"/>
+        <pin position="62" name="PB9"/>
+        <pin position="63" name="VSS" type="power"/>
+        <pin position="64" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PI10"/>
+        <pin position="A2" name="PH2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PI0"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PI9"/>
+        <pin position="B2" name="PI7"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PG9"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PI6"/>
+        <pin position="B10" name="PI2"/>
+        <pin position="B11" name="PI1"/>
+        <pin position="B12" name="PH15"/>
+        <pin position="B13" name="PH12"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI11"/>
+        <pin position="C4" name="PB8"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PG15"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD1"/>
+        <pin position="C9" name="PH13"/>
+        <pin position="C10" name="PI3"/>
+        <pin position="C11" name="PI8"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="PE4"/>
+        <pin position="D2" name="PE3"/>
+        <pin position="D3" name="PE2"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB7"/>
+        <pin position="D6" name="PG10"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC10"/>
+        <pin position="D10" name="PI4"/>
+        <pin position="D11" name="PH9"/>
+        <pin position="D12" name="PH7"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="PC13"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PH3-BOOT0"/>
+        <pin position="E6" name="PG11"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PD3"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PI5"/>
+        <pin position="E11" name="PH6"/>
+        <pin position="E12" name="VDDUSB" type="power"/>
+        <pin position="E13" name="PA11"/>
+        <pin position="F1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF2"/>
+        <pin position="F4" name="PF1"/>
+        <pin position="F5" name="PF0"/>
+        <pin position="F6" name="PG12"/>
+        <pin position="F7" name="PD7"/>
+        <pin position="F8" name="PC12"/>
+        <pin position="F9" name="PA10"/>
+        <pin position="F10" name="PA9"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDDIO2" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF3"/>
+        <pin position="G4" name="PF4"/>
+        <pin position="G5" name="PF5"/>
+        <pin position="G6" name="PG14"/>
+        <pin position="G7" name="PG13"/>
+        <pin position="G8" name="PA8"/>
+        <pin position="G9" name="PC9"/>
+        <pin position="G10" name="PC8"/>
+        <pin position="G11" name="PG6"/>
+        <pin position="G12" name="PC7"/>
+        <pin position="G13" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="NRST" type="reset"/>
+        <pin position="H4" name="PF10"/>
+        <pin position="H5" name="PC4"/>
+        <pin position="H6" name="PG1"/>
+        <pin position="H7" name="PE10"/>
+        <pin position="H8" name="PB11"/>
+        <pin position="H9" name="PG8"/>
+        <pin position="H10" name="PG7"/>
+        <pin position="H11" name="PD15"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PC0"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC2"/>
+        <pin position="J5" name="PC5"/>
+        <pin position="J6" name="PG0"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE15"/>
+        <pin position="J9" name="PG5"/>
+        <pin position="J10" name="PG4"/>
+        <pin position="J11" name="PG3"/>
+        <pin position="J12" name="PG2"/>
+        <pin position="J13" name="PD10"/>
+        <pin position="K1" name="PC3"/>
+        <pin position="K2" name="VSSA/VREF-" type="power"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PB0"/>
+        <pin position="K6" name="PF15"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE14"/>
+        <pin position="K9" name="PH4"/>
+        <pin position="K10" name="PD14"/>
+        <pin position="K11" name="PD12"/>
+        <pin position="K12" name="PD11"/>
+        <pin position="K13" name="PD13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="PA7"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE13"/>
+        <pin position="L9" name="PH5"/>
+        <pin position="L10" name="PD9"/>
+        <pin position="L11" name="PD8"/>
+        <pin position="L12" name="VDD" type="power"/>
+        <pin position="L13" name="VSS" type="power"/>
+        <pin position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin position="M4" name="PA6"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE12"/>
+        <pin position="M9" name="PH10"/>
+        <pin position="M10" name="PH11"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin position="M12" name="PB15"/>
+        <pin position="M13" name="PB14"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PA1"/>
+        <pin position="N3" name="VDD" type="power"/>
+        <pin position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="N5" name="PB2"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PB10"/>
+        <pin position="N10" name="PH8"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB13"/>
+      </package>
+      <package device-package="u" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="4" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="5" name="PH0-OSC_IN (PH0)"/>
+        <pin position="6" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VSSA/VREF-" type="power"/>
+        <pin position="9" name="VDDA/VREF+" type="power"/>
+        <pin position="10" name="PA0"/>
+        <pin position="11" name="PA1"/>
+        <pin position="12" name="PA2"/>
+        <pin position="13" name="PA3"/>
+        <pin position="14" name="PA4"/>
+        <pin position="15" name="PA5"/>
+        <pin position="16" name="PA6"/>
+        <pin position="17" name="PA7"/>
+        <pin position="18" name="PB0"/>
+        <pin position="19" name="PB1"/>
+        <pin position="20" name="PB2"/>
+        <pin position="21" name="PB10"/>
+        <pin position="22" name="PB11"/>
+        <pin position="23" name="VSS" type="power"/>
+        <pin position="24" name="VDD" type="power"/>
+        <pin position="25" name="PB12"/>
+        <pin position="26" name="PB13"/>
+        <pin position="27" name="PB14"/>
+        <pin position="28" name="PB15"/>
+        <pin position="29" name="PA8"/>
+        <pin position="30" name="PA9"/>
+        <pin position="31" name="PA10"/>
+        <pin position="32" name="PA11"/>
+        <pin position="33" name="PA12"/>
+        <pin position="34" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="35" name="VSS" type="power"/>
+        <pin position="36" name="VDDUSB" type="power"/>
+        <pin position="37" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="38" name="PA15 (JTDI)"/>
+        <pin position="39" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="40" name="PB4 (NJTRST)"/>
+        <pin position="41" name="PB5"/>
+        <pin position="42" name="PB6"/>
+        <pin position="43" name="PB7"/>
+        <pin position="44" name="PH3-BOOT0"/>
+        <pin position="45" name="PB8"/>
+        <pin position="46" name="PB9"/>
+        <pin position="47" name="VSS" type="power"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="VDDUSB" type="power"/>
+        <pin position="A2" name="PA15 (JTDI)"/>
+        <pin position="A3" name="PD1"/>
+        <pin position="A4" name="VDD" type="power"/>
+        <pin position="A5" name="PG10"/>
+        <pin position="A6" name="VDDIO2" type="power"/>
+        <pin position="A7" name="PB6"/>
+        <pin position="A8" name="PB9"/>
+        <pin position="A9" name="VSS" type="power"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VSS" type="power"/>
+        <pin position="B2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="B3" name="PD0"/>
+        <pin position="B4" name="PD4"/>
+        <pin position="B5" name="PG9"/>
+        <pin position="B6" name="PG12"/>
+        <pin position="B7" name="PB5"/>
+        <pin position="B8" name="PB8"/>
+        <pin position="B9" name="PE2"/>
+        <pin position="B10" name="PE3"/>
+        <pin position="C1" name="PA12"/>
+        <pin position="C2" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="C3" name="PC11"/>
+        <pin position="C4" name="PC12"/>
+        <pin position="C5" name="PD7"/>
+        <pin position="C6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="C7" name="PB4 (NJTRST)"/>
+        <pin position="C8" name="PE4"/>
+        <pin position="C9" name="PC13"/>
+        <pin position="C10" name="VBAT" type="power"/>
+        <pin position="D1" name="PA11"/>
+        <pin position="D2" name="PA10"/>
+        <pin position="D3" name="PA9"/>
+        <pin position="D4" name="PC10"/>
+        <pin position="D5" name="PD6"/>
+        <pin position="D6" name="PG11"/>
+        <pin position="D7" name="PB7"/>
+        <pin position="D8" name="PE5"/>
+        <pin position="D9" name="VSS" type="power"/>
+        <pin position="D10" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E1" name="PC8"/>
+        <pin position="E2" name="PC9"/>
+        <pin position="E3" name="PA8"/>
+        <pin position="E4" name="PD2"/>
+        <pin position="E5" name="PD5"/>
+        <pin position="E6" name="PH3-BOOT0"/>
+        <pin position="E7" name="PE6"/>
+        <pin position="E8" name="NRST" type="reset"/>
+        <pin position="E9" name="VDD" type="power"/>
+        <pin position="E10" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="F1" name="VDD" type="power"/>
+        <pin position="F2" name="PC6"/>
+        <pin position="F3" name="PC7"/>
+        <pin position="F4" name="PD15"/>
+        <pin position="F5" name="PB2"/>
+        <pin position="F6" name="PA4"/>
+        <pin position="F7" name="PC3"/>
+        <pin position="F8" name="PC1"/>
+        <pin position="F9" name="PC0"/>
+        <pin position="F10" name="PH0-OSC_IN (PH0)"/>
+        <pin position="G1" name="PD10"/>
+        <pin position="G2" name="PD9"/>
+        <pin position="G3" name="PD14"/>
+        <pin position="G4" name="PE13"/>
+        <pin position="G5" name="PE12"/>
+        <pin position="G6" name="PA5"/>
+        <pin position="G7" name="VREF+" type="monoio"/>
+        <pin position="G8" name="VREF-" type="power"/>
+        <pin position="G9" name="PA0"/>
+        <pin position="G10" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H1" name="PB15"/>
+        <pin position="H2" name="PB14"/>
+        <pin position="H3" name="PD8"/>
+        <pin position="H4" name="PE15"/>
+        <pin position="H5" name="PE10"/>
+        <pin position="H6" name="PC4"/>
+        <pin position="H7" name="PA2"/>
+        <pin position="H8" name="PA1"/>
+        <pin position="H9" name="VSSA" type="power"/>
+        <pin position="H10" name="PC2"/>
+        <pin position="J1" name="PB12"/>
+        <pin position="J2" name="PB13"/>
+        <pin position="J3" name="PB11"/>
+        <pin position="J4" name="PE14"/>
+        <pin position="J5" name="PE9"/>
+        <pin position="J6" name="PB0"/>
+        <pin position="J7" name="PA7"/>
+        <pin position="J8" name="VDD" type="power"/>
+        <pin position="J9" name="PA3"/>
+        <pin position="J10" name="VDDA" type="power"/>
+        <pin position="K1" name="VDD" type="power"/>
+        <pin position="K2" name="VSS" type="power"/>
+        <pin position="K3" name="PB10"/>
+        <pin position="K4" name="PE11"/>
+        <pin position="K5" name="PE8"/>
+        <pin position="K6" name="PE7"/>
+        <pin position="K7" name="PB1"/>
+        <pin position="K8" name="PC5"/>
+        <pin position="K9" name="PA6"/>
+        <pin position="K10" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-r5_r7_r9.xml
+++ b/devices/stm32/stm32l4-r5_r7_r9.xml
@@ -1807,6 +1807,1489 @@
       <gpio device-pin="a" port="i" pin="11">
         <signal af="5" driver="octospim" name="p2_io0"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin device-name="r9" device-size="g|i" position="19" name="VSSA/VREF-" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="19" name="VSSA" type="power"/>
+        <pin device-name="r7" device-size="i" position="19" name="VSSA" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="20" name="VDDA/VREF+" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="20" name="VREF-" type="power"/>
+        <pin device-name="r7" device-size="i" position="20" name="VREF-" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="21" name="PA0"/>
+        <pin device-name="r5" device-size="g|i" position="21" name="VREF+" type="monoio"/>
+        <pin device-name="r7" device-size="i" position="21" name="VREF+" type="monoio"/>
+        <pin device-name="r9" device-size="g|i" position="22" name="PA1"/>
+        <pin device-name="r5" device-size="g|i" position="22" name="VDDA" type="power"/>
+        <pin device-name="r7" device-size="i" position="22" name="VDDA" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="23" name="PA2"/>
+        <pin device-name="r5" device-size="g|i" position="23" name="PA0"/>
+        <pin device-name="r7" device-size="i" position="23" name="PA0"/>
+        <pin device-name="r9" device-size="g|i" position="24" name="PA3"/>
+        <pin device-name="r5" device-size="g|i" position="24" name="PA1"/>
+        <pin device-name="r7" device-size="i" position="24" name="PA1"/>
+        <pin device-name="r9" device-size="g|i" position="25" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="25" name="PA2"/>
+        <pin device-name="r7" device-size="i" position="25" name="PA2"/>
+        <pin device-name="r9" device-size="g|i" position="26" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="26" name="PA3"/>
+        <pin device-name="r7" device-size="i" position="26" name="PA3"/>
+        <pin device-name="r9" device-size="g|i" position="27" name="PA4"/>
+        <pin device-name="r5" device-size="g|i" position="27" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" position="27" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="28" name="PA5"/>
+        <pin device-name="r5" device-size="g|i" position="28" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" position="28" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="29" name="PA6"/>
+        <pin device-name="r5" device-size="g|i" position="29" name="PA4"/>
+        <pin device-name="r7" device-size="i" position="29" name="PA4"/>
+        <pin device-name="r9" device-size="g|i" position="30" name="PA7"/>
+        <pin device-name="r5" device-size="g|i" position="30" name="PA5"/>
+        <pin device-name="r7" device-size="i" position="30" name="PA5"/>
+        <pin device-name="r9" device-size="g|i" position="31" name="PC4"/>
+        <pin device-name="r5" device-size="g|i" position="31" name="PA6"/>
+        <pin device-name="r7" device-size="i" position="31" name="PA6"/>
+        <pin device-name="r9" device-size="g|i" position="32" name="PB0"/>
+        <pin device-name="r5" device-size="g|i" position="32" name="PA7"/>
+        <pin device-name="r7" device-size="i" position="32" name="PA7"/>
+        <pin device-name="r9" device-size="g|i" position="33" name="PB1"/>
+        <pin device-name="r5" device-size="g|i" position="33" name="PC4"/>
+        <pin device-name="r7" device-size="i" position="33" name="PC4"/>
+        <pin device-name="r9" device-size="g|i" position="34" name="PB2"/>
+        <pin device-name="r5" device-size="g|i" position="34" name="PC5"/>
+        <pin device-name="r7" device-size="i" position="34" name="PC5"/>
+        <pin device-name="r9" device-size="g|i" position="35" name="PE7"/>
+        <pin device-name="r5" device-size="g|i" position="35" name="PB0"/>
+        <pin device-name="r7" device-size="i" position="35" name="PB0"/>
+        <pin device-name="r9" device-size="g|i" position="36" name="PE8"/>
+        <pin device-name="r5" device-size="g|i" position="36" name="PB1"/>
+        <pin device-name="r7" device-size="i" position="36" name="PB1"/>
+        <pin device-name="r9" device-size="g|i" position="37" name="PE9"/>
+        <pin device-name="r5" device-size="g|i" position="37" name="PB2"/>
+        <pin device-name="r7" device-size="i" position="37" name="PB2"/>
+        <pin device-name="r9" device-size="g|i" position="38" name="PE10"/>
+        <pin device-name="r5" device-size="g|i" position="38" name="PE7"/>
+        <pin device-name="r7" device-size="i" position="38" name="PE7"/>
+        <pin device-name="r9" device-size="g|i" position="39" name="PE11"/>
+        <pin device-name="r5" device-size="g|i" position="39" name="PE8"/>
+        <pin device-name="r7" device-size="i" position="39" name="PE8"/>
+        <pin device-name="r9" device-size="g|i" position="40" name="PE12"/>
+        <pin device-name="r5" device-size="g|i" position="40" name="PE9"/>
+        <pin device-name="r7" device-size="i" position="40" name="PE9"/>
+        <pin device-name="r9" device-size="g|i" position="41" name="PE13"/>
+        <pin device-name="r5" device-size="g|i" position="41" name="PE10"/>
+        <pin device-name="r7" device-size="i" position="41" name="PE10"/>
+        <pin device-name="r9" device-size="g|i" position="42" name="PE14"/>
+        <pin device-name="r5" device-size="g|i" position="42" name="PE11"/>
+        <pin device-name="r7" device-size="i" position="42" name="PE11"/>
+        <pin device-name="r9" device-size="g|i" position="43" name="PE15"/>
+        <pin device-name="r5" device-size="g|i" position="43" name="PE12"/>
+        <pin device-name="r7" device-size="i" position="43" name="PE12"/>
+        <pin device-name="r9" device-size="g|i" position="44" name="PB10"/>
+        <pin device-name="r5" device-size="g|i" position="44" name="PE13"/>
+        <pin device-name="r7" device-size="i" position="44" name="PE13"/>
+        <pin device-name="r9" device-size="g|i" position="45" name="PB11"/>
+        <pin device-name="r5" device-size="g|i" position="45" name="PE14"/>
+        <pin device-name="r7" device-size="i" position="45" name="PE14"/>
+        <pin device-name="r9" device-size="g|i" position="46" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="46" name="PE15"/>
+        <pin device-name="r7" device-size="i" position="46" name="PE15"/>
+        <pin device-name="r9" device-size="g|i" position="47" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="47" name="PB10"/>
+        <pin device-name="r7" device-size="i" position="47" name="PB10"/>
+        <pin device-name="r9" device-size="g|i" position="48" name="PB12"/>
+        <pin device-name="r5" device-size="g|i" position="48" name="PB11"/>
+        <pin device-name="r7" device-size="i" position="48" name="PB11"/>
+        <pin device-name="r9" device-size="g|i" position="49" name="PB13"/>
+        <pin device-name="r5" device-size="g|i" position="49" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" position="49" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="50" name="PB14"/>
+        <pin device-name="r5" device-size="g|i" position="50" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" position="50" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="51" name="PB15"/>
+        <pin device-name="r5" device-size="g|i" position="51" name="PB12"/>
+        <pin device-name="r7" device-size="i" position="51" name="PB12"/>
+        <pin device-name="r9" device-size="g|i" position="52" name="VDDDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="52" name="PB13"/>
+        <pin device-name="r7" device-size="i" position="52" name="PB13"/>
+        <pin device-name="r9" device-size="g|i" position="53" name="VCAPDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="53" name="PB14"/>
+        <pin device-name="r7" device-size="i" position="53" name="PB14"/>
+        <pin device-name="r9" device-size="g|i" position="54" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="54" name="PB15"/>
+        <pin device-name="r7" device-size="i" position="54" name="PB15"/>
+        <pin device-name="r9" device-size="g|i" position="55" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="55" name="PD8"/>
+        <pin device-name="r7" device-size="i" position="55" name="PD8"/>
+        <pin device-name="r9" device-size="g|i" position="56" name="VSSDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="56" name="PD9"/>
+        <pin device-name="r7" device-size="i" position="56" name="PD9"/>
+        <pin device-name="r9" device-size="g|i" position="57" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="57" name="PD10"/>
+        <pin device-name="r7" device-size="i" position="57" name="PD10"/>
+        <pin device-name="r9" device-size="g|i" position="58" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="58" name="PD11"/>
+        <pin device-name="r7" device-size="i" position="58" name="PD11"/>
+        <pin device-name="r9" device-size="g|i" position="59" name="VDD12DSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="59" name="PD12"/>
+        <pin device-name="r7" device-size="i" position="59" name="PD12"/>
+        <pin device-name="r9" device-size="g|i" position="60" name="PD8"/>
+        <pin device-name="r5" device-size="g|i" position="60" name="PD13"/>
+        <pin device-name="r7" device-size="i" position="60" name="PD13"/>
+        <pin device-name="r9" device-size="g|i" position="61" name="PD9"/>
+        <pin device-name="r5" device-size="g|i" position="61" name="PD14"/>
+        <pin device-name="r7" device-size="i" position="61" name="PD14"/>
+        <pin device-name="r9" device-size="g|i" position="62" name="PD10"/>
+        <pin device-name="r5" device-size="g|i" position="62" name="PD15"/>
+        <pin device-name="r7" device-size="i" position="62" name="PD15"/>
+        <pin device-name="r9" device-size="g|i" position="63" name="PD14"/>
+        <pin device-name="r5" device-size="g|i" position="63" name="PC6"/>
+        <pin device-name="r7" device-size="i" position="63" name="PC6"/>
+        <pin device-name="r9" device-size="g|i" position="64" name="PD15"/>
+        <pin device-name="r5" device-size="g|i" position="64" name="PC7"/>
+        <pin device-name="r7" device-size="i" position="64" name="PC7"/>
+        <pin device-name="r9" device-size="g|i" position="65" name="PC6"/>
+        <pin device-name="r5" device-size="g|i" position="65" name="PC8"/>
+        <pin device-name="r7" device-size="i" position="65" name="PC8"/>
+        <pin device-name="r9" device-size="g|i" position="66" name="PC7"/>
+        <pin device-name="r5" device-size="g|i" position="66" name="PC9"/>
+        <pin device-name="r7" device-size="i" position="66" name="PC9"/>
+        <pin device-name="r9" device-size="g|i" position="67" name="PC8"/>
+        <pin device-name="r5" device-size="g|i" position="67" name="PA8"/>
+        <pin device-name="r7" device-size="i" position="67" name="PA8"/>
+        <pin device-name="r9" device-size="g|i" position="68" name="PC9"/>
+        <pin device-name="r5" device-size="g|i" position="68" name="PA9"/>
+        <pin device-name="r7" device-size="i" position="68" name="PA9"/>
+        <pin device-name="r9" device-size="g|i" position="69" name="PA8"/>
+        <pin device-name="r5" device-size="g|i" position="69" name="PA10"/>
+        <pin device-name="r7" device-size="i" position="69" name="PA10"/>
+        <pin device-name="r9" device-size="g|i" position="70" name="PA9"/>
+        <pin device-name="r5" device-size="g|i" position="70" name="PA11"/>
+        <pin device-name="r7" device-size="i" position="70" name="PA11"/>
+        <pin device-name="r9" device-size="g|i" position="71" name="PA10"/>
+        <pin device-name="r5" device-size="g|i" position="71" name="PA12"/>
+        <pin device-name="r7" device-size="i" position="71" name="PA12"/>
+        <pin device-name="r9" device-size="g|i" position="72" name="PA11"/>
+        <pin device-name="r5" device-size="g|i" position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r7" device-size="i" position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r9" device-size="g|i" position="73" name="PA12"/>
+        <pin device-name="r5" device-size="g|i" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="r7" device-size="i" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="74" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r5" device-size="g|i" position="74" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" position="74" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="75" name="VDDUSB" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="75" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" position="75" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="76" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r7" device-size="i" position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r9" device-size="g|i" position="77" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="77" name="PA15 (JTDI)"/>
+        <pin device-name="r7" device-size="i" position="77" name="PA15 (JTDI)"/>
+        <pin device-name="r9" device-size="g|i" position="78" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r5" device-size="g|i" position="78" name="PC10"/>
+        <pin device-name="r7" device-size="i" position="78" name="PC10"/>
+        <pin device-name="r9" device-size="g|i" position="79" name="PA15 (JTDI)"/>
+        <pin device-name="r5" device-size="g|i" position="79" name="PC11"/>
+        <pin device-name="r7" device-size="i" position="79" name="PC11"/>
+        <pin device-name="r9" device-size="g|i" position="80" name="PC10"/>
+        <pin device-name="r5" device-size="g|i" position="80" name="PC12"/>
+        <pin device-name="r7" device-size="i" position="80" name="PC12"/>
+        <pin device-name="r9" device-size="g|i" position="81" name="PC11"/>
+        <pin device-name="r5" device-size="g|i" position="81" name="PD0"/>
+        <pin device-name="r7" device-size="i" position="81" name="PD0"/>
+        <pin device-name="r9" device-size="g|i" position="82" name="PC12"/>
+        <pin device-name="r5" device-size="g|i" position="82" name="PD1"/>
+        <pin device-name="r7" device-size="i" position="82" name="PD1"/>
+        <pin device-name="r9" device-size="g|i" position="83" name="PD0"/>
+        <pin device-name="r5" device-size="g|i" position="83" name="PD2"/>
+        <pin device-name="r7" device-size="i" position="83" name="PD2"/>
+        <pin device-name="r9" device-size="g|i" position="84" name="PD1"/>
+        <pin device-name="r5" device-size="g|i" position="84" name="PD3"/>
+        <pin device-name="r7" device-size="i" position="84" name="PD3"/>
+        <pin device-name="r9" device-size="g|i" position="85" name="PD2"/>
+        <pin device-name="r5" device-size="g|i" position="85" name="PD4"/>
+        <pin device-name="r7" device-size="i" position="85" name="PD4"/>
+        <pin device-name="r9" device-size="g|i" position="86" name="PD3"/>
+        <pin device-name="r5" device-size="g|i" position="86" name="PD5"/>
+        <pin device-name="r7" device-size="i" position="86" name="PD5"/>
+        <pin device-name="r9" device-size="g|i" position="87" name="PD4"/>
+        <pin device-name="r5" device-size="g|i" position="87" name="PD6"/>
+        <pin device-name="r7" device-size="i" position="87" name="PD6"/>
+        <pin device-name="r9" device-size="g|i" position="88" name="PD5"/>
+        <pin device-name="r5" device-size="g|i" position="88" name="PD7"/>
+        <pin device-name="r7" device-size="i" position="88" name="PD7"/>
+        <pin device-name="r9" device-size="g|i" position="89" name="PD6"/>
+        <pin device-name="r5" device-size="g|i" position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r7" device-size="i" position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r9" device-size="g|i" position="90" name="PD7"/>
+        <pin device-name="r5" device-size="g|i" position="90" name="PB4 (NJTRST)"/>
+        <pin device-name="r7" device-size="i" position="90" name="PB4 (NJTRST)"/>
+        <pin device-name="r9" device-size="g|i" position="91" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r5" device-size="g|i" position="91" name="PB5"/>
+        <pin device-name="r7" device-size="i" position="91" name="PB5"/>
+        <pin device-name="r9" device-size="g|i" position="92" name="PB4 (NJTRST)"/>
+        <pin device-name="r5" device-size="g|i" position="92" name="PB6"/>
+        <pin device-name="r7" device-size="i" position="92" name="PB6"/>
+        <pin device-name="r9" device-size="g|i" position="93" name="PB5"/>
+        <pin device-name="r5" device-size="g|i" position="93" name="PB7"/>
+        <pin device-name="r7" device-size="i" position="93" name="PB7"/>
+        <pin device-name="r9" device-size="g|i" position="94" name="PB6"/>
+        <pin device-name="r5" device-size="g|i" position="94" name="PH3-BOOT0"/>
+        <pin device-name="r7" device-size="i" position="94" name="PH3-BOOT0"/>
+        <pin device-name="r9" device-size="g|i" position="95" name="PB7"/>
+        <pin device-name="r5" device-size="g|i" position="95" name="PB8"/>
+        <pin device-name="r7" device-size="i" position="95" name="PB8"/>
+        <pin device-name="r9" device-size="g|i" position="96" name="PH3-BOOT0"/>
+        <pin device-name="r5" device-size="g|i" position="96" name="PB9"/>
+        <pin device-name="r7" device-size="i" position="96" name="PB9"/>
+        <pin device-name="r9" device-size="g|i" position="97" name="PB8"/>
+        <pin device-name="r5" device-size="g|i" position="97" name="PE0"/>
+        <pin device-name="r7" device-size="i" position="97" name="PE0"/>
+        <pin device-name="r9" device-size="g|i" position="98" name="PB9"/>
+        <pin device-name="r5" device-size="g|i" position="98" name="PE1"/>
+        <pin device-name="r7" device-size="i" position="98" name="PE1"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="20" name="PF10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="20" name="PF8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="20" name="PF8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="20" name="PF8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="21" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="21" name="PF9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="21" name="PF9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="21" name="PF9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="22" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="22" name="PF10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="22" name="PF10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="22" name="PF10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="23" name="NRST" type="reset"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="24" name="PC0"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="25" name="PC1"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="25" name="NRST" type="reset"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="25" name="NRST" type="reset"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="25" name="NRST" type="reset"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="26" name="PC2"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="26" name="PC0"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="26" name="PC0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="26" name="PC0"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="27" name="PC3"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="27" name="PC1"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="27" name="PC1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="27" name="PC1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="28" name="VSSA/VREF-" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="28" name="PC2"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="28" name="PC2"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="28" name="PC2"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="29" name="VREF+" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="29" name="PC3"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="29" name="PC3"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="29" name="PC3"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="30" name="VDDA" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="30" name="VSSA" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="30" name="VSSA" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="30" name="VSSA" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="31" name="PA0"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="31" name="VREF-" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="31" name="VREF-" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="31" name="VREF-" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="32" name="PA1"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="32" name="VREF+" type="monoio"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="32" name="VREF+" type="monoio"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="32" name="VREF+" type="monoio"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="33" name="PA2"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="33" name="VDDA" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="33" name="VDDA" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="33" name="VDDA" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="34" name="PA3"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="34" name="PA0"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="34" name="PA0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="34" name="PA0"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="35" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="35" name="PA1"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="35" name="PA1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="35" name="PA1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="36" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="36" name="PA2"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="36" name="PA2"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="36" name="PA2"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="37" name="PA4"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="37" name="PA3"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="37" name="PA3"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="37" name="PA3"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="38" name="PA5"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="38" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="38" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="38" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="39" name="PA6"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="39" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="39" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="39" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="40" name="PA7"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="40" name="PA4"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="40" name="PA4"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="40" name="PA4"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="41" name="PC4"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="41" name="PA5"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="41" name="PA5"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="41" name="PA5"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="42" name="PB0"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="42" name="PA6"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="42" name="PA6"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="42" name="PA6"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="43" name="PB1"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="43" name="PA7"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="43" name="PA7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="43" name="PA7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="44" name="PB2"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="44" name="PC4"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="44" name="PC4"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="44" name="PC4"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="45" name="PF11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="45" name="PC5"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="45" name="PC5"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="45" name="PC5"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="46" name="PF12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="46" name="PB0"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="46" name="PB0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="46" name="PB0"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="47" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="47" name="PB1"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="47" name="PB1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="47" name="PB1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="48" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="48" name="PB2"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="48" name="PB2"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="48" name="PB2"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="49" name="PF13"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="49" name="PF11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="49" name="PF11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="49" name="PF11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="50" name="PF14"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="50" name="PF12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="50" name="PF12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="50" name="PF12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="51" name="PF15"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="51" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="51" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="51" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="52" name="PG0"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="52" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="52" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="52" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="53" name="PG1"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="53" name="PF13"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="53" name="PF13"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="53" name="PF13"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="54" name="PE7"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="54" name="PF14"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="54" name="PF14"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="54" name="PF14"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="55" name="PE8"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="55" name="PF15"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="55" name="PF15"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="55" name="PF15"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="56" name="PE9"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="56" name="PG0"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="56" name="PG0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="56" name="PG0"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="57" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="57" name="PG1"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="57" name="PG1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="57" name="PG1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="58" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="58" name="PE7"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="58" name="PE7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="58" name="PE7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="59" name="PE10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="59" name="PE8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="59" name="PE8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="59" name="PE8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="60" name="PE11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="60" name="PE9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="60" name="PE9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="60" name="PE9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="61" name="PE12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="61" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="61" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="62" name="PE13"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="62" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="62" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="63" name="PE14"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="63" name="PE10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="63" name="PE10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="63" name="PE10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="64" name="PE15"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="64" name="PE11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="64" name="PE11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="64" name="PE11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="65" name="PB10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="65" name="PE12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="65" name="PE12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="65" name="PE12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="66" name="PB11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="66" name="PE13"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="66" name="PE13"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="66" name="PE13"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="67" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="67" name="PE14"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="67" name="PE14"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="67" name="PE14"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="68" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="68" name="PE15"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="68" name="PE15"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="68" name="PE15"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="69" name="PB12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="69" name="PB10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="69" name="PB10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="69" name="PB10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="70" name="PB13"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="70" name="PB11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="70" name="PB11"/>
+        <pin device-name="r5" device-variant="p" position="70" name="VDD12" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="71" name="PB14"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="71" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="71" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="71" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="72" name="PB15"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="72" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="72" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="73" name="VDDDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="73" name="PB12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="73" name="PB12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="73" name="PB12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="74" name="VCAPDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="74" name="PB13"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="74" name="PB13"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="74" name="PB13"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="75" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="75" name="PB14"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="75" name="PB14"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="75" name="PB14"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="76" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="76" name="PB15"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="76" name="PB15"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="76" name="PB15"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="77" name="VSSDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="77" name="PD8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="77" name="PD8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="77" name="PD8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="78" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="78" name="PD9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="78" name="PD9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="78" name="PD9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="79" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="79" name="PD10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="79" name="PD10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="79" name="PD10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="80" name="VDD12DSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="80" name="PD11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="80" name="PD11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="80" name="PD11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="81" name="PD8"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="81" name="PD12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="81" name="PD12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="81" name="PD12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="82" name="PD9"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="82" name="PD13"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="82" name="PD13"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="82" name="PD13"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="83" name="PD10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="83" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="83" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="83" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="84" name="PD11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="84" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="84" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="84" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="85" name="PD12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="85" name="PD14"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="85" name="PD14"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="85" name="PD14"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="86" name="PD13"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="86" name="PD15"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="86" name="PD15"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="86" name="PD15"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="87" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="87" name="PG2"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="87" name="PG2"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="87" name="PG2"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="88" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="88" name="PG3"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="88" name="PG3"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="88" name="PG3"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="89" name="PD14"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="89" name="PG4"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="89" name="PG4"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="89" name="PG4"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="90" name="PD15"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="90" name="PG5"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="90" name="PG5"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="90" name="PG5"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="91" name="PG2"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="91" name="PG6"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="91" name="PG6"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="91" name="PG6"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="92" name="PG3"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="92" name="PG7"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="92" name="PG7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="92" name="PG7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="93" name="PG4"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="93" name="PG8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="93" name="PG8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="93" name="PG8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="94" name="PG5"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="94" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="94" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="94" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="95" name="PG6"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="95" name="VDDIO2" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="95" name="VDDIO2" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="95" name="VDDIO2" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="96" name="PG7"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="96" name="PC6"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="96" name="PC6"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="96" name="PC6"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="97" name="PG8"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="97" name="PC7"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="97" name="PC7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="97" name="PC7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="98" name="PC6"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="98" name="PC8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="98" name="PC8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="98" name="PC8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="99" name="PC7"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="99" name="PC9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="99" name="PC9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="99" name="PC9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="100" name="PC8"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="100" name="PA8"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="100" name="PA8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="100" name="PA8"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="101" name="PC9"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="101" name="PA9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="101" name="PA9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="101" name="PA9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="102" name="PA8"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="102" name="PA10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="102" name="PA10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="102" name="PA10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="103" name="PA9"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="103" name="PA11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="103" name="PA11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="103" name="PA11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="104" name="PA10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="104" name="PA12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="104" name="PA12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="104" name="PA12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="105" name="PA11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="106" name="PA12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="106" name="VDDUSB" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="106" name="VDDUSB" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="106" name="VDDUSB" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="107" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="107" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="107" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="107" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="108" name="VDDUSB" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="108" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="108" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="108" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="109" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="110" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="110" name="PA15 (JTDI)"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="110" name="PA15 (JTDI)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="110" name="PA15 (JTDI)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="111" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="111" name="PC10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="111" name="PC10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="111" name="PC10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="112" name="PA15 (JTDI)"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="112" name="PC11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="112" name="PC11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="112" name="PC11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="113" name="PC10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="113" name="PC12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="113" name="PC12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="113" name="PC12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="114" name="PC11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="114" name="PD0"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="114" name="PD0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="114" name="PD0"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="115" name="PC12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="115" name="PD1"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="115" name="PD1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="115" name="PD1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="116" name="PD0"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="116" name="PD2"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="116" name="PD2"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="116" name="PD2"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="117" name="PD1"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="117" name="PD3"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="117" name="PD3"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="117" name="PD3"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="118" name="PD2"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="118" name="PD4"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="118" name="PD4"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="118" name="PD4"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="119" name="PD3"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="119" name="PD5"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="119" name="PD5"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="119" name="PD5"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="120" name="PD4"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="120" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="120" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="120" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="121" name="PD5"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="121" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="121" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="121" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="122" name="VSS" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="122" name="PD6"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="122" name="PD6"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="122" name="PD6"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="123" name="VDD" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="123" name="PD7"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="123" name="PD7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="123" name="PD7"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="124" name="PD6"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="124" name="PG9"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="124" name="PG9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="124" name="PG9"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="125" name="PD7"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="125" name="PG10"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="125" name="PG10"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="125" name="PG10"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="126" name="PG9"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="126" name="PG11"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="126" name="PG11"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="126" name="PG11"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="127" name="PG10"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="127" name="PG12"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="127" name="PG12"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="127" name="PG12"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="128" name="PG11"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="128" name="PG13"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="128" name="PG13"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="128" name="PG13"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="129" name="PG12"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="129" name="PG14"/>
+        <pin device-name="r5" device-size="i" device-variant="p" position="129" name="PG14"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="129" name="PG14"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="132" name="PG15"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="132" name="PG15"/>
+        <pin device-name="r5" device-variant="p" position="132" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="r5" device-variant="p" position="133" name="PB4 (NJTRST)"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="134" name="PB4 (NJTRST)"/>
+        <pin device-name="r5" device-variant="p" position="134" name="PB5"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="135" name="PB5"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="135" name="PB5"/>
+        <pin device-name="r5" device-variant="p" position="135" name="PB6"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="136" name="PB6"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="136" name="PB6"/>
+        <pin device-name="r5" device-variant="p" position="136" name="PB7"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="137" name="PB7"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="137" name="PB7"/>
+        <pin device-name="r5" device-variant="p" position="137" name="PH3-BOOT0"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="138" name="PH3-BOOT0"/>
+        <pin device-name="r5" device-variant="p" position="138" name="PB8"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="139" name="PB8"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="139" name="PB8"/>
+        <pin device-name="r5" device-variant="p" position="139" name="PB9"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="140" name="PB9"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="140" name="PB9"/>
+        <pin device-name="r5" device-variant="p" position="140" name="PE0"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="141" name="PE0"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="141" name="PE0"/>
+        <pin device-name="r5" device-variant="p" position="141" name="PE1"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="142" name="PE1"/>
+        <pin device-name="r7" device-size="i" device-variant="" position="142" name="PE1"/>
+        <pin device-name="r5" device-variant="p" position="142" name="VDD12" type="power"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PE0"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="VDDIO2" type="power"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="PD3"/>
+        <pin position="A9" name="PC11"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="VDD" type="power"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B7" name="PD6"/>
+        <pin position="B8" name="PD1"/>
+        <pin position="B9" name="PA15 (JTDI)"/>
+        <pin position="B10" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B11" name="PA12"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="VSS" type="power"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PG13"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD0"/>
+        <pin position="C9" name="PC10"/>
+        <pin position="C10" name="PA10"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PC9"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="D3" name="PE4"/>
+        <pin position="D4" name="PE6"/>
+        <pin position="D5" name="PB6"/>
+        <pin position="D6" name="PG12"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC12"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC6"/>
+        <pin position="E1" name="PF2"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PF0"/>
+        <pin position="E4" name="PC13"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="PG10"/>
+        <pin position="E7" name="PD7"/>
+        <pin position="E8" name="PG8"/>
+        <pin position="E9" name="PC7"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PG7"/>
+        <pin position="E12" name="VDDIO2" type="power"/>
+        <pin position="F1" name="PF8"/>
+        <pin position="F2" name="PF6"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F5" name="PF7"/>
+        <pin position="F6" name="PG9"/>
+        <pin position="F7" name="PG3"/>
+        <pin position="F8" name="PG5"/>
+        <pin position="F9" name="PG6"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="PG2"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF10"/>
+        <pin position="G4" name="PF9"/>
+        <pin position="G5" name="PF12"/>
+        <pin position="G6" name="PE7"/>
+        <pin position="G7" name="PD15"/>
+        <pin position="G8" name="PD14"/>
+        <pin position="G9" name="PD12"/>
+        <pin position="G10" name="PD13"/>
+        <pin position="G11" name="PD11"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H3" name="PC0"/>
+        <pin position="H4" name="PC2"/>
+        <pin position="H5" name="PB2"/>
+        <pin position="H6" name="PF15"/>
+        <pin position="H7" name="PE11"/>
+        <pin position="H8" name="PD10"/>
+        <pin position="H9" name="PD9"/>
+        <pin position="H10" name="PD8"/>
+        <pin position="H11" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="H12" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC3"/>
+        <pin position="J4" name="PA6"/>
+        <pin position="J5" name="PB1"/>
+        <pin position="J6" name="PF13"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE13"/>
+        <pin position="J9" name="PB15"/>
+        <pin position="J10" name="VSSDSI" type="power"/>
+        <pin position="J11" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="J12" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="K1" name="VSSA/VREF-" type="power"/>
+        <pin position="K2" name="VREF+" type="monoio"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA4"/>
+        <pin position="K5" name="PC5"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE15"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB14"/>
+        <pin position="K11" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="K12" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PA1"/>
+        <pin position="L3" name="PA2"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PC4"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="PG0"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PB12"/>
+        <pin position="L11" name="VDD" type="power"/>
+        <pin position="L12" name="VCAPDSI" type="power"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="VDD" type="power"/>
+        <pin position="M3" name="PA3"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="VDD" type="power"/>
+        <pin position="M7" name="PF14"/>
+        <pin position="M8" name="PG1"/>
+        <pin position="M9" name="PE12"/>
+        <pin position="M10" name="PE14"/>
+        <pin position="M11" name="PB13"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PI10"/>
+        <pin position="A2" name="PH2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PI0"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PI9"/>
+        <pin position="B2" name="PI7"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PG9"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PI6"/>
+        <pin position="B10" name="PI2"/>
+        <pin position="B11" name="PI1"/>
+        <pin position="B12" name="PH15"/>
+        <pin position="B13" name="PH12"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI11"/>
+        <pin position="C4" name="PB8"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PG15"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD1"/>
+        <pin position="C9" name="PH13"/>
+        <pin position="C10" name="PI3"/>
+        <pin device-name="r9" device-size="g|i" position="C11" name="PH9"/>
+        <pin device-name="r5" device-size="g|i" position="C11" name="PI8"/>
+        <pin device-name="r7" device-size="i" position="C11" name="PI8"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="PE4"/>
+        <pin position="D2" name="PE3"/>
+        <pin position="D3" name="PE2"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB7"/>
+        <pin position="D6" name="PG10"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC10"/>
+        <pin position="D10" name="PI4"/>
+        <pin device-name="r9" device-size="g|i" position="D11" name="PA10"/>
+        <pin device-name="r5" device-size="g|i" position="D11" name="PH9"/>
+        <pin device-name="r7" device-size="i" position="D11" name="PH9"/>
+        <pin device-name="r9" device-size="g|i" position="D12" name="VDDUSB" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="D12" name="PH7"/>
+        <pin device-name="r7" device-size="i" position="D12" name="PH7"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="PC13"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PH3-BOOT0"/>
+        <pin position="E6" name="PG11"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PD3"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PI5"/>
+        <pin device-name="r9" device-size="g|i" position="E11" name="PA8"/>
+        <pin device-name="r5" device-size="g|i" position="E11" name="PH6"/>
+        <pin device-name="r7" device-size="i" position="E11" name="PH6"/>
+        <pin device-name="r9" device-size="g|i" position="E12" name="PA9"/>
+        <pin device-name="r5" device-size="g|i" position="E12" name="VDDUSB" type="power"/>
+        <pin device-name="r7" device-size="i" position="E12" name="VDDUSB" type="power"/>
+        <pin position="E13" name="PA11"/>
+        <pin position="F1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF2"/>
+        <pin position="F4" name="PF1"/>
+        <pin position="F5" name="PF0"/>
+        <pin position="F6" name="PG12"/>
+        <pin position="F7" name="PD7"/>
+        <pin position="F8" name="PC12"/>
+        <pin device-name="r9" device-size="g|i" position="F9" name="PC8"/>
+        <pin device-name="r5" device-size="g|i" position="F9" name="PA10"/>
+        <pin device-name="r7" device-size="i" position="F9" name="PA10"/>
+        <pin device-name="r9" device-size="g|i" position="F10" name="PG8"/>
+        <pin device-name="r5" device-size="g|i" position="F10" name="PA9"/>
+        <pin device-name="r7" device-size="i" position="F10" name="PA9"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDDIO2" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF3"/>
+        <pin position="G4" name="PF4"/>
+        <pin position="G5" name="PF5"/>
+        <pin device-name="r9" device-size="g|i" position="G6" name="PG13"/>
+        <pin device-name="r5" device-size="g|i" position="G6" name="PG14"/>
+        <pin device-name="r7" device-size="i" position="G6" name="PG14"/>
+        <pin device-name="r9" device-size="g|i" position="G7" name="PG4"/>
+        <pin device-name="r5" device-size="g|i" position="G7" name="PG13"/>
+        <pin device-name="r7" device-size="i" position="G7" name="PG13"/>
+        <pin device-name="r9" device-size="g|i" position="G8" name="PG3"/>
+        <pin device-name="r5" device-size="g|i" position="G8" name="PA8"/>
+        <pin device-name="r7" device-size="i" position="G8" name="PA8"/>
+        <pin device-name="r9" device-size="g|i" position="G9" name="PG5"/>
+        <pin device-name="r5" device-size="g|i" position="G9" name="PC9"/>
+        <pin device-name="r7" device-size="i" position="G9" name="PC9"/>
+        <pin device-name="r9" device-size="g|i" position="G10" name="PG7"/>
+        <pin device-name="r5" device-size="g|i" position="G10" name="PC8"/>
+        <pin device-name="r7" device-size="i" position="G10" name="PC8"/>
+        <pin device-name="r9" device-size="g|i" position="G11" name="PC7"/>
+        <pin device-name="r5" device-size="g|i" position="G11" name="PG6"/>
+        <pin device-name="r7" device-size="i" position="G11" name="PG6"/>
+        <pin device-name="r9" device-size="g|i" position="G12" name="PG6"/>
+        <pin device-name="r5" device-size="g|i" position="G12" name="PC7"/>
+        <pin device-name="r7" device-size="i" position="G12" name="PC7"/>
+        <pin device-name="r9" device-size="g|i" position="G13" name="PC9"/>
+        <pin device-name="r5" device-size="g|i" position="G13" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" position="G13" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="NRST" type="reset"/>
+        <pin position="H4" name="PF10"/>
+        <pin device-name="r9" device-size="g|i" position="H5" name="PG1"/>
+        <pin device-name="r5" device-size="g|i" position="H5" name="PC4"/>
+        <pin device-name="r7" device-size="i" position="H5" name="PC4"/>
+        <pin device-name="r9" device-size="g|i" position="H6" name="PE10"/>
+        <pin device-name="r5" device-size="g|i" position="H6" name="PG1"/>
+        <pin device-name="r7" device-size="i" position="H6" name="PG1"/>
+        <pin device-name="r9" device-size="g|i" position="H7" name="PB11"/>
+        <pin device-name="r5" device-size="g|i" position="H7" name="PE10"/>
+        <pin device-name="r7" device-size="i" position="H7" name="PE10"/>
+        <pin device-name="r9" device-size="g|i" position="H8" name="PD13"/>
+        <pin device-name="r5" device-size="g|i" position="H8" name="PB11"/>
+        <pin device-name="r7" device-size="i" position="H8" name="PB11"/>
+        <pin device-name="r9" device-size="g|i" position="H9" name="PG2"/>
+        <pin device-name="r5" device-size="g|i" position="H9" name="PG8"/>
+        <pin device-name="r7" device-size="i" position="H9" name="PG8"/>
+        <pin device-name="r9" device-size="g|i" position="H10" name="PD15"/>
+        <pin device-name="r5" device-size="g|i" position="H10" name="PG7"/>
+        <pin device-name="r7" device-size="i" position="H10" name="PG7"/>
+        <pin device-name="r9" device-size="g|i" position="H11" name="PD14"/>
+        <pin device-name="r5" device-size="g|i" position="H11" name="PD15"/>
+        <pin device-name="r7" device-size="i" position="H11" name="PD15"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PC0"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC2"/>
+        <pin device-name="r9" device-size="g|i" position="J5" name="PG0"/>
+        <pin device-name="r5" device-size="g|i" position="J5" name="PC5"/>
+        <pin device-name="r7" device-size="i" position="J5" name="PC5"/>
+        <pin device-name="r9" device-size="g|i" position="J6" name="PE9"/>
+        <pin device-name="r5" device-size="g|i" position="J6" name="PG0"/>
+        <pin device-name="r7" device-size="i" position="J6" name="PG0"/>
+        <pin device-name="r9" device-size="g|i" position="J7" name="PE15"/>
+        <pin device-name="r5" device-size="g|i" position="J7" name="PE9"/>
+        <pin device-name="r7" device-size="i" position="J7" name="PE9"/>
+        <pin device-name="r9" device-size="g|i" position="J8" name="PD12"/>
+        <pin device-name="r5" device-size="g|i" position="J8" name="PE15"/>
+        <pin device-name="r7" device-size="i" position="J8" name="PE15"/>
+        <pin device-name="r9" device-size="g|i" position="J9" name="PD11"/>
+        <pin device-name="r5" device-size="g|i" position="J9" name="PG5"/>
+        <pin device-name="r7" device-size="i" position="J9" name="PG5"/>
+        <pin device-name="r9" device-size="g|i" position="J10" name="PD10"/>
+        <pin device-name="r5" device-size="g|i" position="J10" name="PG4"/>
+        <pin device-name="r7" device-size="i" position="J10" name="PG4"/>
+        <pin device-name="r9" device-size="g|i" position="J11" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="J11" name="PG3"/>
+        <pin device-name="r7" device-size="i" position="J11" name="PG3"/>
+        <pin device-name="r9" device-size="g|i" position="J12" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="J12" name="PG2"/>
+        <pin device-name="r7" device-size="i" position="J12" name="PG2"/>
+        <pin device-name="r9" device-size="g|i" position="J13" name="VSSDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="J13" name="PD10"/>
+        <pin device-name="r7" device-size="i" position="J13" name="PD10"/>
+        <pin position="K1" name="PC3"/>
+        <pin position="K2" name="VSSA/VREF-" type="power"/>
+        <pin position="K3" name="PA0"/>
+        <pin device-name="r9" device-size="g|i" position="K4" name="PC4"/>
+        <pin device-name="r5" device-size="g|i" position="K4" name="PA5"/>
+        <pin device-name="r7" device-size="i" position="K4" name="PA5"/>
+        <pin device-name="r9" device-size="g|i" position="K5" name="PF15"/>
+        <pin device-name="r5" device-size="g|i" position="K5" name="PB0"/>
+        <pin device-name="r7" device-size="i" position="K5" name="PB0"/>
+        <pin device-name="r9" device-size="g|i" position="K6" name="PE8"/>
+        <pin device-name="r5" device-size="g|i" position="K6" name="PF15"/>
+        <pin device-name="r7" device-size="i" position="K6" name="PF15"/>
+        <pin device-name="r9" device-size="g|i" position="K7" name="PE14"/>
+        <pin device-name="r5" device-size="g|i" position="K7" name="PE8"/>
+        <pin device-name="r7" device-size="i" position="K7" name="PE8"/>
+        <pin device-name="r9" device-size="g|i" position="K8" name="PH4"/>
+        <pin device-name="r5" device-size="g|i" position="K8" name="PE14"/>
+        <pin device-name="r7" device-size="i" position="K8" name="PE14"/>
+        <pin device-name="r9" device-size="g|i" position="K9" name="PD9"/>
+        <pin device-name="r5" device-size="g|i" position="K9" name="PH4"/>
+        <pin device-name="r7" device-size="i" position="K9" name="PH4"/>
+        <pin device-name="r9" device-size="g|i" position="K10" name="PD8"/>
+        <pin device-name="r5" device-size="g|i" position="K10" name="PD14"/>
+        <pin device-name="r7" device-size="i" position="K10" name="PD14"/>
+        <pin device-name="r9" device-size="g|i" position="K11" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="K11" name="PD12"/>
+        <pin device-name="r7" device-size="i" position="K11" name="PD12"/>
+        <pin device-name="r9" device-size="g|i" position="K12" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="K12" name="PD11"/>
+        <pin device-name="r7" device-size="i" position="K12" name="PD11"/>
+        <pin device-name="r9" device-size="g|i" position="K13" name="VSSDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="K13" name="PD13"/>
+        <pin device-name="r7" device-size="i" position="K13" name="PD13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="L3" name="PA5"/>
+        <pin device-name="r5" device-size="g|i" position="L3" name="PA4"/>
+        <pin device-name="r7" device-size="i" position="L3" name="PA4"/>
+        <pin device-name="r9" device-size="g|i" position="L4" name="PA6"/>
+        <pin device-name="r5" device-size="g|i" position="L4" name="PA7"/>
+        <pin device-name="r7" device-size="i" position="L4" name="PA7"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE13"/>
+        <pin position="L9" name="PH5"/>
+        <pin device-name="r9" device-size="g|i" position="L10" name="PB15"/>
+        <pin device-name="r5" device-size="g|i" position="L10" name="PD9"/>
+        <pin device-name="r7" device-size="i" position="L10" name="PD9"/>
+        <pin device-name="r9" device-size="g|i" position="L11" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="L11" name="PD8"/>
+        <pin device-name="r7" device-size="i" position="L11" name="PD8"/>
+        <pin device-name="r9" device-size="g|i" position="L12" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" position="L12" name="VDD" type="power"/>
+        <pin device-name="r7" device-size="i" position="L12" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="L13" name="VCAPDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="L13" name="VSS" type="power"/>
+        <pin device-name="r7" device-size="i" position="L13" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="M1" name="PA1"/>
+        <pin device-name="r5" device-size="g|i" position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin device-name="r7" device-size="i" position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="M4" name="PA7"/>
+        <pin device-name="r5" device-size="g|i" position="M4" name="PA6"/>
+        <pin device-name="r7" device-size="i" position="M4" name="PA6"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE12"/>
+        <pin position="M9" name="PH10"/>
+        <pin position="M10" name="PH11"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="M12" name="PB14"/>
+        <pin device-name="r5" device-size="g|i" position="M12" name="PB15"/>
+        <pin device-name="r7" device-size="i" position="M12" name="PB15"/>
+        <pin device-name="r9" device-size="g|i" position="M13" name="VDDDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" position="M13" name="PB14"/>
+        <pin device-name="r7" device-size="i" position="M13" name="PB14"/>
+        <pin position="N1" name="PA2"/>
+        <pin device-name="r9" device-size="g|i" position="N2" name="PA4"/>
+        <pin device-name="r5" device-size="g|i" position="N2" name="PA1"/>
+        <pin device-name="r7" device-size="i" position="N2" name="PA1"/>
+        <pin position="N3" name="VDD" type="power"/>
+        <pin device-name="r9" device-size="g|i" position="N4" name="PB0"/>
+        <pin device-name="r5" device-size="g|i" position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin device-name="r7" device-size="i" position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="N5" name="PB2"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PB10"/>
+        <pin position="N10" name="PH8"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB13"/>
+      </package>
+      <package device-package="y" name="WLCSP144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A3" name="PA15 (JTDI)"/>
+        <pin position="A4" name="PD0"/>
+        <pin position="A5" name="PD5"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="VDDIO2" type="power"/>
+        <pin position="A9" name="PB7"/>
+        <pin position="A10" name="PE0"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="A11" name="PE1"/>
+        <pin device-name="r9" device-variant="p" position="A11" name="VDD12" type="power"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VDD" type="power"/>
+        <pin position="B2" name="VDDUSB" type="power"/>
+        <pin position="B3" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PG10"/>
+        <pin position="B8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B9" name="PH3-BOOT0"/>
+        <pin position="B10" name="PB9"/>
+        <pin position="B11" name="PE2"/>
+        <pin position="B12" name="VDD" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA12"/>
+        <pin position="C3" name="PC10"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PD1"/>
+        <pin position="C6" name="PD4"/>
+        <pin position="C7" name="PG9"/>
+        <pin position="C8" name="PB4 (NJTRST)"/>
+        <pin position="C9" name="PB6"/>
+        <pin position="C10" name="PB8"/>
+        <pin position="C11" name="PE3"/>
+        <pin position="C12" name="PE4"/>
+        <pin position="D1" name="PC8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PA10"/>
+        <pin position="D6" name="PD3"/>
+        <pin position="D7" name="PD7"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="D8" name="PG13"/>
+        <pin device-name="r9" device-variant="p" position="D8" name="PE1"/>
+        <pin position="D9" name="PE5"/>
+        <pin position="D10" name="PE6"/>
+        <pin position="D11" name="PC13"/>
+        <pin position="D12" name="VSS" type="power"/>
+        <pin position="E1" name="PG7"/>
+        <pin position="E2" name="PG8"/>
+        <pin position="E3" name="VDDIO2" type="power"/>
+        <pin position="E4" name="PC6"/>
+        <pin position="E5" name="PG6"/>
+        <pin position="E6" name="PC7"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PB5"/>
+        <pin position="E9" name="PF0"/>
+        <pin position="E10" name="VBAT" type="power"/>
+        <pin position="E11" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E12" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="F1" name="PD15"/>
+        <pin position="F2" name="PG2"/>
+        <pin position="F3" name="PD14"/>
+        <pin position="F4" name="PD12"/>
+        <pin position="F5" name="PG3"/>
+        <pin position="F6" name="PG4"/>
+        <pin position="F7" name="PG5"/>
+        <pin position="F8" name="PF1"/>
+        <pin position="F9" name="PF5"/>
+        <pin position="F10" name="PF4"/>
+        <pin position="F11" name="PF3"/>
+        <pin position="F12" name="PF2"/>
+        <pin position="G1" name="VSS" type="power"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PD13"/>
+        <pin position="G4" name="PD11"/>
+        <pin position="G5" name="PD10"/>
+        <pin position="G6" name="PE9"/>
+        <pin position="G7" name="PF14"/>
+        <pin position="G8" name="PA5"/>
+        <pin position="G9" name="PF7"/>
+        <pin position="G10" name="PF6"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PD9"/>
+        <pin position="H2" name="PD8"/>
+        <pin position="H3" name="PB14"/>
+        <pin position="H4" name="PB13"/>
+        <pin position="H5" name="PE14"/>
+        <pin position="H6" name="PE8"/>
+        <pin position="H7" name="PB1"/>
+        <pin position="H8" name="PA2"/>
+        <pin position="H9" name="PC2"/>
+        <pin position="H10" name="PF10"/>
+        <pin position="H11" name="NRST" type="reset"/>
+        <pin position="H12" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="J1" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="J1" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="J1" name="NC" type="nc"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="J2" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="J2" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="J2" name="NC" type="nc"/>
+        <pin position="J3" name="PB15"/>
+        <pin position="J4" name="PB12"/>
+        <pin position="J5" name="PE13"/>
+        <pin position="J6" name="PF15"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA6"/>
+        <pin position="J9" name="PA0"/>
+        <pin position="J10" name="PC3"/>
+        <pin position="J11" name="PC0"/>
+        <pin position="J12" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="K1" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="K1" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="K1" name="NC" type="nc"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="K2" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="K2" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="K2" name="NC" type="nc"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="K3" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="K3" name="VSS" type="power"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="K3" name="VSSDSI" type="power"/>
+        <pin position="K4" name="PE15"/>
+        <pin position="K5" name="PE10"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PF11"/>
+        <pin position="K8" name="PC5"/>
+        <pin position="K9" name="PA4"/>
+        <pin position="K10" name="PA1"/>
+        <pin position="K11" name="VSSA/VREF-" type="power"/>
+        <pin position="K12" name="PC1"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="L1" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="L1" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="L1" name="NC" type="nc"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="L2" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="L2" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="L2" name="NC" type="nc"/>
+        <pin device-name="r9" device-size="g|i" device-variant="" position="L3" name="VCAPDSI" type="power"/>
+        <pin device-name="r9" device-size="i" device-variant="p" position="L3" name="VCAPDSI" type="power"/>
+        <pin device-name="r5" device-size="g|i" device-variant="" position="L3" name="NC" type="nc"/>
+        <pin position="L4" name="PB10"/>
+        <pin position="L5" name="PE11"/>
+        <pin position="L6" name="PG1"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="PF12"/>
+        <pin position="L9" name="PC4"/>
+        <pin position="L10" name="PA3"/>
+        <pin position="L11" name="VREF+" type="monoio"/>
+        <pin position="L12" name="VDDA" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VDD" type="power"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="M3" name="VSS" type="power"/>
+        <pin device-name="r9" device-variant="p" position="M3" name="VDD12" type="power"/>
+        <pin device-name="r5|r9" device-size="g|i" device-variant="" position="M4" name="PB11"/>
+        <pin device-name="r9" device-variant="p" position="M4" name="VSS" type="power"/>
+        <pin position="M5" name="PE12"/>
+        <pin position="M6" name="PE7"/>
+        <pin position="M7" name="PF13"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="PB0"/>
+        <pin position="M10" name="PA7"/>
+        <pin position="M11" name="VDD" type="power"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32l4-s5_s7_s9.xml
+++ b/devices/stm32/stm32l4-s5_s7_s9.xml
@@ -1800,6 +1800,1182 @@
       <gpio device-pin="a" port="i" pin="11">
         <signal af="5" driver="octospim" name="p2_io0"/>
       </gpio>
+      <package device-pin="v" name="LQFP100">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="VSS" type="power"/>
+        <pin position="11" name="VDD" type="power"/>
+        <pin position="12" name="PH0-OSC_IN (PH0)"/>
+        <pin position="13" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="14" name="NRST" type="reset"/>
+        <pin position="15" name="PC0"/>
+        <pin position="16" name="PC1"/>
+        <pin position="17" name="PC2"/>
+        <pin position="18" name="PC3"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="19" name="VSSA" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="19" name="VSSA" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="19" name="VSSA/VREF-" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="20" name="VREF-" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="20" name="VREF-" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="20" name="VDDA/VREF+" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="21" name="VREF+" type="monoio"/>
+        <pin device-name="s7" device-temperature="6" position="21" name="VREF+" type="monoio"/>
+        <pin device-name="s9" device-temperature="6" position="21" name="PA0"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="22" name="VDDA" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="22" name="VDDA" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="22" name="PA1"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="23" name="PA0"/>
+        <pin device-name="s7" device-temperature="6" position="23" name="PA0"/>
+        <pin device-name="s9" device-temperature="6" position="23" name="PA2"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="24" name="PA1"/>
+        <pin device-name="s7" device-temperature="6" position="24" name="PA1"/>
+        <pin device-name="s9" device-temperature="6" position="24" name="PA3"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="25" name="PA2"/>
+        <pin device-name="s7" device-temperature="6" position="25" name="PA2"/>
+        <pin device-name="s9" device-temperature="6" position="25" name="VSS" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="26" name="PA3"/>
+        <pin device-name="s7" device-temperature="6" position="26" name="PA3"/>
+        <pin device-name="s9" device-temperature="6" position="26" name="VDD" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="27" name="VSS" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="27" name="VSS" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="27" name="PA4"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="28" name="VDD" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="28" name="VDD" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="28" name="PA5"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="29" name="PA4"/>
+        <pin device-name="s7" device-temperature="6" position="29" name="PA4"/>
+        <pin device-name="s9" device-temperature="6" position="29" name="PA6"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="30" name="PA5"/>
+        <pin device-name="s7" device-temperature="6" position="30" name="PA5"/>
+        <pin device-name="s9" device-temperature="6" position="30" name="PA7"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="31" name="PA6"/>
+        <pin device-name="s7" device-temperature="6" position="31" name="PA6"/>
+        <pin device-name="s9" device-temperature="6" position="31" name="PC4"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="32" name="PA7"/>
+        <pin device-name="s7" device-temperature="6" position="32" name="PA7"/>
+        <pin device-name="s9" device-temperature="6" position="32" name="PB0"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="33" name="PC4"/>
+        <pin device-name="s7" device-temperature="6" position="33" name="PC4"/>
+        <pin device-name="s9" device-temperature="6" position="33" name="PB1"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="34" name="PC5"/>
+        <pin device-name="s7" device-temperature="6" position="34" name="PC5"/>
+        <pin device-name="s9" device-temperature="6" position="34" name="PB2"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="35" name="PB0"/>
+        <pin device-name="s7" device-temperature="6" position="35" name="PB0"/>
+        <pin device-name="s9" device-temperature="6" position="35" name="PE7"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="36" name="PB1"/>
+        <pin device-name="s7" device-temperature="6" position="36" name="PB1"/>
+        <pin device-name="s9" device-temperature="6" position="36" name="PE8"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="37" name="PB2"/>
+        <pin device-name="s7" device-temperature="6" position="37" name="PB2"/>
+        <pin device-name="s9" device-temperature="6" position="37" name="PE9"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="38" name="PE7"/>
+        <pin device-name="s7" device-temperature="6" position="38" name="PE7"/>
+        <pin device-name="s9" device-temperature="6" position="38" name="PE10"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="39" name="PE8"/>
+        <pin device-name="s7" device-temperature="6" position="39" name="PE8"/>
+        <pin device-name="s9" device-temperature="6" position="39" name="PE11"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="40" name="PE9"/>
+        <pin device-name="s7" device-temperature="6" position="40" name="PE9"/>
+        <pin device-name="s9" device-temperature="6" position="40" name="PE12"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="41" name="PE10"/>
+        <pin device-name="s7" device-temperature="6" position="41" name="PE10"/>
+        <pin device-name="s9" device-temperature="6" position="41" name="PE13"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="42" name="PE11"/>
+        <pin device-name="s7" device-temperature="6" position="42" name="PE11"/>
+        <pin device-name="s9" device-temperature="6" position="42" name="PE14"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="43" name="PE12"/>
+        <pin device-name="s7" device-temperature="6" position="43" name="PE12"/>
+        <pin device-name="s9" device-temperature="6" position="43" name="PE15"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="44" name="PE13"/>
+        <pin device-name="s7" device-temperature="6" position="44" name="PE13"/>
+        <pin device-name="s9" device-temperature="6" position="44" name="PB10"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="45" name="PE14"/>
+        <pin device-name="s7" device-temperature="6" position="45" name="PE14"/>
+        <pin device-name="s9" device-temperature="6" position="45" name="PB11"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="46" name="PE15"/>
+        <pin device-name="s7" device-temperature="6" position="46" name="PE15"/>
+        <pin device-name="s9" device-temperature="6" position="46" name="VSS" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="47" name="PB10"/>
+        <pin device-name="s7" device-temperature="6" position="47" name="PB10"/>
+        <pin device-name="s9" device-temperature="6" position="47" name="VDD" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="48" name="PB11"/>
+        <pin device-name="s7" device-temperature="6" position="48" name="PB11"/>
+        <pin device-name="s9" device-temperature="6" position="48" name="PB12"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="49" name="VSS" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="49" name="VSS" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="49" name="PB13"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="50" name="VDD" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="50" name="VDD" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="50" name="PB14"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="51" name="PB12"/>
+        <pin device-name="s7" device-temperature="6" position="51" name="PB12"/>
+        <pin device-name="s9" device-temperature="6" position="51" name="PB15"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="52" name="PB13"/>
+        <pin device-name="s7" device-temperature="6" position="52" name="PB13"/>
+        <pin device-name="s9" device-temperature="6" position="52" name="VDDDSI" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="53" name="PB14"/>
+        <pin device-name="s7" device-temperature="6" position="53" name="PB14"/>
+        <pin device-name="s9" device-temperature="6" position="53" name="VCAPDSI" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="54" name="PB15"/>
+        <pin device-name="s7" device-temperature="6" position="54" name="PB15"/>
+        <pin device-name="s9" device-temperature="6" position="54" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="55" name="PD8"/>
+        <pin device-name="s7" device-temperature="6" position="55" name="PD8"/>
+        <pin device-name="s9" device-temperature="6" position="55" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="56" name="PD9"/>
+        <pin device-name="s7" device-temperature="6" position="56" name="PD9"/>
+        <pin device-name="s9" device-temperature="6" position="56" name="VSSDSI" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="57" name="PD10"/>
+        <pin device-name="s7" device-temperature="6" position="57" name="PD10"/>
+        <pin device-name="s9" device-temperature="6" position="57" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="58" name="PD11"/>
+        <pin device-name="s7" device-temperature="6" position="58" name="PD11"/>
+        <pin device-name="s9" device-temperature="6" position="58" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="59" name="PD12"/>
+        <pin device-name="s7" device-temperature="6" position="59" name="PD12"/>
+        <pin device-name="s9" device-temperature="6" position="59" name="VDD12DSI" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="60" name="PD13"/>
+        <pin device-name="s7" device-temperature="6" position="60" name="PD13"/>
+        <pin device-name="s9" device-temperature="6" position="60" name="PD8"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="61" name="PD14"/>
+        <pin device-name="s7" device-temperature="6" position="61" name="PD14"/>
+        <pin device-name="s9" device-temperature="6" position="61" name="PD9"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="62" name="PD15"/>
+        <pin device-name="s7" device-temperature="6" position="62" name="PD15"/>
+        <pin device-name="s9" device-temperature="6" position="62" name="PD10"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="63" name="PC6"/>
+        <pin device-name="s7" device-temperature="6" position="63" name="PC6"/>
+        <pin device-name="s9" device-temperature="6" position="63" name="PD14"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="64" name="PC7"/>
+        <pin device-name="s7" device-temperature="6" position="64" name="PC7"/>
+        <pin device-name="s9" device-temperature="6" position="64" name="PD15"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="65" name="PC8"/>
+        <pin device-name="s7" device-temperature="6" position="65" name="PC8"/>
+        <pin device-name="s9" device-temperature="6" position="65" name="PC6"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="66" name="PC9"/>
+        <pin device-name="s7" device-temperature="6" position="66" name="PC9"/>
+        <pin device-name="s9" device-temperature="6" position="66" name="PC7"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="67" name="PA8"/>
+        <pin device-name="s7" device-temperature="6" position="67" name="PA8"/>
+        <pin device-name="s9" device-temperature="6" position="67" name="PC8"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="68" name="PA9"/>
+        <pin device-name="s7" device-temperature="6" position="68" name="PA9"/>
+        <pin device-name="s9" device-temperature="6" position="68" name="PC9"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="69" name="PA10"/>
+        <pin device-name="s7" device-temperature="6" position="69" name="PA10"/>
+        <pin device-name="s9" device-temperature="6" position="69" name="PA8"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="70" name="PA11"/>
+        <pin device-name="s7" device-temperature="6" position="70" name="PA11"/>
+        <pin device-name="s9" device-temperature="6" position="70" name="PA9"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="71" name="PA12"/>
+        <pin device-name="s7" device-temperature="6" position="71" name="PA12"/>
+        <pin device-name="s9" device-temperature="6" position="71" name="PA10"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="s7" device-temperature="6" position="72" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="s9" device-temperature="6" position="72" name="PA11"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="73" name="VDDUSB" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="73" name="PA12"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="74" name="VSS" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="74" name="VSS" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="74" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="75" name="VDD" type="power"/>
+        <pin device-name="s7" device-temperature="6" position="75" name="VDD" type="power"/>
+        <pin device-name="s9" device-temperature="6" position="75" name="VDDUSB" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="s7" device-temperature="6" position="76" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="s9" device-temperature="6" position="76" name="VSS" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="77" name="PA15 (JTDI)"/>
+        <pin device-name="s7" device-temperature="6" position="77" name="PA15 (JTDI)"/>
+        <pin device-name="s9" device-temperature="6" position="77" name="VDD" type="power"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="78" name="PC10"/>
+        <pin device-name="s7" device-temperature="6" position="78" name="PC10"/>
+        <pin device-name="s9" device-temperature="6" position="78" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="79" name="PC11"/>
+        <pin device-name="s7" device-temperature="6" position="79" name="PC11"/>
+        <pin device-name="s9" device-temperature="6" position="79" name="PA15 (JTDI)"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="80" name="PC12"/>
+        <pin device-name="s7" device-temperature="6" position="80" name="PC12"/>
+        <pin device-name="s9" device-temperature="6" position="80" name="PC10"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="81" name="PD0"/>
+        <pin device-name="s7" device-temperature="6" position="81" name="PD0"/>
+        <pin device-name="s9" device-temperature="6" position="81" name="PC11"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="82" name="PD1"/>
+        <pin device-name="s7" device-temperature="6" position="82" name="PD1"/>
+        <pin device-name="s9" device-temperature="6" position="82" name="PC12"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="83" name="PD2"/>
+        <pin device-name="s7" device-temperature="6" position="83" name="PD2"/>
+        <pin device-name="s9" device-temperature="6" position="83" name="PD0"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="84" name="PD3"/>
+        <pin device-name="s7" device-temperature="6" position="84" name="PD3"/>
+        <pin device-name="s9" device-temperature="6" position="84" name="PD1"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="85" name="PD4"/>
+        <pin device-name="s7" device-temperature="6" position="85" name="PD4"/>
+        <pin device-name="s9" device-temperature="6" position="85" name="PD2"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="86" name="PD5"/>
+        <pin device-name="s7" device-temperature="6" position="86" name="PD5"/>
+        <pin device-name="s9" device-temperature="6" position="86" name="PD3"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="87" name="PD6"/>
+        <pin device-name="s7" device-temperature="6" position="87" name="PD6"/>
+        <pin device-name="s9" device-temperature="6" position="87" name="PD4"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="88" name="PD7"/>
+        <pin device-name="s7" device-temperature="6" position="88" name="PD7"/>
+        <pin device-name="s9" device-temperature="6" position="88" name="PD5"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="s7" device-temperature="6" position="89" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="s9" device-temperature="6" position="89" name="PD6"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="90" name="PB4 (NJTRST)"/>
+        <pin device-name="s7" device-temperature="6" position="90" name="PB4 (NJTRST)"/>
+        <pin device-name="s9" device-temperature="6" position="90" name="PD7"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="91" name="PB5"/>
+        <pin device-name="s7" device-temperature="6" position="91" name="PB5"/>
+        <pin device-name="s9" device-temperature="6" position="91" name="PB3 (JTDO/TRACESWO)"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="92" name="PB6"/>
+        <pin device-name="s7" device-temperature="6" position="92" name="PB6"/>
+        <pin device-name="s9" device-temperature="6" position="92" name="PB4 (NJTRST)"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="93" name="PB7"/>
+        <pin device-name="s7" device-temperature="6" position="93" name="PB7"/>
+        <pin device-name="s9" device-temperature="6" position="93" name="PB5"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="94" name="PH3-BOOT0"/>
+        <pin device-name="s7" device-temperature="6" position="94" name="PH3-BOOT0"/>
+        <pin device-name="s9" device-temperature="6" position="94" name="PB6"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="95" name="PB8"/>
+        <pin device-name="s7" device-temperature="6" position="95" name="PB8"/>
+        <pin device-name="s9" device-temperature="6" position="95" name="PB7"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="96" name="PB9"/>
+        <pin device-name="s7" device-temperature="6" position="96" name="PB9"/>
+        <pin device-name="s9" device-temperature="6" position="96" name="PH3-BOOT0"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="97" name="PE0"/>
+        <pin device-name="s7" device-temperature="6" position="97" name="PE0"/>
+        <pin device-name="s9" device-temperature="6" position="97" name="PB8"/>
+        <pin device-name="s5" device-temperature="3|6|7" position="98" name="PE1"/>
+        <pin device-name="s7" device-temperature="6" position="98" name="PE1"/>
+        <pin device-name="s9" device-temperature="6" position="98" name="PB9"/>
+        <pin position="99" name="VSS" type="power"/>
+        <pin position="100" name="VDD" type="power"/>
+      </package>
+      <package device-pin="z" device-package="t" name="LQFP144">
+        <pin position="1" name="PE2"/>
+        <pin position="2" name="PE3"/>
+        <pin position="3" name="PE4"/>
+        <pin position="4" name="PE5"/>
+        <pin position="5" name="PE6"/>
+        <pin position="6" name="VBAT" type="power"/>
+        <pin position="7" name="PC13"/>
+        <pin position="8" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="9" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="10" name="PF0"/>
+        <pin position="11" name="PF1"/>
+        <pin position="12" name="PF2"/>
+        <pin position="13" name="PF3"/>
+        <pin position="14" name="PF4"/>
+        <pin position="15" name="PF5"/>
+        <pin position="16" name="VSS" type="power"/>
+        <pin position="17" name="VDD" type="power"/>
+        <pin position="18" name="PF6"/>
+        <pin position="19" name="PF7"/>
+        <pin device-name="s5|s7" position="20" name="PF8"/>
+        <pin device-name="s9" position="20" name="PF10"/>
+        <pin device-name="s5|s7" position="21" name="PF9"/>
+        <pin device-name="s9" position="21" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="s5|s7" position="22" name="PF10"/>
+        <pin device-name="s9" position="22" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="s5|s7" position="23" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="s9" position="23" name="NRST" type="reset"/>
+        <pin device-name="s5|s7" position="24" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="s9" position="24" name="PC0"/>
+        <pin device-name="s5|s7" position="25" name="NRST" type="reset"/>
+        <pin device-name="s9" position="25" name="PC1"/>
+        <pin device-name="s5|s7" position="26" name="PC0"/>
+        <pin device-name="s9" position="26" name="PC2"/>
+        <pin device-name="s5|s7" position="27" name="PC1"/>
+        <pin device-name="s9" position="27" name="PC3"/>
+        <pin device-name="s5|s7" position="28" name="PC2"/>
+        <pin device-name="s9" position="28" name="VSSA/VREF-" type="power"/>
+        <pin device-name="s5|s7" position="29" name="PC3"/>
+        <pin device-name="s9" position="29" name="VREF+" type="monoio"/>
+        <pin device-name="s5|s7" position="30" name="VSSA" type="power"/>
+        <pin device-name="s9" position="30" name="VDDA" type="power"/>
+        <pin device-name="s5|s7" position="31" name="VREF-" type="power"/>
+        <pin device-name="s9" position="31" name="PA0"/>
+        <pin device-name="s5|s7" position="32" name="VREF+" type="monoio"/>
+        <pin device-name="s9" position="32" name="PA1"/>
+        <pin device-name="s5|s7" position="33" name="VDDA" type="power"/>
+        <pin device-name="s9" position="33" name="PA2"/>
+        <pin device-name="s5|s7" position="34" name="PA0"/>
+        <pin device-name="s9" position="34" name="PA3"/>
+        <pin device-name="s5|s7" position="35" name="PA1"/>
+        <pin device-name="s9" position="35" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="36" name="PA2"/>
+        <pin device-name="s9" position="36" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="37" name="PA3"/>
+        <pin device-name="s9" position="37" name="PA4"/>
+        <pin device-name="s5|s7" position="38" name="VSS" type="power"/>
+        <pin device-name="s9" position="38" name="PA5"/>
+        <pin device-name="s5|s7" position="39" name="VDD" type="power"/>
+        <pin device-name="s9" position="39" name="PA6"/>
+        <pin device-name="s5|s7" position="40" name="PA4"/>
+        <pin device-name="s9" position="40" name="PA7"/>
+        <pin device-name="s5|s7" position="41" name="PA5"/>
+        <pin device-name="s9" position="41" name="PC4"/>
+        <pin device-name="s5|s7" position="42" name="PA6"/>
+        <pin device-name="s9" position="42" name="PB0"/>
+        <pin device-name="s5|s7" position="43" name="PA7"/>
+        <pin device-name="s9" position="43" name="PB1"/>
+        <pin device-name="s5|s7" position="44" name="PC4"/>
+        <pin device-name="s9" position="44" name="PB2"/>
+        <pin device-name="s5|s7" position="45" name="PC5"/>
+        <pin device-name="s9" position="45" name="PF11"/>
+        <pin device-name="s5|s7" position="46" name="PB0"/>
+        <pin device-name="s9" position="46" name="PF12"/>
+        <pin device-name="s5|s7" position="47" name="PB1"/>
+        <pin device-name="s9" position="47" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="48" name="PB2"/>
+        <pin device-name="s9" position="48" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="49" name="PF11"/>
+        <pin device-name="s9" position="49" name="PF13"/>
+        <pin device-name="s5|s7" position="50" name="PF12"/>
+        <pin device-name="s9" position="50" name="PF14"/>
+        <pin device-name="s5|s7" position="51" name="VSS" type="power"/>
+        <pin device-name="s9" position="51" name="PF15"/>
+        <pin device-name="s5|s7" position="52" name="VDD" type="power"/>
+        <pin device-name="s9" position="52" name="PG0"/>
+        <pin device-name="s5|s7" position="53" name="PF13"/>
+        <pin device-name="s9" position="53" name="PG1"/>
+        <pin device-name="s5|s7" position="54" name="PF14"/>
+        <pin device-name="s9" position="54" name="PE7"/>
+        <pin device-name="s5|s7" position="55" name="PF15"/>
+        <pin device-name="s9" position="55" name="PE8"/>
+        <pin device-name="s5|s7" position="56" name="PG0"/>
+        <pin device-name="s9" position="56" name="PE9"/>
+        <pin device-name="s5|s7" position="57" name="PG1"/>
+        <pin device-name="s9" position="57" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="58" name="PE7"/>
+        <pin device-name="s9" position="58" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="59" name="PE8"/>
+        <pin device-name="s9" position="59" name="PE10"/>
+        <pin device-name="s5|s7" position="60" name="PE9"/>
+        <pin device-name="s9" position="60" name="PE11"/>
+        <pin device-name="s5|s7" position="61" name="VSS" type="power"/>
+        <pin device-name="s9" position="61" name="PE12"/>
+        <pin device-name="s5|s7" position="62" name="VDD" type="power"/>
+        <pin device-name="s9" position="62" name="PE13"/>
+        <pin device-name="s5|s7" position="63" name="PE10"/>
+        <pin device-name="s9" position="63" name="PE14"/>
+        <pin device-name="s5|s7" position="64" name="PE11"/>
+        <pin device-name="s9" position="64" name="PE15"/>
+        <pin device-name="s5|s7" position="65" name="PE12"/>
+        <pin device-name="s9" position="65" name="PB10"/>
+        <pin device-name="s5|s7" position="66" name="PE13"/>
+        <pin device-name="s9" position="66" name="PB11"/>
+        <pin device-name="s5|s7" position="67" name="PE14"/>
+        <pin device-name="s9" position="67" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="68" name="PE15"/>
+        <pin device-name="s9" position="68" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="69" name="PB10"/>
+        <pin device-name="s9" position="69" name="PB12"/>
+        <pin device-name="s5|s7" position="70" name="PB11"/>
+        <pin device-name="s9" position="70" name="PB13"/>
+        <pin device-name="s5|s7" position="71" name="VSS" type="power"/>
+        <pin device-name="s9" position="71" name="PB14"/>
+        <pin device-name="s5|s7" position="72" name="VDD" type="power"/>
+        <pin device-name="s9" position="72" name="PB15"/>
+        <pin device-name="s5|s7" position="73" name="PB12"/>
+        <pin device-name="s9" position="73" name="VDDDSI" type="power"/>
+        <pin device-name="s5|s7" position="74" name="PB13"/>
+        <pin device-name="s9" position="74" name="VCAPDSI" type="power"/>
+        <pin device-name="s5|s7" position="75" name="PB14"/>
+        <pin device-name="s9" position="75" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="s5|s7" position="76" name="PB15"/>
+        <pin device-name="s9" position="76" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="s5|s7" position="77" name="PD8"/>
+        <pin device-name="s9" position="77" name="VSSDSI" type="power"/>
+        <pin device-name="s5|s7" position="78" name="PD9"/>
+        <pin device-name="s9" position="78" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="s5|s7" position="79" name="PD10"/>
+        <pin device-name="s9" position="79" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="s5|s7" position="80" name="PD11"/>
+        <pin device-name="s9" position="80" name="VDD12DSI" type="power"/>
+        <pin device-name="s5|s7" position="81" name="PD12"/>
+        <pin device-name="s9" position="81" name="PD8"/>
+        <pin device-name="s5|s7" position="82" name="PD13"/>
+        <pin device-name="s9" position="82" name="PD9"/>
+        <pin device-name="s5|s7" position="83" name="VSS" type="power"/>
+        <pin device-name="s9" position="83" name="PD10"/>
+        <pin device-name="s5|s7" position="84" name="VDD" type="power"/>
+        <pin device-name="s9" position="84" name="PD11"/>
+        <pin device-name="s5|s7" position="85" name="PD14"/>
+        <pin device-name="s9" position="85" name="PD12"/>
+        <pin device-name="s5|s7" position="86" name="PD15"/>
+        <pin device-name="s9" position="86" name="PD13"/>
+        <pin device-name="s5|s7" position="87" name="PG2"/>
+        <pin device-name="s9" position="87" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="88" name="PG3"/>
+        <pin device-name="s9" position="88" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="89" name="PG4"/>
+        <pin device-name="s9" position="89" name="PD14"/>
+        <pin device-name="s5|s7" position="90" name="PG5"/>
+        <pin device-name="s9" position="90" name="PD15"/>
+        <pin device-name="s5|s7" position="91" name="PG6"/>
+        <pin device-name="s9" position="91" name="PG2"/>
+        <pin device-name="s5|s7" position="92" name="PG7"/>
+        <pin device-name="s9" position="92" name="PG3"/>
+        <pin device-name="s5|s7" position="93" name="PG8"/>
+        <pin device-name="s9" position="93" name="PG4"/>
+        <pin device-name="s5|s7" position="94" name="VSS" type="power"/>
+        <pin device-name="s9" position="94" name="PG5"/>
+        <pin device-name="s5|s7" position="95" name="VDDIO2" type="power"/>
+        <pin device-name="s9" position="95" name="PG6"/>
+        <pin device-name="s5|s7" position="96" name="PC6"/>
+        <pin device-name="s9" position="96" name="PG7"/>
+        <pin device-name="s5|s7" position="97" name="PC7"/>
+        <pin device-name="s9" position="97" name="PG8"/>
+        <pin device-name="s5|s7" position="98" name="PC8"/>
+        <pin device-name="s9" position="98" name="PC6"/>
+        <pin device-name="s5|s7" position="99" name="PC9"/>
+        <pin device-name="s9" position="99" name="PC7"/>
+        <pin device-name="s5|s7" position="100" name="PA8"/>
+        <pin device-name="s9" position="100" name="PC8"/>
+        <pin device-name="s5|s7" position="101" name="PA9"/>
+        <pin device-name="s9" position="101" name="PC9"/>
+        <pin device-name="s5|s7" position="102" name="PA10"/>
+        <pin device-name="s9" position="102" name="PA8"/>
+        <pin device-name="s5|s7" position="103" name="PA11"/>
+        <pin device-name="s9" position="103" name="PA9"/>
+        <pin device-name="s5|s7" position="104" name="PA12"/>
+        <pin device-name="s9" position="104" name="PA10"/>
+        <pin device-name="s5|s7" position="105" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="s9" position="105" name="PA11"/>
+        <pin device-name="s5|s7" position="106" name="VDDUSB" type="power"/>
+        <pin device-name="s9" position="106" name="PA12"/>
+        <pin device-name="s5|s7" position="107" name="VSS" type="power"/>
+        <pin device-name="s9" position="107" name="PA13 (JTMS/SWDIO)"/>
+        <pin device-name="s5|s7" position="108" name="VDD" type="power"/>
+        <pin device-name="s9" position="108" name="VDDUSB" type="power"/>
+        <pin device-name="s5|s7" position="109" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="s9" position="109" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="110" name="PA15 (JTDI)"/>
+        <pin device-name="s9" position="110" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="111" name="PC10"/>
+        <pin device-name="s9" position="111" name="PA14 (JTCK/SWCLK)"/>
+        <pin device-name="s5|s7" position="112" name="PC11"/>
+        <pin device-name="s9" position="112" name="PA15 (JTDI)"/>
+        <pin device-name="s5|s7" position="113" name="PC12"/>
+        <pin device-name="s9" position="113" name="PC10"/>
+        <pin device-name="s5|s7" position="114" name="PD0"/>
+        <pin device-name="s9" position="114" name="PC11"/>
+        <pin device-name="s5|s7" position="115" name="PD1"/>
+        <pin device-name="s9" position="115" name="PC12"/>
+        <pin device-name="s5|s7" position="116" name="PD2"/>
+        <pin device-name="s9" position="116" name="PD0"/>
+        <pin device-name="s5|s7" position="117" name="PD3"/>
+        <pin device-name="s9" position="117" name="PD1"/>
+        <pin device-name="s5|s7" position="118" name="PD4"/>
+        <pin device-name="s9" position="118" name="PD2"/>
+        <pin device-name="s5|s7" position="119" name="PD5"/>
+        <pin device-name="s9" position="119" name="PD3"/>
+        <pin device-name="s5|s7" position="120" name="VSS" type="power"/>
+        <pin device-name="s9" position="120" name="PD4"/>
+        <pin device-name="s5|s7" position="121" name="VDD" type="power"/>
+        <pin device-name="s9" position="121" name="PD5"/>
+        <pin device-name="s5|s7" position="122" name="PD6"/>
+        <pin device-name="s9" position="122" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="123" name="PD7"/>
+        <pin device-name="s9" position="123" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="124" name="PG9"/>
+        <pin device-name="s9" position="124" name="PD6"/>
+        <pin device-name="s5|s7" position="125" name="PG10"/>
+        <pin device-name="s9" position="125" name="PD7"/>
+        <pin device-name="s5|s7" position="126" name="PG11"/>
+        <pin device-name="s9" position="126" name="PG9"/>
+        <pin device-name="s5|s7" position="127" name="PG12"/>
+        <pin device-name="s9" position="127" name="PG10"/>
+        <pin device-name="s5|s7" position="128" name="PG13"/>
+        <pin device-name="s9" position="128" name="PG11"/>
+        <pin device-name="s5|s7" position="129" name="PG14"/>
+        <pin device-name="s9" position="129" name="PG12"/>
+        <pin position="130" name="VSS" type="power"/>
+        <pin position="131" name="VDDIO2" type="power"/>
+        <pin position="132" name="PG15"/>
+        <pin position="133" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="134" name="PB4 (NJTRST)"/>
+        <pin position="135" name="PB5"/>
+        <pin position="136" name="PB6"/>
+        <pin position="137" name="PB7"/>
+        <pin position="138" name="PH3-BOOT0"/>
+        <pin position="139" name="PB8"/>
+        <pin position="140" name="PB9"/>
+        <pin position="141" name="PE0"/>
+        <pin position="142" name="PE1"/>
+        <pin position="143" name="VSS" type="power"/>
+        <pin position="144" name="VDD" type="power"/>
+      </package>
+      <package device-pin="q" name="UFBGA132">
+        <pin position="A1" name="PE3"/>
+        <pin position="A2" name="PE1"/>
+        <pin position="A3" name="PB8"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PD7"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PB4 (NJTRST)"/>
+        <pin position="A8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PA12"/>
+        <pin position="B1" name="PE4"/>
+        <pin position="B2" name="PE2"/>
+        <pin position="B3" name="PB9"/>
+        <pin position="B4" name="PB7"/>
+        <pin position="B5" name="PB6"/>
+        <pin position="B6" name="PD6"/>
+        <pin position="B7" name="PD4"/>
+        <pin position="B8" name="PD3"/>
+        <pin position="B9" name="PD1"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PC10"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="PC13"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE0"/>
+        <pin position="C4" name="VDD" type="power"/>
+        <pin position="C5" name="PB5"/>
+        <pin position="C6" name="PG14"/>
+        <pin position="C7" name="PG13"/>
+        <pin position="C8" name="PD2"/>
+        <pin position="C9" name="PD0"/>
+        <pin position="C10" name="PC11"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PE6"/>
+        <pin position="D3" name="VSS" type="power"/>
+        <pin position="D4" name="PF2"/>
+        <pin position="D5" name="PF1"/>
+        <pin position="D6" name="PF0"/>
+        <pin position="D7" name="PG12"/>
+        <pin position="D8" name="PG10"/>
+        <pin position="D9" name="PG9"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC9"/>
+        <pin position="E1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="VSS" type="power"/>
+        <pin position="E4" name="PF3"/>
+        <pin position="E9" name="PG5"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PC7"/>
+        <pin position="E12" name="PC6"/>
+        <pin position="F1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F6" name="VSS" type="power"/>
+        <pin position="F7" name="VSS" type="power"/>
+        <pin position="F9" name="PG3"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="VSS" type="power"/>
+        <pin position="G1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PG11"/>
+        <pin position="G4" name="PG6"/>
+        <pin position="G6" name="VDD" type="power"/>
+        <pin position="G7" name="VDDIO2" type="power"/>
+        <pin position="G9" name="PG1"/>
+        <pin position="G10" name="PG2"/>
+        <pin position="G11" name="VDD" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PC0"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="VDD" type="power"/>
+        <pin position="H4" name="PG7"/>
+        <pin position="H9" name="PG0"/>
+        <pin position="H10" name="PD15"/>
+        <pin position="H11" name="PD14"/>
+        <pin position="H12" name="PD13"/>
+        <pin position="J1" name="VSSA/VREF-" type="power"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC2"/>
+        <pin position="J4" name="PA4"/>
+        <pin position="J5" name="PA7"/>
+        <pin position="J6" name="PG8"/>
+        <pin position="J7" name="PF12"/>
+        <pin position="J8" name="PF14"/>
+        <pin position="J9" name="PF15"/>
+        <pin position="J10" name="PD12"/>
+        <pin position="J11" name="PD11"/>
+        <pin position="J12" name="PD10"/>
+        <pin position="K1" name="PG15"/>
+        <pin position="K2" name="PC3"/>
+        <pin position="K3" name="PA2"/>
+        <pin position="K4" name="PA5"/>
+        <pin position="K5" name="PC4"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PF13"/>
+        <pin position="K8" name="PD9"/>
+        <pin position="K9" name="PD8"/>
+        <pin position="K10" name="PB15"/>
+        <pin position="K11" name="PB14"/>
+        <pin position="K12" name="PB13"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA0"/>
+        <pin position="L3" name="PA3"/>
+        <pin position="L4" name="PA6"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB2"/>
+        <pin position="L7" name="PE8"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PE12"/>
+        <pin position="L10" name="PB10"/>
+        <pin position="L11" name="PB11"/>
+        <pin position="L12" name="PB12"/>
+        <pin position="M1" name="VDDA" type="power"/>
+        <pin position="M2" name="PA1"/>
+        <pin position="M3" name="OPAMP1_VINM" type="monoio"/>
+        <pin position="M4" name="OPAMP2_VINM" type="monoio"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="PB1"/>
+        <pin position="M7" name="PE7"/>
+        <pin position="M8" name="PE9"/>
+        <pin position="M9" name="PE11"/>
+        <pin position="M10" name="PE13"/>
+        <pin position="M11" name="PE14"/>
+        <pin position="M12" name="PE15"/>
+      </package>
+      <package device-package="j" name="UFBGA144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PE0"/>
+        <pin position="A3" name="PB9"/>
+        <pin position="A4" name="PH3-BOOT0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="VDDIO2" type="power"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="PD3"/>
+        <pin position="A9" name="PC11"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="VDD" type="power"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VBAT" type="power"/>
+        <pin position="B2" name="VDD" type="power"/>
+        <pin position="B3" name="PE3"/>
+        <pin position="B4" name="PB8"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B7" name="PD6"/>
+        <pin position="B8" name="PD1"/>
+        <pin position="B9" name="PA15 (JTDI)"/>
+        <pin position="B10" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B11" name="PA12"/>
+        <pin position="B12" name="PA11"/>
+        <pin position="C1" name="VSS" type="power"/>
+        <pin position="C2" name="PE5"/>
+        <pin position="C3" name="PE2"/>
+        <pin position="C4" name="PE1"/>
+        <pin position="C5" name="PB7"/>
+        <pin position="C6" name="PG13"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD0"/>
+        <pin position="C9" name="PC10"/>
+        <pin position="C10" name="PA10"/>
+        <pin position="C11" name="VDDUSB" type="power"/>
+        <pin position="C12" name="PC9"/>
+        <pin position="D1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="D2" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="D3" name="PE4"/>
+        <pin position="D4" name="PE6"/>
+        <pin position="D5" name="PB6"/>
+        <pin position="D6" name="PG12"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC12"/>
+        <pin position="D10" name="PA9"/>
+        <pin position="D11" name="PA8"/>
+        <pin position="D12" name="PC6"/>
+        <pin position="E1" name="PF2"/>
+        <pin position="E2" name="PF1"/>
+        <pin position="E3" name="PF0"/>
+        <pin position="E4" name="PC13"/>
+        <pin position="E5" name="PF3"/>
+        <pin position="E6" name="PG10"/>
+        <pin position="E7" name="PD7"/>
+        <pin position="E8" name="PG8"/>
+        <pin position="E9" name="PC7"/>
+        <pin position="E10" name="PC8"/>
+        <pin position="E11" name="PG7"/>
+        <pin position="E12" name="VDDIO2" type="power"/>
+        <pin position="F1" name="PF8"/>
+        <pin position="F2" name="PF6"/>
+        <pin position="F3" name="PF4"/>
+        <pin position="F4" name="PF5"/>
+        <pin position="F5" name="PF7"/>
+        <pin position="F6" name="PG9"/>
+        <pin position="F7" name="PG3"/>
+        <pin position="F8" name="PG5"/>
+        <pin position="F9" name="PG6"/>
+        <pin position="F10" name="PG4"/>
+        <pin position="F11" name="VSS" type="power"/>
+        <pin position="F12" name="PG2"/>
+        <pin position="G1" name="VDD" type="power"/>
+        <pin position="G2" name="VSS" type="power"/>
+        <pin position="G3" name="PF10"/>
+        <pin position="G4" name="PF9"/>
+        <pin position="G5" name="PF12"/>
+        <pin position="G6" name="PE7"/>
+        <pin position="G7" name="PD15"/>
+        <pin position="G8" name="PD14"/>
+        <pin position="G9" name="PD12"/>
+        <pin position="G10" name="PD13"/>
+        <pin position="G11" name="PD11"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="H3" name="PC0"/>
+        <pin position="H4" name="PC2"/>
+        <pin position="H5" name="PB2"/>
+        <pin position="H6" name="PF15"/>
+        <pin position="H7" name="PE11"/>
+        <pin position="H8" name="PD10"/>
+        <pin position="H9" name="PD9"/>
+        <pin position="H10" name="PD8"/>
+        <pin position="H11" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="H12" name="DSIHOST_D1N" type="monoio"/>
+        <pin position="J1" name="NRST" type="reset"/>
+        <pin position="J2" name="PC1"/>
+        <pin position="J3" name="PC3"/>
+        <pin position="J4" name="PA6"/>
+        <pin position="J5" name="PB1"/>
+        <pin position="J6" name="PF13"/>
+        <pin position="J7" name="PE9"/>
+        <pin position="J8" name="PE13"/>
+        <pin position="J9" name="PB15"/>
+        <pin position="J10" name="VSSDSI" type="power"/>
+        <pin position="J11" name="DSIHOST_CKP" type="monoio"/>
+        <pin position="J12" name="DSIHOST_CKN" type="monoio"/>
+        <pin position="K1" name="VSSA/VREF-" type="power"/>
+        <pin position="K2" name="VREF+" type="monoio"/>
+        <pin position="K3" name="PA0"/>
+        <pin position="K4" name="PA4"/>
+        <pin position="K5" name="PC5"/>
+        <pin position="K6" name="PF11"/>
+        <pin position="K7" name="PE8"/>
+        <pin position="K8" name="PE15"/>
+        <pin position="K9" name="PB11"/>
+        <pin position="K10" name="PB14"/>
+        <pin position="K11" name="DSIHOST_D0P" type="monoio"/>
+        <pin position="K12" name="DSIHOST_D0N" type="monoio"/>
+        <pin position="L1" name="VDDA" type="power"/>
+        <pin position="L2" name="PA1"/>
+        <pin position="L3" name="PA2"/>
+        <pin position="L4" name="PA5"/>
+        <pin position="L5" name="PC4"/>
+        <pin position="L6" name="VSS" type="power"/>
+        <pin position="L7" name="PG0"/>
+        <pin position="L8" name="PE10"/>
+        <pin position="L9" name="PB10"/>
+        <pin position="L10" name="PB12"/>
+        <pin position="L11" name="VDD" type="power"/>
+        <pin position="L12" name="VCAPDSI" type="power"/>
+        <pin position="M1" name="VSS" type="power"/>
+        <pin position="M2" name="VDD" type="power"/>
+        <pin position="M3" name="PA3"/>
+        <pin position="M4" name="PA7"/>
+        <pin position="M5" name="PB0"/>
+        <pin position="M6" name="VDD" type="power"/>
+        <pin position="M7" name="PF14"/>
+        <pin position="M8" name="PG1"/>
+        <pin position="M9" name="PE12"/>
+        <pin position="M10" name="PE14"/>
+        <pin position="M11" name="PB13"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
+      <package device-pin="a" name="UFBGA169">
+        <pin position="A1" name="PI10"/>
+        <pin position="A2" name="PH2"/>
+        <pin position="A3" name="VDD" type="power"/>
+        <pin position="A4" name="PE0"/>
+        <pin position="A5" name="PB4 (NJTRST)"/>
+        <pin position="A6" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="A7" name="VSS" type="power"/>
+        <pin position="A8" name="VDD" type="power"/>
+        <pin position="A9" name="PA15 (JTDI)"/>
+        <pin position="A10" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A11" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="A12" name="PI0"/>
+        <pin position="A13" name="PH14"/>
+        <pin position="B1" name="PI9"/>
+        <pin position="B2" name="PI7"/>
+        <pin position="B3" name="VSS" type="power"/>
+        <pin position="B4" name="PE1"/>
+        <pin position="B5" name="PB5"/>
+        <pin position="B6" name="VDDIO2" type="power"/>
+        <pin position="B7" name="PG9"/>
+        <pin position="B8" name="PD0"/>
+        <pin position="B9" name="PI6"/>
+        <pin position="B10" name="PI2"/>
+        <pin position="B11" name="PI1"/>
+        <pin position="B12" name="PH15"/>
+        <pin position="B13" name="PH12"/>
+        <pin position="C1" name="VDD" type="power"/>
+        <pin position="C2" name="VSS" type="power"/>
+        <pin position="C3" name="PI11"/>
+        <pin position="C4" name="PB8"/>
+        <pin position="C5" name="PB6"/>
+        <pin position="C6" name="PG15"/>
+        <pin position="C7" name="PD4"/>
+        <pin position="C8" name="PD1"/>
+        <pin position="C9" name="PH13"/>
+        <pin position="C10" name="PI3"/>
+        <pin device-name="s5|s7" position="C11" name="PI8"/>
+        <pin device-name="s9" position="C11" name="PH9"/>
+        <pin position="C12" name="VSS" type="power"/>
+        <pin position="C13" name="VDD" type="power"/>
+        <pin position="D1" name="PE4"/>
+        <pin position="D2" name="PE3"/>
+        <pin position="D3" name="PE2"/>
+        <pin position="D4" name="PB9"/>
+        <pin position="D5" name="PB7"/>
+        <pin position="D6" name="PG10"/>
+        <pin position="D7" name="PD5"/>
+        <pin position="D8" name="PD2"/>
+        <pin position="D9" name="PC10"/>
+        <pin position="D10" name="PI4"/>
+        <pin device-name="s5|s7" position="D11" name="PH9"/>
+        <pin device-name="s9" position="D11" name="PA10"/>
+        <pin device-name="s5|s7" position="D12" name="PH7"/>
+        <pin device-name="s9" position="D12" name="VDDUSB" type="power"/>
+        <pin position="D13" name="PA12"/>
+        <pin position="E1" name="PC13"/>
+        <pin position="E2" name="VBAT" type="power"/>
+        <pin position="E3" name="PE6"/>
+        <pin position="E4" name="PE5"/>
+        <pin position="E5" name="PH3-BOOT0"/>
+        <pin position="E6" name="PG11"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PD3"/>
+        <pin position="E9" name="PC11"/>
+        <pin position="E10" name="PI5"/>
+        <pin device-name="s5|s7" position="E11" name="PH6"/>
+        <pin device-name="s9" position="E11" name="PA8"/>
+        <pin device-name="s5|s7" position="E12" name="VDDUSB" type="power"/>
+        <pin device-name="s9" position="E12" name="PA9"/>
+        <pin position="E13" name="PA11"/>
+        <pin position="F1" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F3" name="PF2"/>
+        <pin position="F4" name="PF1"/>
+        <pin position="F5" name="PF0"/>
+        <pin position="F6" name="PG12"/>
+        <pin position="F7" name="PD7"/>
+        <pin position="F8" name="PC12"/>
+        <pin device-name="s5|s7" position="F9" name="PA10"/>
+        <pin device-name="s9" position="F9" name="PC8"/>
+        <pin device-name="s5|s7" position="F10" name="PA9"/>
+        <pin device-name="s9" position="F10" name="PG8"/>
+        <pin position="F11" name="PC6"/>
+        <pin position="F12" name="VDDIO2" type="power"/>
+        <pin position="F13" name="VSS" type="power"/>
+        <pin position="G1" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PF3"/>
+        <pin position="G4" name="PF4"/>
+        <pin position="G5" name="PF5"/>
+        <pin device-name="s5|s7" position="G6" name="PG14"/>
+        <pin device-name="s9" position="G6" name="PG13"/>
+        <pin device-name="s5|s7" position="G7" name="PG13"/>
+        <pin device-name="s9" position="G7" name="PG4"/>
+        <pin device-name="s5|s7" position="G8" name="PA8"/>
+        <pin device-name="s9" position="G8" name="PG3"/>
+        <pin device-name="s5|s7" position="G9" name="PC9"/>
+        <pin device-name="s9" position="G9" name="PG5"/>
+        <pin device-name="s5|s7" position="G10" name="PC8"/>
+        <pin device-name="s9" position="G10" name="PG7"/>
+        <pin device-name="s5|s7" position="G11" name="PG6"/>
+        <pin device-name="s9" position="G11" name="PC7"/>
+        <pin device-name="s5|s7" position="G12" name="PC7"/>
+        <pin device-name="s9" position="G12" name="PG6"/>
+        <pin device-name="s5|s7" position="G13" name="VDD" type="power"/>
+        <pin device-name="s9" position="G13" name="PC9"/>
+        <pin position="H1" name="PH0-OSC_IN (PH0)"/>
+        <pin position="H2" name="VSS" type="power"/>
+        <pin position="H3" name="NRST" type="reset"/>
+        <pin position="H4" name="PF10"/>
+        <pin device-name="s5|s7" position="H5" name="PC4"/>
+        <pin device-name="s9" position="H5" name="PG1"/>
+        <pin device-name="s5|s7" position="H6" name="PG1"/>
+        <pin device-name="s9" position="H6" name="PE10"/>
+        <pin device-name="s5|s7" position="H7" name="PE10"/>
+        <pin device-name="s9" position="H7" name="PB11"/>
+        <pin device-name="s5|s7" position="H8" name="PB11"/>
+        <pin device-name="s9" position="H8" name="PD13"/>
+        <pin device-name="s5|s7" position="H9" name="PG8"/>
+        <pin device-name="s9" position="H9" name="PG2"/>
+        <pin device-name="s5|s7" position="H10" name="PG7"/>
+        <pin device-name="s9" position="H10" name="PD15"/>
+        <pin device-name="s5|s7" position="H11" name="PD15"/>
+        <pin device-name="s9" position="H11" name="PD14"/>
+        <pin position="H12" name="VSS" type="power"/>
+        <pin position="H13" name="VDD" type="power"/>
+        <pin position="J1" name="PH1-OSC_OUT (PH1)"/>
+        <pin position="J2" name="PC0"/>
+        <pin position="J3" name="PC1"/>
+        <pin position="J4" name="PC2"/>
+        <pin device-name="s5|s7" position="J5" name="PC5"/>
+        <pin device-name="s9" position="J5" name="PG0"/>
+        <pin device-name="s5|s7" position="J6" name="PG0"/>
+        <pin device-name="s9" position="J6" name="PE9"/>
+        <pin device-name="s5|s7" position="J7" name="PE9"/>
+        <pin device-name="s9" position="J7" name="PE15"/>
+        <pin device-name="s5|s7" position="J8" name="PE15"/>
+        <pin device-name="s9" position="J8" name="PD12"/>
+        <pin device-name="s5|s7" position="J9" name="PG5"/>
+        <pin device-name="s9" position="J9" name="PD11"/>
+        <pin device-name="s5|s7" position="J10" name="PG4"/>
+        <pin device-name="s9" position="J10" name="PD10"/>
+        <pin device-name="s5|s7" position="J11" name="PG3"/>
+        <pin device-name="s9" position="J11" name="DSIHOST_D1P" type="monoio"/>
+        <pin device-name="s5|s7" position="J12" name="PG2"/>
+        <pin device-name="s9" position="J12" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="s5|s7" position="J13" name="PD10"/>
+        <pin device-name="s9" position="J13" name="VSSDSI" type="power"/>
+        <pin position="K1" name="PC3"/>
+        <pin position="K2" name="VSSA/VREF-" type="power"/>
+        <pin position="K3" name="PA0"/>
+        <pin device-name="s5|s7" position="K4" name="PA5"/>
+        <pin device-name="s9" position="K4" name="PC4"/>
+        <pin device-name="s5|s7" position="K5" name="PB0"/>
+        <pin device-name="s9" position="K5" name="PF15"/>
+        <pin device-name="s5|s7" position="K6" name="PF15"/>
+        <pin device-name="s9" position="K6" name="PE8"/>
+        <pin device-name="s5|s7" position="K7" name="PE8"/>
+        <pin device-name="s9" position="K7" name="PE14"/>
+        <pin device-name="s5|s7" position="K8" name="PE14"/>
+        <pin device-name="s9" position="K8" name="PH4"/>
+        <pin device-name="s5|s7" position="K9" name="PH4"/>
+        <pin device-name="s9" position="K9" name="PD9"/>
+        <pin device-name="s5|s7" position="K10" name="PD14"/>
+        <pin device-name="s9" position="K10" name="PD8"/>
+        <pin device-name="s5|s7" position="K11" name="PD12"/>
+        <pin device-name="s9" position="K11" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="s5|s7" position="K12" name="PD11"/>
+        <pin device-name="s9" position="K12" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="s5|s7" position="K13" name="PD13"/>
+        <pin device-name="s9" position="K13" name="VSSDSI" type="power"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="VDDA" type="power"/>
+        <pin device-name="s5|s7" position="L3" name="PA4"/>
+        <pin device-name="s9" position="L3" name="PA5"/>
+        <pin device-name="s5|s7" position="L4" name="PA7"/>
+        <pin device-name="s9" position="L4" name="PA6"/>
+        <pin position="L5" name="PB1"/>
+        <pin position="L6" name="PF14"/>
+        <pin position="L7" name="PE7"/>
+        <pin position="L8" name="PE13"/>
+        <pin position="L9" name="PH5"/>
+        <pin device-name="s5|s7" position="L10" name="PD9"/>
+        <pin device-name="s9" position="L10" name="PB15"/>
+        <pin device-name="s5|s7" position="L11" name="PD8"/>
+        <pin device-name="s9" position="L11" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="s5|s7" position="L12" name="VDD" type="power"/>
+        <pin device-name="s9" position="L12" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="s5|s7" position="L13" name="VSS" type="power"/>
+        <pin device-name="s9" position="L13" name="VCAPDSI" type="power"/>
+        <pin device-name="s5|s7" position="M1" name="OPAMP1_VINM" type="monoio"/>
+        <pin device-name="s9" position="M1" name="PA1"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="M4" name="PA6"/>
+        <pin device-name="s9" position="M4" name="PA7"/>
+        <pin position="M5" name="PF11"/>
+        <pin position="M6" name="PF13"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="PE12"/>
+        <pin position="M9" name="PH10"/>
+        <pin position="M10" name="PH11"/>
+        <pin position="M11" name="VSS" type="power"/>
+        <pin device-name="s5|s7" position="M12" name="PB15"/>
+        <pin device-name="s9" position="M12" name="PB14"/>
+        <pin device-name="s5|s7" position="M13" name="PB14"/>
+        <pin device-name="s9" position="M13" name="VDDDSI" type="power"/>
+        <pin position="N1" name="PA2"/>
+        <pin device-name="s5|s7" position="N2" name="PA1"/>
+        <pin device-name="s9" position="N2" name="PA4"/>
+        <pin position="N3" name="VDD" type="power"/>
+        <pin device-name="s5|s7" position="N4" name="OPAMP2_VINM" type="monoio"/>
+        <pin device-name="s9" position="N4" name="PB0"/>
+        <pin position="N5" name="PB2"/>
+        <pin position="N6" name="PF12"/>
+        <pin position="N7" name="VDD" type="power"/>
+        <pin position="N8" name="PE11"/>
+        <pin position="N9" name="PB10"/>
+        <pin position="N10" name="PH8"/>
+        <pin position="N11" name="VDD" type="power"/>
+        <pin position="N12" name="PB12"/>
+        <pin position="N13" name="PB13"/>
+      </package>
+      <package device-package="y" name="WLCSP144">
+        <pin position="A1" name="VSS" type="power"/>
+        <pin position="A2" name="PA14 (JTCK/SWCLK)"/>
+        <pin position="A3" name="PA15 (JTDI)"/>
+        <pin position="A4" name="PD0"/>
+        <pin position="A5" name="PD5"/>
+        <pin position="A6" name="VDD" type="power"/>
+        <pin position="A7" name="PG12"/>
+        <pin position="A8" name="VDDIO2" type="power"/>
+        <pin position="A9" name="PB7"/>
+        <pin position="A10" name="PE0"/>
+        <pin position="A11" name="PE1"/>
+        <pin position="A12" name="VSS" type="power"/>
+        <pin position="B1" name="VDD" type="power"/>
+        <pin position="B2" name="VDDUSB" type="power"/>
+        <pin position="B3" name="PA13 (JTMS/SWDIO)"/>
+        <pin position="B4" name="PC12"/>
+        <pin position="B5" name="PD2"/>
+        <pin position="B6" name="VSS" type="power"/>
+        <pin position="B7" name="PG10"/>
+        <pin position="B8" name="PB3 (JTDO/TRACESWO)"/>
+        <pin position="B9" name="PH3-BOOT0"/>
+        <pin position="B10" name="PB9"/>
+        <pin position="B11" name="PE2"/>
+        <pin position="B12" name="VDD" type="power"/>
+        <pin position="C1" name="PA11"/>
+        <pin position="C2" name="PA12"/>
+        <pin position="C3" name="PC10"/>
+        <pin position="C4" name="PC11"/>
+        <pin position="C5" name="PD1"/>
+        <pin position="C6" name="PD4"/>
+        <pin position="C7" name="PG9"/>
+        <pin position="C8" name="PB4 (NJTRST)"/>
+        <pin position="C9" name="PB6"/>
+        <pin position="C10" name="PB8"/>
+        <pin position="C11" name="PE3"/>
+        <pin position="C12" name="PE4"/>
+        <pin position="D1" name="PC8"/>
+        <pin position="D2" name="PC9"/>
+        <pin position="D3" name="PA8"/>
+        <pin position="D4" name="PA9"/>
+        <pin position="D5" name="PA10"/>
+        <pin position="D6" name="PD3"/>
+        <pin position="D7" name="PD7"/>
+        <pin position="D8" name="PG13"/>
+        <pin position="D9" name="PE5"/>
+        <pin position="D10" name="PE6"/>
+        <pin position="D11" name="PC13"/>
+        <pin position="D12" name="VSS" type="power"/>
+        <pin position="E1" name="PG7"/>
+        <pin position="E2" name="PG8"/>
+        <pin position="E3" name="VDDIO2" type="power"/>
+        <pin position="E4" name="PC6"/>
+        <pin position="E5" name="PG6"/>
+        <pin position="E6" name="PC7"/>
+        <pin position="E7" name="PD6"/>
+        <pin position="E8" name="PB5"/>
+        <pin position="E9" name="PF0"/>
+        <pin position="E10" name="VBAT" type="power"/>
+        <pin position="E11" name="PC14-OSC32_IN (PC14)"/>
+        <pin position="E12" name="PC15-OSC32_OUT (PC15)"/>
+        <pin position="F1" name="PD15"/>
+        <pin position="F2" name="PG2"/>
+        <pin position="F3" name="PD14"/>
+        <pin position="F4" name="PD12"/>
+        <pin position="F5" name="PG3"/>
+        <pin position="F6" name="PG4"/>
+        <pin position="F7" name="PG5"/>
+        <pin position="F8" name="PF1"/>
+        <pin position="F9" name="PF5"/>
+        <pin position="F10" name="PF4"/>
+        <pin position="F11" name="PF3"/>
+        <pin position="F12" name="PF2"/>
+        <pin position="G1" name="VSS" type="power"/>
+        <pin position="G2" name="VDD" type="power"/>
+        <pin position="G3" name="PD13"/>
+        <pin position="G4" name="PD11"/>
+        <pin position="G5" name="PD10"/>
+        <pin position="G6" name="PE9"/>
+        <pin position="G7" name="PF14"/>
+        <pin position="G8" name="PA5"/>
+        <pin position="G9" name="PF7"/>
+        <pin position="G10" name="PF6"/>
+        <pin position="G11" name="VSS" type="power"/>
+        <pin position="G12" name="VDD" type="power"/>
+        <pin position="H1" name="PD9"/>
+        <pin position="H2" name="PD8"/>
+        <pin position="H3" name="PB14"/>
+        <pin position="H4" name="PB13"/>
+        <pin position="H5" name="PE14"/>
+        <pin position="H6" name="PE8"/>
+        <pin position="H7" name="PB1"/>
+        <pin position="H8" name="PA2"/>
+        <pin position="H9" name="PC2"/>
+        <pin position="H10" name="PF10"/>
+        <pin position="H11" name="NRST" type="reset"/>
+        <pin position="H12" name="PH0-OSC_IN (PH0)"/>
+        <pin device-name="s5" position="J1" name="NC" type="nc"/>
+        <pin device-name="s9" position="J1" name="DSIHOST_D1N" type="monoio"/>
+        <pin device-name="s5" position="J2" name="NC" type="nc"/>
+        <pin device-name="s9" position="J2" name="DSIHOST_D1P" type="monoio"/>
+        <pin position="J3" name="PB15"/>
+        <pin position="J4" name="PB12"/>
+        <pin position="J5" name="PE13"/>
+        <pin position="J6" name="PF15"/>
+        <pin position="J7" name="PB2"/>
+        <pin position="J8" name="PA6"/>
+        <pin position="J9" name="PA0"/>
+        <pin position="J10" name="PC3"/>
+        <pin position="J11" name="PC0"/>
+        <pin position="J12" name="PH1-OSC_OUT (PH1)"/>
+        <pin device-name="s5" position="K1" name="NC" type="nc"/>
+        <pin device-name="s9" position="K1" name="DSIHOST_CKP" type="monoio"/>
+        <pin device-name="s5" position="K2" name="NC" type="nc"/>
+        <pin device-name="s9" position="K2" name="DSIHOST_CKN" type="monoio"/>
+        <pin device-name="s5" position="K3" name="VSS" type="power"/>
+        <pin device-name="s9" position="K3" name="VSSDSI" type="power"/>
+        <pin position="K4" name="PE15"/>
+        <pin position="K5" name="PE10"/>
+        <pin position="K6" name="PG0"/>
+        <pin position="K7" name="PF11"/>
+        <pin position="K8" name="PC5"/>
+        <pin position="K9" name="PA4"/>
+        <pin position="K10" name="PA1"/>
+        <pin position="K11" name="VSSA/VREF-" type="power"/>
+        <pin position="K12" name="PC1"/>
+        <pin device-name="s5" position="L1" name="NC" type="nc"/>
+        <pin device-name="s9" position="L1" name="DSIHOST_D0P" type="monoio"/>
+        <pin device-name="s5" position="L2" name="NC" type="nc"/>
+        <pin device-name="s9" position="L2" name="DSIHOST_D0N" type="monoio"/>
+        <pin device-name="s5" position="L3" name="NC" type="nc"/>
+        <pin device-name="s9" position="L3" name="VCAPDSI" type="power"/>
+        <pin position="L4" name="PB10"/>
+        <pin position="L5" name="PE11"/>
+        <pin position="L6" name="PG1"/>
+        <pin position="L7" name="VDD" type="power"/>
+        <pin position="L8" name="PF12"/>
+        <pin position="L9" name="PC4"/>
+        <pin position="L10" name="PA3"/>
+        <pin position="L11" name="VREF+" type="monoio"/>
+        <pin position="L12" name="VDDA" type="power"/>
+        <pin position="M1" name="VDD" type="power"/>
+        <pin position="M2" name="VDD" type="power"/>
+        <pin position="M3" name="VSS" type="power"/>
+        <pin position="M4" name="PB11"/>
+        <pin position="M5" name="PE12"/>
+        <pin position="M6" name="PE7"/>
+        <pin position="M7" name="PF13"/>
+        <pin position="M8" name="VSS" type="power"/>
+        <pin position="M9" name="PB0"/>
+        <pin position="M10" name="PA7"/>
+        <pin position="M11" name="VDD" type="power"/>
+        <pin position="M12" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32wb-30_50.xml
+++ b/devices/stm32/stm32wb-30_50.xml
@@ -390,6 +390,61 @@
       <gpio port="h" pin="3">
         <signal af="0" driver="rcc" name="lsco"/>
       </gpio>
+      <package name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="PH3-BOOT0"/>
+        <pin position="5" name="PB8"/>
+        <pin position="6" name="PB9"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VDDA" type="power"/>
+        <pin position="9" name="PA0"/>
+        <pin position="10" name="PA1"/>
+        <pin position="11" name="PA2"/>
+        <pin position="12" name="PA3"/>
+        <pin position="13" name="PA4"/>
+        <pin position="14" name="PA5"/>
+        <pin position="15" name="PA6"/>
+        <pin position="16" name="PA7"/>
+        <pin position="17" name="PA8"/>
+        <pin position="18" name="PA9"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VDD" type="power"/>
+        <pin position="21" name="RF1" type="monoio"/>
+        <pin position="22" name="VSSRF" type="power"/>
+        <pin position="23" name="VDDRF" type="power"/>
+        <pin position="24" name="OSC_OUT" type="monoio"/>
+        <pin position="25" name="OSC_IN" type="monoio"/>
+        <pin position="26" name="AT0" type="nc"/>
+        <pin position="27" name="AT1" type="nc"/>
+        <pin position="28" name="PB0"/>
+        <pin position="29" name="PB1"/>
+        <pin position="30" name="PE4"/>
+        <pin device-name="30" position="31" name="VDD" type="power"/>
+        <pin device-name="50" position="31" name="VFBSMPS" type="power"/>
+        <pin device-name="30" position="32" name="VSS" type="power"/>
+        <pin device-name="50" position="32" name="VSSSMPS" type="power"/>
+        <pin device-name="30" position="33" name="VDD" type="power"/>
+        <pin device-name="50" position="33" name="VLXSMPS" type="power"/>
+        <pin device-name="30" position="34" name="VDD" type="power"/>
+        <pin device-name="50" position="34" name="VDDSMPS" type="power"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA10"/>
+        <pin position="37" name="PA11"/>
+        <pin position="38" name="PA12"/>
+        <pin position="39" name="PA13"/>
+        <pin device-name="30" position="40" name="VDD" type="power"/>
+        <pin device-name="50" position="40" name="VDDUSB" type="power"/>
+        <pin position="41" name="PA14"/>
+        <pin position="42" name="PA15"/>
+        <pin position="43" name="PB3"/>
+        <pin position="44" name="PB4"/>
+        <pin position="45" name="PB5"/>
+        <pin position="46" name="PB6"/>
+        <pin position="47" name="PB7"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32wb-35_55.xml
+++ b/devices/stm32/stm32wb-35_55.xml
@@ -814,6 +814,359 @@
       <gpio port="h" pin="3">
         <signal af="0" driver="rcc" name="lsco"/>
       </gpio>
+      <package device-package="q" name="UFBGA129">
+        <pin position="A1" name="PE1"/>
+        <pin position="A2" name="PB6"/>
+        <pin position="A3" name="PB5"/>
+        <pin position="A6" name="PD5"/>
+        <pin position="A7" name="PD10"/>
+        <pin position="A8" name="VDDCAP" type="power"/>
+        <pin position="A11" name="PA13"/>
+        <pin position="A12" name="VDDUSB" type="power"/>
+        <pin position="A13" name="PA12"/>
+        <pin position="B1" name="PE2"/>
+        <pin position="B2" name="PE0"/>
+        <pin position="B3" name="PB4"/>
+        <pin position="B4" name="PD12"/>
+        <pin position="B5" name="PD11"/>
+        <pin position="B6" name="PD8"/>
+        <pin position="B7" name="PD2"/>
+        <pin position="B8" name="VSS" type="power"/>
+        <pin position="B9" name="PC10"/>
+        <pin position="B10" name="PC12"/>
+        <pin position="B11" name="PD0"/>
+        <pin position="B12" name="VSS" type="power"/>
+        <pin position="B13" name="PA11"/>
+        <pin position="C1" name="PD13"/>
+        <pin position="C2" name="PD15"/>
+        <pin position="C3" name="PB7"/>
+        <pin position="C4" name="PB3"/>
+        <pin position="C5" name="PD7"/>
+        <pin position="C6" name="PD4"/>
+        <pin position="C7" name="PD1"/>
+        <pin position="C8" name="PC11"/>
+        <pin position="C9" name="PA15"/>
+        <pin position="C10" name="PA14"/>
+        <pin position="C11" name="VSS" type="power"/>
+        <pin position="C12" name="PA10"/>
+        <pin position="C13" name="PC9"/>
+        <pin position="D2" name="VBAT" type="power"/>
+        <pin position="D3" name="PD14"/>
+        <pin position="D4" name="PD9"/>
+        <pin position="D6" name="PD6"/>
+        <pin position="D8" name="PD3"/>
+        <pin position="D10" name="PC6"/>
+        <pin position="D11" name="PC8"/>
+        <pin position="D12" name="PC7"/>
+        <pin position="E2" name="PC15-OSC32_OUT"/>
+        <pin position="E3" name="PC14-OSC32_IN"/>
+        <pin position="E5" name="VSS" type="power"/>
+        <pin position="E7" name="VSS" type="power"/>
+        <pin position="E9" name="VSS" type="power"/>
+        <pin position="E11" name="PB14"/>
+        <pin position="E12" name="PB13"/>
+        <pin position="F1" name="PH0"/>
+        <pin position="F2" name="VDDCAP" type="power"/>
+        <pin position="F3" name="VSS" type="power"/>
+        <pin position="F4" name="PC13"/>
+        <pin position="F6" name="VDD" type="power"/>
+        <pin position="F8" name="VDD" type="power"/>
+        <pin position="F10" name="PB15"/>
+        <pin position="F11" name="VLXSMPS" type="power"/>
+        <pin position="F12" name="VDDSMPS" type="power"/>
+        <pin position="F13" name="VDDSMPS" type="power"/>
+        <pin position="G1" name="PH3-BOOT0"/>
+        <pin position="G2" name="PH1"/>
+        <pin position="G3" name="PB8"/>
+        <pin position="G5" name="VSS" type="power"/>
+        <pin position="G7" name="VDD" type="power"/>
+        <pin position="G9" name="VSS" type="power"/>
+        <pin position="G11" name="VLXSMPS" type="power"/>
+        <pin position="G12" name="VSSSMPS" type="power"/>
+        <pin position="G13" name="VSSSMPS" type="power"/>
+        <pin position="H1" name="PC1"/>
+        <pin position="H2" name="NRST" type="reset"/>
+        <pin position="H3" name="PC0"/>
+        <pin position="H4" name="PB9"/>
+        <pin position="H6" name="VDD" type="power"/>
+        <pin position="H8" name="VDD" type="power"/>
+        <pin position="H10" name="PB12"/>
+        <pin position="H11" name="VFBSMPS" type="power"/>
+        <pin position="H12" name="PE3"/>
+        <pin position="H13" name="PE4"/>
+        <pin position="J2" name="PC2"/>
+        <pin position="J3" name="PC3"/>
+        <pin position="J5" name="VSS" type="power"/>
+        <pin position="J7" name="VSS" type="power"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J11" name="VSS" type="power"/>
+        <pin position="J12" name="VDDCAP" type="power"/>
+        <pin position="K2" name="VSSA" type="power"/>
+        <pin position="K3" name="VDDA" type="power"/>
+        <pin position="K4" name="VSS" type="power"/>
+        <pin position="K6" name="VSS" type="power"/>
+        <pin position="K8" name="VSSRF" type="power"/>
+        <pin position="K10" name="VSSRF" type="power"/>
+        <pin position="K11" name="AT0" type="nc"/>
+        <pin position="K12" name="AT1" type="nc"/>
+        <pin position="L1" name="VREF+" type="monoio"/>
+        <pin position="L2" name="PA1"/>
+        <pin position="L3" name="PA4"/>
+        <pin position="L4" name="PA9"/>
+        <pin position="L5" name="PC5"/>
+        <pin position="L6" name="PB10"/>
+        <pin position="L7" name="VSSRF" type="power"/>
+        <pin position="L8" name="VSSRF" type="power"/>
+        <pin position="L9" name="VSSRF" type="power"/>
+        <pin position="L10" name="VSSRF" type="power"/>
+        <pin position="L11" name="VSSRF" type="power"/>
+        <pin position="L12" name="PB1"/>
+        <pin position="L13" name="PB0"/>
+        <pin position="M1" name="PA0"/>
+        <pin position="M2" name="PA3"/>
+        <pin position="M3" name="PA6"/>
+        <pin position="M4" name="PA8"/>
+        <pin position="M5" name="PC4"/>
+        <pin position="M6" name="PB11"/>
+        <pin position="M7" name="VSS" type="power"/>
+        <pin position="M8" name="VSSRF" type="power"/>
+        <pin position="M9" name="RF1" type="monoio"/>
+        <pin position="M10" name="VSSRF" type="power"/>
+        <pin position="M11" name="VSSRF" type="power"/>
+        <pin position="M12" name="VSSRF" type="power"/>
+        <pin position="M13" name="OSC_IN" type="monoio"/>
+        <pin position="N1" name="PA2"/>
+        <pin position="N2" name="PA5"/>
+        <pin position="N3" name="PA7"/>
+        <pin position="N6" name="PB2"/>
+        <pin position="N7" name="VDDCAP" type="power"/>
+        <pin position="N8" name="VSSRF" type="power"/>
+        <pin position="N11" name="VSSRF" type="power"/>
+        <pin position="N12" name="VDDRF" type="power"/>
+        <pin position="N13" name="OSC_OUT" type="monoio"/>
+      </package>
+      <package device-pin="c" name="UFQFPN48">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC14-OSC32_IN"/>
+        <pin position="3" name="PC15-OSC32_OUT"/>
+        <pin position="4" name="PH3-BOOT0"/>
+        <pin position="5" name="PB8"/>
+        <pin position="6" name="PB9"/>
+        <pin position="7" name="NRST" type="reset"/>
+        <pin position="8" name="VDDA" type="power"/>
+        <pin position="9" name="PA0"/>
+        <pin position="10" name="PA1"/>
+        <pin position="11" name="PA2"/>
+        <pin position="12" name="PA3"/>
+        <pin position="13" name="PA4"/>
+        <pin position="14" name="PA5"/>
+        <pin position="15" name="PA6"/>
+        <pin position="16" name="PA7"/>
+        <pin position="17" name="PA8"/>
+        <pin position="18" name="PA9"/>
+        <pin position="19" name="PB2"/>
+        <pin position="20" name="VDD" type="power"/>
+        <pin position="21" name="RF1" type="monoio"/>
+        <pin position="22" name="VSSRF" type="power"/>
+        <pin position="23" name="VDDRF" type="power"/>
+        <pin position="24" name="OSC_OUT" type="monoio"/>
+        <pin position="25" name="OSC_IN" type="monoio"/>
+        <pin position="26" name="AT0" type="nc"/>
+        <pin position="27" name="AT1" type="nc"/>
+        <pin position="28" name="PB0"/>
+        <pin position="29" name="PB1"/>
+        <pin position="30" name="PE4"/>
+        <pin position="31" name="VFBSMPS" type="power"/>
+        <pin position="32" name="VSSSMPS" type="power"/>
+        <pin position="33" name="VLXSMPS" type="power"/>
+        <pin position="34" name="VDDSMPS" type="power"/>
+        <pin position="35" name="VDD" type="power"/>
+        <pin position="36" name="PA10"/>
+        <pin position="37" name="PA11"/>
+        <pin position="38" name="PA12"/>
+        <pin position="39" name="PA13"/>
+        <pin position="40" name="VDDUSB" type="power"/>
+        <pin position="41" name="PA14"/>
+        <pin position="42" name="PA15"/>
+        <pin position="43" name="PB3"/>
+        <pin position="44" name="PB4"/>
+        <pin position="45" name="PB5"/>
+        <pin position="46" name="PB6"/>
+        <pin position="47" name="PB7"/>
+        <pin position="48" name="VDD" type="power"/>
+      </package>
+      <package device-pin="r" name="VFQFPN68">
+        <pin position="1" name="VBAT" type="power"/>
+        <pin position="2" name="PC13"/>
+        <pin position="3" name="PC14-OSC32_IN"/>
+        <pin position="4" name="PC15-OSC32_OUT"/>
+        <pin position="5" name="PH3-BOOT0"/>
+        <pin position="6" name="PB8"/>
+        <pin position="7" name="PB9"/>
+        <pin position="8" name="NRST" type="reset"/>
+        <pin position="9" name="PC0"/>
+        <pin position="10" name="PC1"/>
+        <pin position="11" name="PC2"/>
+        <pin position="12" name="PC3"/>
+        <pin position="13" name="VREF+" type="monoio"/>
+        <pin position="14" name="VDDA" type="power"/>
+        <pin position="15" name="PA0"/>
+        <pin position="16" name="PA1"/>
+        <pin position="17" name="PA2"/>
+        <pin position="18" name="PA3"/>
+        <pin position="19" name="PA4"/>
+        <pin position="20" name="PA5"/>
+        <pin position="21" name="PA6"/>
+        <pin position="22" name="PA7"/>
+        <pin position="23" name="PA8"/>
+        <pin position="24" name="PA9"/>
+        <pin position="25" name="PC4"/>
+        <pin position="26" name="PC5"/>
+        <pin position="27" name="PB2"/>
+        <pin position="28" name="PB10"/>
+        <pin position="29" name="PB11"/>
+        <pin position="30" name="VDD" type="power"/>
+        <pin position="31" name="RF1" type="monoio"/>
+        <pin position="32" name="VSSRF" type="power"/>
+        <pin position="33" name="VDDRF" type="power"/>
+        <pin position="34" name="OSC_OUT" type="monoio"/>
+        <pin position="35" name="OSC_IN" type="monoio"/>
+        <pin position="36" name="AT0" type="nc"/>
+        <pin position="37" name="AT1" type="nc"/>
+        <pin position="38" name="PB0"/>
+        <pin position="39" name="PB1"/>
+        <pin position="40" name="PE4"/>
+        <pin position="41" name="VFBSMPS" type="power"/>
+        <pin position="42" name="VSSSMPS" type="power"/>
+        <pin position="43" name="VLXSMPS" type="power"/>
+        <pin position="44" name="VDDSMPS" type="power"/>
+        <pin position="45" name="VDD" type="power"/>
+        <pin position="46" name="PB12"/>
+        <pin position="47" name="PB13"/>
+        <pin position="48" name="PB14"/>
+        <pin position="49" name="PB15"/>
+        <pin position="50" name="PC6"/>
+        <pin position="51" name="PA10"/>
+        <pin position="52" name="PA11"/>
+        <pin position="53" name="PA12"/>
+        <pin position="54" name="PA13"/>
+        <pin position="55" name="VDDUSB" type="power"/>
+        <pin position="56" name="PA14"/>
+        <pin position="57" name="PA15"/>
+        <pin position="58" name="PC10"/>
+        <pin position="59" name="PC11"/>
+        <pin position="60" name="PC12"/>
+        <pin position="61" name="PD0"/>
+        <pin position="62" name="PD1"/>
+        <pin position="63" name="PB3"/>
+        <pin position="64" name="PB4"/>
+        <pin position="65" name="PB5"/>
+        <pin position="66" name="PB6"/>
+        <pin position="67" name="PB7"/>
+        <pin position="68" name="VDD" type="power"/>
+      </package>
+      <package device-package="y" name="WLCSP100">
+        <pin position="A1" name="PA11"/>
+        <pin position="A2" name="PA12"/>
+        <pin position="A3" name="PA14"/>
+        <pin position="A4" name="PA15"/>
+        <pin position="A5" name="PA13"/>
+        <pin position="A6" name="PC10"/>
+        <pin position="A7" name="PD2"/>
+        <pin position="A8" name="PD7"/>
+        <pin position="A9" name="PB3"/>
+        <pin position="A10" name="VDD" type="power"/>
+        <pin position="B1" name="VDD" type="power"/>
+        <pin position="B2" name="VSS" type="power"/>
+        <pin position="B3" name="VDDUSB" type="power"/>
+        <pin position="B4" name="PC9"/>
+        <pin position="B5" name="PA10"/>
+        <pin position="B6" name="PC11"/>
+        <pin position="B7" name="PD5"/>
+        <pin position="B8" name="PD12"/>
+        <pin position="B9" name="VSS" type="power"/>
+        <pin position="B10" name="PE1"/>
+        <pin position="C1" name="PB13"/>
+        <pin position="C2" name="PD3"/>
+        <pin position="C3" name="PD1"/>
+        <pin position="C4" name="PD0"/>
+        <pin position="C5" name="PC12"/>
+        <pin position="C6" name="PD6"/>
+        <pin position="C7" name="PB4"/>
+        <pin position="C8" name="PE0"/>
+        <pin position="C9" name="PD13"/>
+        <pin position="C10" name="VBAT" type="power"/>
+        <pin position="D1" name="VDDSMPS" type="power"/>
+        <pin position="D2" name="PC6"/>
+        <pin position="D3" name="PD4"/>
+        <pin position="D4" name="PD8"/>
+        <pin position="D5" name="PD9"/>
+        <pin position="D6" name="PB5"/>
+        <pin position="D7" name="PB7"/>
+        <pin position="D8" name="PD14"/>
+        <pin position="D9" name="PC15-OSC32_OUT"/>
+        <pin position="D10" name="PC14-OSC32_IN"/>
+        <pin position="E1" name="VLXSMPS" type="power"/>
+        <pin position="E2" name="PB14"/>
+        <pin position="E3" name="PC7"/>
+        <pin position="E4" name="PD10"/>
+        <pin position="E5" name="PD11"/>
+        <pin position="E6" name="PE2"/>
+        <pin position="E7" name="PD15"/>
+        <pin position="E8" name="PH3-BOOT0"/>
+        <pin position="E9" name="PH1"/>
+        <pin position="E10" name="PH0"/>
+        <pin position="F1" name="VSSSMPS" type="power"/>
+        <pin position="F2" name="VFBSMPS" type="power"/>
+        <pin position="F3" name="PB15"/>
+        <pin position="F4" name="PC8"/>
+        <pin position="F5" name="PB6"/>
+        <pin position="F6" name="PA2"/>
+        <pin position="F7" name="PB8"/>
+        <pin position="F8" name="PC0"/>
+        <pin position="F9" name="NRST" type="reset"/>
+        <pin position="F10" name="PB9"/>
+        <pin position="G1" name="PE4"/>
+        <pin position="G2" name="PE3"/>
+        <pin position="G3" name="PB12"/>
+        <pin position="G4" name="PC4"/>
+        <pin position="G5" name="PC13"/>
+        <pin position="G6" name="PA1"/>
+        <pin position="G7" name="PA0"/>
+        <pin position="G8" name="PC1"/>
+        <pin position="G9" name="PC2"/>
+        <pin position="G10" name="PC3"/>
+        <pin position="H1" name="PB1"/>
+        <pin position="H2" name="PB0"/>
+        <pin position="H3" name="AT0" type="nc"/>
+        <pin position="H4" name="AT1" type="nc"/>
+        <pin position="H5" name="PC5"/>
+        <pin position="H6" name="PA7"/>
+        <pin position="H7" name="PA6"/>
+        <pin position="H8" name="VREF+" type="monoio"/>
+        <pin position="H9" name="VDDA" type="power"/>
+        <pin position="H10" name="VSSA" type="power"/>
+        <pin position="J1" name="OSC_IN" type="monoio"/>
+        <pin position="J2" name="OSC_OUT" type="monoio"/>
+        <pin position="J3" name="VDDRF" type="power"/>
+        <pin position="J4" name="VSSRF" type="power"/>
+        <pin position="J5" name="VSS" type="power"/>
+        <pin position="J6" name="PB11"/>
+        <pin position="J7" name="PA8"/>
+        <pin position="J8" name="PA3"/>
+        <pin position="J9" name="VSS" type="power"/>
+        <pin position="J10" name="VDD" type="power"/>
+        <pin position="K1" name="VSSRF" type="power"/>
+        <pin position="K2" name="VSSRF" type="power"/>
+        <pin position="K3" name="VSSRF" type="power"/>
+        <pin position="K4" name="RF1" type="monoio"/>
+        <pin position="K5" name="VDD" type="power"/>
+        <pin position="K6" name="PB10"/>
+        <pin position="K7" name="PB2"/>
+        <pin position="K8" name="PA9"/>
+        <pin position="K9" name="PA5"/>
+        <pin position="K10" name="PA4"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/devices/stm32/stm32wb-5m.xml
+++ b/devices/stm32/stm32wb-5m.xml
@@ -760,6 +760,94 @@
       <gpio port="h" pin="3">
         <signal af="0" driver="rcc" name="lsco"/>
       </gpio>
+      <package name="LGA86">
+        <pin position="1" name="PA2"/>
+        <pin position="2" name="PA1"/>
+        <pin position="3" name="PA0"/>
+        <pin position="4" name="VREF+" type="monoio"/>
+        <pin position="5" name="VSS" type="power"/>
+        <pin position="6" name="VDDA" type="power"/>
+        <pin position="7" name="PC3"/>
+        <pin position="8" name="PC2"/>
+        <pin position="9" name="PC1"/>
+        <pin position="10" name="NRST" type="reset"/>
+        <pin position="11" name="PB9"/>
+        <pin position="12" name="PC0"/>
+        <pin position="13" name="PH3-BOOT0"/>
+        <pin position="14" name="PB8"/>
+        <pin position="15" name="VBAT" type="power"/>
+        <pin position="16" name="VSSSMPS" type="power"/>
+        <pin position="17" name="VDDSMPS" type="power"/>
+        <pin position="18" name="PB7"/>
+        <pin position="19" name="PB5"/>
+        <pin position="20" name="PB4"/>
+        <pin position="21" name="PB3"/>
+        <pin position="22" name="PC10"/>
+        <pin position="23" name="PC11"/>
+        <pin position="24" name="PC12"/>
+        <pin position="25" name="PA13"/>
+        <pin position="26" name="PA14"/>
+        <pin position="27" name="PA15"/>
+        <pin position="28" name="PA10"/>
+        <pin position="29" name="PA12"/>
+        <pin position="30" name="PA11"/>
+        <pin position="31" name="VSS" type="power"/>
+        <pin position="32" name="VDDUSB" type="power"/>
+        <pin position="33" name="PD0"/>
+        <pin position="34" name="PD1"/>
+        <pin position="35" name="PB13"/>
+        <pin position="36" name="PC6"/>
+        <pin position="37" name="PB14"/>
+        <pin position="38" name="PB15"/>
+        <pin position="39" name="PB6"/>
+        <pin position="40" name="PC13"/>
+        <pin position="41" name="PB12"/>
+        <pin position="42" name="PE4"/>
+        <pin position="43" name="NC" type="nc"/>
+        <pin position="44" name="NC" type="nc"/>
+        <pin position="45" name="PC5"/>
+        <pin position="46" name="PB11"/>
+        <pin position="47" name="PB10"/>
+        <pin position="48" name="PB2"/>
+        <pin position="49" name="PC4"/>
+        <pin position="50" name="PA8"/>
+        <pin position="51" name="PA9"/>
+        <pin position="52" name="PA7"/>
+        <pin position="53" name="PA6"/>
+        <pin position="54" name="PA5"/>
+        <pin position="55" name="PA4"/>
+        <pin position="56" name="PA3"/>
+        <pin position="57" name="VSS" type="power"/>
+        <pin position="58" name="ANT_IN"/>
+        <pin position="59" name="RF_OUT"/>
+        <pin position="60" name="VSS" type="power"/>
+        <pin position="61" name="PH0"/>
+        <pin position="62" name="PH1"/>
+        <pin position="63" name="PD14"/>
+        <pin position="64" name="PE1"/>
+        <pin position="65" name="PD13"/>
+        <pin position="66" name="PD12"/>
+        <pin position="67" name="PD7"/>
+        <pin position="68" name="PD2"/>
+        <pin position="69" name="PC9"/>
+        <pin position="70" name="PD3"/>
+        <pin position="71" name="PC7"/>
+        <pin position="72" name="PE3"/>
+        <pin position="73" name="PD4"/>
+        <pin position="74" name="PD9"/>
+        <pin position="75" name="PD8"/>
+        <pin position="76" name="PD15"/>
+        <pin position="77" name="PD10"/>
+        <pin position="78" name="PE2"/>
+        <pin position="79" name="PE0"/>
+        <pin position="80" name="PD5"/>
+        <pin position="81" name="PD6"/>
+        <pin position="82" name="PD11"/>
+        <pin position="83" name="PC8"/>
+        <pin position="84" name="VSS" type="power"/>
+        <pin position="85" name="ANT_NC"/>
+        <pin position="86" name="VSS" type="power"/>
+      </package>
     </driver>
   </device>
 </modm>

--- a/modm_devices/__init__.py
+++ b/modm_devices/__init__.py
@@ -16,4 +16,4 @@ from .exception import ParserException
 
 __all__ = ['exception', 'device_file', 'device_identifier', 'device', 'parser', 'pkg']
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"


### PR DESCRIPTION
Replacement for #40.

The type is implicitly "i/o", and thus only added if it's not.
The mapping from name to `<gpio>` must be done in user software, the code for this is rather simple:
```py
def pin_name(name):
    name = name[:4]
    if len(name) > 3 and not name[3].isdigit():
        name = name[:3]
    return (name[1:2].lower(), name[2:].lower())
```

cc @tgree

