### PR TITLE
Fix duplicate STM32 remap pins

### DIFF
--- a/devices/stm32/stm32f0-42.xml
+++ b/devices/stm32/stm32f0-42.xml
@@ -308,22 +308,22 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|k|t" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
-        <signal af="1" driver="usart" instance="1" name="cts"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="4" driver="can" name="rx"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|k|t" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
-        <signal af="1" driver="usart" instance="1" name="de"/>
-        <signal af="1" driver="usart" instance="1" name="rts"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="de"/>
+        <signal device-pin="c|g|k|t" af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
         <signal af="4" driver="can" name="tx"/>
-        <signal af="5" driver="i2c" instance="1" name="sda"/>
+        <signal device-pin="c|k|t" af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>

--- a/devices/stm32/stm32f0-48.xml
+++ b/devices/stm32/stm32f0-48.xml
@@ -288,20 +288,20 @@
         <signal af="3" driver="tsc" name="g4_io2"/>
         <signal af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|t" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
         <signal af="3" driver="tsc" name="g4_io3"/>
         <signal af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|t" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>
         <signal af="2" driver="tim" instance="1" name="etr"/>
         <signal af="3" driver="tsc" name="g4_io4"/>
-        <signal af="5" driver="i2c" instance="1" name="sda"/>
+        <signal device-pin="c|t" af="5" driver="i2c" instance="1" name="sda"/>
       </gpio>
       <gpio port="a" pin="13">
         <signal af="0" driver="sys" name="swdio"/>

--- a/devices/stm32/stm32f0-70.xml
+++ b/devices/stm32/stm32f0-70.xml
@@ -341,12 +341,13 @@
         <signal af="2" driver="tim" instance="1" name="ch3"/>
         <signal device-size="6" af="4" driver="i2c" instance="1" name="sda"/>
       </gpio>
-      <gpio device-pin="c|r" port="a" pin="11">
+      <gpio port="a" pin="11">
         <signal driver="usb" name="dm"/>
         <signal af="1" driver="usart" instance="1" name="cts"/>
         <signal af="2" driver="tim" instance="1" name="ch4"/>
+        <signal device-pin="f" af="5" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|r" port="a" pin="12">
+      <gpio port="a" pin="12">
         <signal driver="usb" name="dp"/>
         <signal af="1" driver="usart" instance="1" name="de"/>
         <signal af="1" driver="usart" instance="1" name="rts"/>

--- a/devices/stm32/stm32g0-30.xml
+++ b/devices/stm32/stm32g0-30.xml
@@ -279,14 +279,14 @@
         <signal af="1" driver="spi" instance="2" name="nss"/>
         <signal af="2" driver="tim" instance="1" name="ch1"/>
       </gpio>
-      <gpio device-pin="c|k" port="a" pin="9">
+      <gpio port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|k" port="a" pin="10">
+      <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>

--- a/devices/stm32/stm32g0-31_41.xml
+++ b/devices/stm32/stm32g0-31_41.xml
@@ -377,14 +377,14 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio device-pin="c|k" port="a" pin="9">
+      <gpio port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
         <signal af="4" driver="spi" instance="2" name="miso"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|k" port="a" pin="10">
+      <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>

--- a/devices/stm32/stm32g0-71_81.xml
+++ b/devices/stm32/stm32g0-71_81.xml
@@ -535,8 +535,7 @@
         <signal af="2" driver="tim" instance="1" name="ch1"/>
         <signal af="5" driver="lptim" instance="2" name="out"/>
       </gpio>
-      <gpio device-pin="c|k|r" port="a" pin="9">
-        <signal driver="ucpd" instance="1" name="dbcc1"/>
+      <gpio port="a" pin="9">
         <signal af="0" driver="rcc" name="mco"/>
         <signal af="1" driver="usart" instance="1" name="tx"/>
         <signal af="2" driver="tim" instance="1" name="ch2"/>
@@ -544,8 +543,7 @@
         <signal af="5" driver="tim" instance="15" name="bk"/>
         <signal af="6" driver="i2c" instance="1" name="scl"/>
       </gpio>
