### PR TITLE
[dfg] Fix STM32L0 usart peripheral data

### DIFF
--- a/devices/stm32/stm32l0-10.xml
+++ b/devices/stm32/stm32l0-10.xml
@@ -93,7 +93,8 @@
       <instance value="21"/>
       <instance device-size="b" value="22"/>
     </driver>
-    <driver name="usart" type="stm32">
+    <driver name="usart" type="stm32-extended">
+      <feature value="over8"/>
       <instance value="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>

--- a/devices/stm32/stm32l0-11_21.xml
+++ b/devices/stm32/stm32l0-11_21.xml
@@ -119,7 +119,8 @@
     <driver name="tim" type="stm32-v2.x">
       <instance value="21"/>
     </driver>
-    <driver name="usart" type="stm32">
+    <driver name="usart" type="stm32-extended">
+      <feature value="over8"/>
       <instance value="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>

--- a/devices/stm32/stm32l0-31_41.xml
+++ b/devices/stm32/stm32l0-31_41.xml
@@ -130,7 +130,8 @@
       <instance value="21"/>
       <instance value="22"/>
     </driver>
-    <driver name="usart" type="stm32">
+    <driver name="usart" type="stm32-extended">
+      <feature value="over8"/>
       <instance value="2"/>
     </driver>
     <driver name="wwdg" type="stm32-v1.0"/>

--- a/devices/stm32/stm32l0-51_52_53_62_63.xml
+++ b/devices/stm32/stm32l0-51_52_53_62_63.xml
@@ -180,7 +180,8 @@
       <instance value="22"/>
     </driver>
     <driver device-name="52|53|62|63" name="tsc" type="stm32-v1.0"/>
-    <driver name="usart" type="stm32">
+    <driver name="usart" type="stm32-extended">
+      <feature value="over8"/>
       <instance value="1"/>
       <instance value="2"/>
     </driver>

--- a/devices/stm32/stm32l0-71_72_73_81_82_83.xml
+++ b/devices/stm32/stm32l0-71_72_73_81_82_83.xml
@@ -273,7 +273,8 @@
       <instance value="22"/>
     </driver>
     <driver device-name="72|73|82|83" name="tsc" type="stm32-v1.0"/>
-    <driver name="usart" type="stm32">
+    <driver name="usart" type="stm32-extended">
+      <feature value="over8"/>
       <instance value="1"/>
       <instance value="2"/>
       <instance value="4"/>

--- a/tools/generator/dfg/stm32/stm_peripherals.py
+++ b/tools/generator/dfg/stm32/stm_peripherals.py
@@ -439,6 +439,11 @@ stm_peripherals = \
                 'protocols': ['uart', 'spi'],
                 'devices': [{'family': ['f7', 'l4']}]
             },{
+                'hardware': 'stm32-extended',
+                'features': ['over8'],
+                'protocols': ['uart', 'spi'],
+                'devices': [{'family': ['l0']}]
+            },{
                 'hardware': 'stm32',
                 'features': ['over8'],
                 'protocols': ['uart', 'spi'],


### PR DESCRIPTION
The USART peripheral type for STM32L0 is wrong. The correct type is `stm32-extended` not `stm32`. Please don't merge yet until the corresponding PR in modm I will create for L0 support passes CI.