### PR TITLE
Fix STM32 remapped GPIO data

### DIFF
--- a/devices/stm32/stm32f0-42.xml
+++ b/devices/stm32/stm32f0-42.xml
@@ -308,22 +308,22 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio port="a" pin="11">
+      <gpio device-pin="c|k|t" port="a" pin="11">
         <signal driver="usb" name="dm"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="cts"/>
+        <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="4" driver="can" name="rx"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="12">
+      <gpio device-pin="c|k|t" port="a" pin="12">
         <signal driver="usb" name="dp"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="de"/>
-        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="rts"/>
+        <signal af="1" driver="usart" instance="1" name="de"/>
+        <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
         <signal af="4" driver="can" name="tx"/>
-        <signal device-pin="c|k|t" af="5" driver="i2c" instance="1" name="sda"/>
+        <signal af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>

--- a/devices/stm32/stm32f0-48.xml
+++ b/devices/stm32/stm32f0-48.xml
@@ -288,20 +288,20 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio port="a" pin="11">
+      <gpio device-pin="c|t" port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="12">
+      <gpio device-pin="c|t" port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
-        <signal device-pin="c|t" af="5" driver="i2c" instance="1" name="sda"/>
+        <signal af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>

--- a/devices/stm32/stm32f0-70.xml
+++ b/devices/stm32/stm32f0-70.xml
@@ -341,13 +341,12 @@
         <signal af="2" driver="tim" instance="1" name="ch3"/>
         <signal device-size="6" af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio port="a" pin="11">
+      <gpio device-pin="c|r" port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
-        <signal device-pin="f" af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="12">
+      <gpio device-pin="c|r" port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>

--- a/devices/stm32/stm32g0-30.xml
+++ b/devices/stm32/stm32g0-30.xml
@@ -279,26 +279,12 @@
         <signal af="1" driver="spi" instance="2" name="nss"/>
         <signal af="2" driver="tim" instance="1" name="ch1"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
       <gpio device-pin="c|k" port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k" port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>

--- a/devices/stm32/stm32g0-31_41.xml
+++ b/devices/stm32/stm32g0-31_41.xml
@@ -377,26 +377,12 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
       <gpio device-pin="c|k" port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k" port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>

--- a/devices/stm32/stm32g0-70.xml
+++ b/devices/stm32/stm32g0-70.xml
@@ -329,21 +329,6 @@
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="5" driver="tim" instance="15" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
-      </gpio>
       <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>

--- a/devices/stm32/stm32g0-71_81.xml
+++ b/devices/stm32/stm32g0-71_81.xml
@@ -535,36 +535,17 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio port="a" pin="9">
-        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc1"/>
-        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc1"/>
-        <signal af="0" driver="rcc" name="mco"/>
-        <signal af="1" driver="usart" instance="1" name="tx"/>
-        <signal af="2" driver="tim" instance="1" name="ch2"/>
-        <signal af="4" driver="spi" instance="2" name="miso"/>
-        <signal af="5" driver="tim" instance="15" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
       <gpio device-pin="c|k|r" port="a" pin="9">
-        <signal device-package="i" driver="ucpd" instance="1" name="dbcc1"/>
+        <signal driver="ucpd" instance="1" name="dbcc1"/>
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
-      </gpio>
-      <gpio port="a" pin="10">
-        <signal device-pin="c|k" device-package="u" driver="ucpd" instance="1" name="dbcc2"/>
-        <signal device-pin="c|k|r" device-package="t" driver="ucpd" instance="1" name="dbcc2"/>
-        <signal af="0" driver="spi" instance="2" name="mosi"/>
-        <signal af="1" driver="usart" instance="1" name="rx"/>
-        <signal af="2" driver="tim" instance="1" name="ch3"/>
-        <signal af="5" driver="tim" instance="17" name="bk"/>
-        <signal af="6" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio device-pin="c|k|r" port="a" pin="10">
-        <signal device-package="i" driver="ucpd" instance="1" name="dbcc2"/>
+        <signal driver="ucpd" instance="1" name="dbcc2"/>
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>

--- a/modm_devices/__init__.py
+++ b/modm_devices/__init__.py
@@ -16,4 +16,4 @@ from .exception import ParserException
 
 __all__ = ['exception', 'device_file', 'device_identifier', 'device', 'parser', 'pkg']
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -181,8 +181,8 @@ class STMDeviceTree:
                 pin = pin[:3]
             return (port, int(pin[2:]))
         pins = sorted(pins, key=raw_pin_sort)
-        # STM32G0 has pin remaps?!?
-        # pins = filter(lambda p: "PINREMAP" not in p.get("Variant", ""), pins)
+        # Remove package remaps from GPIO data (but not from package)
+        pins = filter(lambda p: "PINREMAP" not in p.get("Variant", ""), pins)
 
         gpios = []
 


### PR DESCRIPTION
The remapped pins were duplicated inside the GPIO list, which lead to conflicting data.
The remapped pins should only be part of the package, not the GPIO data.