-      <gpio device-pin="c|k|r" port="a" pin="10">
-        <signal driver="ucpd" instance="1" name="dbcc2"/>
+      <gpio port="a" pin="10">
         <signal af="0" driver="spi" instance="2" name="mosi"/>
         <signal af="1" driver="usart" instance="1" name="rx"/>
         <signal af="2" driver="tim" instance="1" name="ch3"/>

--- a/devices/stm32/stm32h7-25_35.xml
+++ b/devices/stm32/stm32h7-25_35.xml
@@ -777,27 +777,6 @@
         <signal af="11" driver="eth" name="crs"/>
         <signal device-pin="a|i|v|z" af="12" driver="fmc" name="a19"/>
       </gpio>
-      <gpio device-package="i|k" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-        <signal driver="pwr" name="wkup1"/>
-        <signal af="1" driver="tim" instance="2" name="ch1"/>
-        <signal af="1" driver="tim" instance="2" name="etr"/>
-        <signal af="2" driver="tim" instance="5" name="ch1"/>
-        <signal af="3" driver="tim" instance="8" name="etr"/>
-        <signal af="4" driver="tim" instance="15" name="bkin"/>
-        <signal af="5" driver="i2s" instance="6" name="ws"/>
-        <signal af="5" driver="spi" instance="6" name="nss"/>
-        <signal af="7" driver="usart" instance="2" name="cts"/>
-        <signal af="7" driver="usart" instance="2" name="nss"/>
-        <signal af="8" driver="uart" instance="4" name="tx"/>
-        <signal af="9" driver="sdmmc" instance="2" name="cmd"/>
-        <signal af="10" driver="sai" instance="4" name="sd_b"/>
-        <signal af="11" driver="eth" name="crs"/>
-        <signal af="12" driver="fmc" name="a19"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -810,23 +789,6 @@
         <signal af="8" driver="uart" instance="4" name="rx"/>
         <signal af="9" driver="octospim" name="p1_io3"/>
         <signal device-pin="a|i|v|z" af="10" driver="sai" instance="4" name="mclk_b"/>
-        <signal af="11" driver="eth" name="ref_clk"/>
-        <signal af="11" driver="eth" name="rx_clk"/>
-        <signal af="12" driver="octospim" name="p1_dqs"/>
-        <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-package="i|k" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
-        <signal af="1" driver="tim" instance="2" name="ch2"/>
-        <signal af="2" driver="tim" instance="5" name="ch2"/>
-        <signal af="3" driver="lptim" instance="3" name="out"/>
-        <signal af="4" driver="tim" instance="15" name="ch1n"/>
-        <signal af="7" driver="usart" instance="2" name="de"/>
-        <signal af="7" driver="usart" instance="2" name="rts"/>
-        <signal af="8" driver="uart" instance="4" name="rx"/>
-        <signal af="9" driver="octospim" name="p1_io3"/>
-        <signal af="10" driver="sai" instance="4" name="mclk_b"/>
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="12" driver="octospim" name="p1_dqs"/>
@@ -1348,19 +1310,6 @@
         <signal device-package="t" af="11" driver="eth" name="txd2"/>
         <signal device-package="t" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-package="i|k" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-        <signal af="3" driver="dfsdm" instance="1" name="ckin1"/>
-        <signal af="4" driver="octospim" name="p1_io5"/>
-        <signal af="5" driver="i2s" instance="2" name="sdi"/>
-        <signal af="5" driver="spi" instance="2" name="miso"/>
-        <signal af="6" driver="dfsdm" instance="1" name="ckout"/>
-        <signal af="9" driver="octospim" name="p1_io2"/>
-        <signal af="10" driver="usb_otg_hs" name="ulpi_dir"/>
-        <signal af="11" driver="eth" name="txd2"/>
-        <signal af="12" driver="fmc" name="sdne0"/>
-      </gpio>
       <gpio device-package="i|k|t" port="c" pin="3">
         <signal device-package="i|k" driver="adc" instance="1" name="inn12"/>
         <signal device-package="i|k" driver="adc" instance="1" name="inp13"/>
@@ -1383,17 +1332,6 @@
         <signal device-package="t" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
         <signal device-package="t" af="11" driver="eth" name="tx_clk"/>
         <signal device-package="t" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-package="i|k" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
-        <signal af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal af="4" driver="octospim" name="p1_io6"/>
-        <signal af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal af="5" driver="spi" instance="2" name="mosi"/>
-        <signal af="9" driver="octospim" name="p1_io0"/>
-        <signal af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal af="11" driver="eth" name="tx_clk"/>
-        <signal af="12" driver="fmc" name="sdcke0"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-30.xml
+++ b/devices/stm32/stm32h7-30.xml
@@ -741,18 +741,6 @@
         <signal af="11" driver="eth" name="crs"/>
         <signal af="12" driver="fmc" name="a19"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -769,14 +757,6 @@
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="12" driver="octospim" name="p1_dqs"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1285,14 +1265,6 @@
         <signal device-package="i|k" driver="spi" instance="2" name="miso"/>
         <signal device-package="i|k" driver="usb_otg_hs" name="ulpi_dir"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-package="i|k" driver="adc" instance="1" name="inn12"/>
         <signal device-package="i|k" driver="adc" instance="1" name="inp13"/>
@@ -1307,12 +1279,6 @@
         <signal device-package="i|k" driver="octospim" name="p1_io6"/>
         <signal device-package="i|k" driver="spi" instance="2" name="mosi"/>
         <signal device-package="i|k" driver="usb_otg_hs" name="ulpi_nxt"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-42.xml
+++ b/devices/stm32/stm32h7-42.xml
@@ -658,12 +658,6 @@
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
         <signal af="11" driver="eth" name="crs"/>
       </gpio>
-      <gpio device-pin="x" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -678,10 +672,6 @@
         <signal af="10" driver="sai" instance="2" name="mclk_b"/>
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
-      </gpio>
-      <gpio device-pin="x" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1125,10 +1115,6 @@
         <signal device-pin="a|b|v|x|z" af="11" driver="eth" name="txd2"/>
         <signal device-pin="a|b|v|x|z" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="x" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="x" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="x" driver="adc" instance="1" name="inp13"/>
@@ -1141,9 +1127,6 @@
         <signal device-pin="a|b|v|x|z" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
         <signal device-pin="a|b|v|x|z" af="11" driver="eth" name="tx_clk"/>
         <signal device-pin="a|b|v|x|z" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="x" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-43_53.xml
+++ b/devices/stm32/stm32h7-43_53.xml
@@ -685,12 +685,6 @@
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
         <signal af="11" driver="eth" name="crs"/>
       </gpio>
-      <gpio device-pin="x" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -706,10 +700,6 @@
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="x" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1175,10 +1165,6 @@
         <signal af="11" driver="eth" name="txd2"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="x" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="x" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="x" driver="adc" instance="1" name="inp13"/>
@@ -1191,9 +1177,6 @@
         <signal af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
         <signal af="11" driver="eth" name="tx_clk"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="x" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -710,12 +710,6 @@
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
         <signal af="11" driver="eth" name="crs"/>
       </gpio>
-      <gpio device-package="h|k" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -731,10 +725,6 @@
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-package="h|k" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1200,10 +1190,6 @@
         <signal af="11" driver="eth" name="txd2"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-package="h|k" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-package="h|k" driver="adc" instance="1" name="inn12"/>
         <signal device-package="h|k" driver="adc" instance="1" name="inp13"/>
@@ -1216,9 +1202,6 @@
         <signal af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
         <signal af="11" driver="eth" name="tx_clk"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-package="h|k" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -691,12 +691,6 @@
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
         <signal af="11" driver="eth" name="crs"/>
       </gpio>
-      <gpio device-pin="x" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -712,10 +706,6 @@
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="x" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1183,10 +1173,6 @@
         <signal af="11" driver="eth" name="txd2"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="x" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="x" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="x" driver="adc" instance="1" name="inp13"/>
@@ -1199,9 +1185,6 @@
         <signal af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
         <signal af="11" driver="eth" name="tx_clk"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="x" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-50.xml
+++ b/devices/stm32/stm32h7-50.xml
@@ -664,12 +664,6 @@
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
         <signal af="11" driver="eth" name="crs"/>
       </gpio>
-      <gpio device-pin="x" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -685,10 +679,6 @@
         <signal af="11" driver="eth" name="ref_clk"/>
         <signal af="11" driver="eth" name="rx_clk"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="x" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1168,10 +1158,6 @@
         <signal device-pin="i" device-package="k" af="12" driver="fmc" name="sdne0"/>
         <signal device-pin="x" device-package="h" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="x" port="c" pin="2">
-        <signal driver="adc" instance="3" name="inn1"/>
-        <signal driver="adc" instance="3" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="x" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="x" driver="adc" instance="1" name="inp13"/>
@@ -1196,9 +1182,6 @@
         <signal device-pin="v|z" device-package="t" af="12" driver="fmc" name="sdcke0"/>
         <signal device-pin="i" device-package="k" af="12" driver="fmc" name="sdcke0"/>
         <signal device-pin="x" device-package="h" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="x" port="c" pin="3">
-        <signal driver="adc" instance="3" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-a3.xml
+++ b/devices/stm32/stm32h7-a3.xml
@@ -764,18 +764,6 @@
         <signal af="9" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -790,15 +778,6 @@
         <signal af="10" driver="sai" instance="2" name="mclk_b"/>
         <signal af="11" driver="octospim" name="p1_dqs"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1315,18 +1294,6 @@
         <signal device-pin="l" device-package="h" device-variant="q" af="12" driver="fmc" name="sdne0"/>
         <signal device-pin="q" device-package="y" device-variant="q" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="a" device-package="i" device-variant="q" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="i" device-package="k" device-variant="q" driver="adc" instance="1" name="inn12"/>
@@ -1373,51 +1340,6 @@
         <signal device-pin="q" device-package="y" device-variant="q" af="11" driver="octospim" name="p1_io6"/>
         <signal device-pin="r" device-package="t" device-variant="" af="11" driver="octospim" name="p1_io6"/>
         <signal device-package="i|k|y" device-variant="q" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-size="g|i" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-size="g|i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-size="g|i" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-size="g|i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-size="g|i" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-size="g|i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-b0.xml
+++ b/devices/stm32/stm32h7-b0.xml
@@ -674,10 +674,6 @@
         <signal af="9" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
       </gpio>
-      <gpio device-package="i|k" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -692,9 +688,6 @@
         <signal af="10" driver="sai" instance="2" name="mclk_b"/>
         <signal af="11" driver="octospim" name="p1_dqs"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-package="i|k" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1180,10 +1173,6 @@
         <signal device-pin="r" device-package="t" af="11" driver="octospim" name="p1_io5"/>
         <signal device-package="i|k" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-package="i|k" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="a" device-package="i" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="i" device-package="k" driver="adc" instance="1" name="inn12"/>
@@ -1217,9 +1206,6 @@
         <signal device-pin="i" device-package="k" af="11" driver="octospim" name="p1_io6"/>
         <signal device-pin="r" device-package="t" af="11" driver="octospim" name="p1_io6"/>
         <signal device-package="i|k" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-package="i|k" port="c" pin="3">
-        <signal driver="adc" instance="2" name="inp1"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/devices/stm32/stm32h7-b3.xml
+++ b/devices/stm32/stm32h7-b3.xml
@@ -770,18 +770,6 @@
         <signal af="9" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="10" driver="sai" instance="2" name="sd_b"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="a" pin="0">
-        <signal driver="adc" instance="1" name="inn1"/>
-        <signal driver="adc" instance="1" name="inp0"/>
-      </gpio>
       <gpio port="a" pin="1">
         <signal driver="adc" instance="1" name="inn16"/>
         <signal driver="adc" instance="1" name="inp17"/>
@@ -796,15 +784,6 @@
         <signal af="10" driver="sai" instance="2" name="mclk_b"/>
         <signal af="11" driver="octospim" name="p1_dqs"/>
         <signal af="14" driver="ltdc" name="r2"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="a" pin="1">
-        <signal driver="adc" instance="1" name="inp1"/>
       </gpio>
       <gpio port="a" pin="2">
         <signal driver="adc" instance="1" name="inp14"/>
@@ -1321,18 +1300,6 @@
         <signal device-pin="l" device-package="h" device-variant="q" af="12" driver="fmc" name="sdne0"/>
         <signal device-pin="q" device-package="y" device-variant="q" af="12" driver="fmc" name="sdne0"/>
       </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="c" pin="2">
-        <signal driver="adc" instance="2" name="inn1"/>
-        <signal driver="adc" instance="2" name="inp0"/>
-      </gpio>
       <gpio port="c" pin="3">
         <signal device-pin="a" device-package="i" device-variant="q" driver="adc" instance="1" name="inn12"/>
         <signal device-pin="i" device-package="k" device-variant="q" driver="adc" instance="1" name="inn12"/>
@@ -1379,51 +1346,6 @@
         <signal device-pin="q" device-package="y" device-variant="q" af="11" driver="octospim" name="p1_io6"/>
         <signal device-pin="r" device-package="t" device-variant="" af="11" driver="octospim" name="p1_io6"/>
         <signal device-package="i|k|y" device-variant="q" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="a" device-package="i" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="i" device-package="k" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
-      </gpio>
-      <gpio device-pin="l" device-package="h" device-variant="q" port="c" pin="3">
-        <signal device-pin="l" driver="adc" instance="1" name="inn12"/>
-        <signal device-pin="l" driver="adc" instance="1" name="inp13"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inn12"/>
-        <signal device-pin="a" device-package="i" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="i" device-package="k" driver="adc" instance="2" name="inp1"/>
-        <signal device-pin="l" driver="adc" instance="2" name="inp13"/>
-        <signal device-pin="l" af="3" driver="dfsdm" instance="1" name="datin1"/>
-        <signal device-pin="l" af="5" driver="i2s" instance="2" name="sdo"/>
-        <signal device-pin="l" af="5" driver="spi" instance="2" name="mosi"/>
-        <signal device-pin="l" af="9" driver="octospim" name="p1_io0"/>
-        <signal device-pin="l" af="10" driver="usb_otg_hs" name="ulpi_nxt"/>
-        <signal device-pin="l" af="11" driver="octospim" name="p1_io6"/>
-        <signal device-pin="l" af="12" driver="fmc" name="sdcke0"/>
       </gpio>
       <gpio port="c" pin="4">
         <signal driver="adc" instance="1" name="inp4"/>

--- a/modm_devices/__init__.py
+++ b/modm_devices/__init__.py
@@ -16,4 +16,4 @@ from .exception import ParserException
 
 __all__ = ['exception', 'device_file', 'device_identifier', 'device', 'parser', 'pkg']
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -182,7 +182,7 @@ class STMDeviceTree:
             return (port, int(pin[2:]))
         pins = sorted(pins, key=raw_pin_sort)
         # Remove package remaps from GPIO data (but not from package)
-        pins = filter(lambda p: "PINREMAP" not in p.get("Variant", ""), pins)
+        pins.sort(key=lambda p: "PINREMAP" not in p.get("Variant", ""))
 
         gpios = []
 
@@ -321,6 +321,7 @@ class STMDeviceTree:
         if did.family == "f1":
             grouped_f1_signals = gpioFile.compactQuery('//GPIO_Pin/PinSignal/@Name')
 
+        _seen_gpio = set()
         for pin in pins:
             rname = pin.get("Name")
             name = pin_name(rname)
@@ -347,7 +348,9 @@ class STMDeviceTree:
                     afs.append(naf)
 
             gpio = (name[0], name[1], afs)
-            gpios.append(gpio)
+            if name not in _seen_gpio:
+                gpios.append(gpio)
+                _seen_gpio.add(name)
             # print(gpio[0].upper(), gpio[1], afs)
             # LOGGER.debug("{}{}: {} ->".format(gpio[0].upper(), gpio[1]))
 


### PR DESCRIPTION
This is a followup to #47.

The remap pin data should only be removed, when it has not already been included.
This is the case when some device packages have enough space to have the remapped pins as both a normal *and* a remapped pin.
![](https://user-images.githubusercontent.com/163066/93381633-43b9fd00-f861-11ea-851b-ab4ae1aed71b.png)
On smaller packages the remap pin data must still be included, since it has no normal pin:
![](https://user-images.githubusercontent.com/163066/93381647-461c5700-f861-11ea-856e-87078fdc4a3e.png)


cc @chris-durand 