### PR TITLE
Fix STM32 DMAMUX request data

### DIFF
--- a/devices/stm32/stm32g0-30.xml
+++ b/devices/stm32/stm32g0-30.xml
@@ -119,94 +119,94 @@
         <request position="5">
           <signal driver="adc" instance="1"/>
         </request>
-        <request position="8">
+        <request position="10">
           <signal driver="i2c" instance="1" name="rx"/>
         </request>
-        <request position="9">
+        <request position="11">
           <signal driver="i2c" instance="1" name="tx"/>
         </request>
-        <request position="10">
+        <request position="12">
           <signal driver="i2c" instance="2" name="rx"/>
         </request>
-        <request position="11">
+        <request position="13">
           <signal driver="i2c" instance="2" name="tx"/>
         </request>
-        <request position="14">
+        <request position="16">
           <signal driver="spi" instance="1" name="rx"/>
         </request>
-        <request position="15">
+        <request position="17">
           <signal driver="spi" instance="1" name="tx"/>
         </request>
-        <request position="16">
+        <request position="18">
           <signal driver="spi" instance="2" name="rx"/>
         </request>
-        <request position="17">
+        <request position="19">
           <signal driver="spi" instance="2" name="tx"/>
         </request>
-        <request position="18">
+        <request position="20">
           <signal driver="tim" instance="1" name="ch1"/>
         </request>
-        <request position="19">
+        <request position="21">
           <signal driver="tim" instance="1" name="ch2"/>
         </request>
-        <request position="20">
+        <request position="22">
           <signal driver="tim" instance="1" name="ch3"/>
         </request>
-        <request position="21">
+        <request position="23">
           <signal driver="tim" instance="1" name="ch4"/>
         </request>
-        <request position="22">
+        <request position="24">
           <signal driver="tim" instance="1" name="trig_com"/>
         </request>
-        <request position="23">
+        <request position="25">
           <signal driver="tim" instance="1" name="up"/>
         </request>
-        <request position="30">
+        <request position="32">
           <signal driver="tim" instance="3" name="ch1"/>
         </request>
-        <request position="31">
+        <request position="33">
           <signal driver="tim" instance="3" name="ch2"/>
         </request>
-        <request position="32">
+        <request position="34">
           <signal driver="tim" instance="3" name="ch3"/>
         </request>
-        <request position="33">
+        <request position="35">
           <signal driver="tim" instance="3" name="ch4"/>
         </request>
-        <request position="34">
+        <request position="36">
           <signal driver="tim" instance="3" name="trig"/>
         </request>
-        <request position="35">
+        <request position="37">
           <signal driver="tim" instance="3" name="up"/>
         </request>
-        <request position="36">
+        <request position="44">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="37">
+        <request position="45">
           <signal driver="tim" instance="16" name="trig_com"/>
         </request>
-        <request position="38">
+        <request position="46">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="39">
+        <request position="47">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="40">
+        <request position="48">
           <signal driver="tim" instance="17" name="trig_com"/>
         </request>
-        <request position="41">
+        <request position="49">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="42">
+        <request position="50">
           <signal driver="usart" instance="1" name="rx"/>
         </request>
-        <request position="43">
+        <request position="51">
           <signal driver="usart" instance="1" name="tx"/>
         </request>
-        <request position="44">
+        <request position="52">
           <signal driver="usart" instance="2" name="rx"/>
         </request>
-        <request position="45">
+        <request position="53">
           <signal driver="usart" instance="2" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32g0-31_41.xml
+++ b/devices/stm32/stm32g0-31_41.xml
@@ -190,118 +190,118 @@
         <request device-name="41" position="7">
           <signal driver="aes" name="out"/>
         </request>
-        <request position="8">
+        <request position="10">
           <signal driver="i2c" instance="1" name="rx"/>
         </request>
-        <request position="9">
+        <request position="11">
           <signal driver="i2c" instance="1" name="tx"/>
         </request>
-        <request position="10">
+        <request position="12">
           <signal driver="i2c" instance="2" name="rx"/>
         </request>
-        <request position="11">
+        <request position="13">
           <signal driver="i2c" instance="2" name="tx"/>
         </request>
-        <request position="12">
+        <request position="14">
           <signal driver="lpuart" instance="1" name="rx"/>
         </request>
-        <request position="13">
+        <request position="15">
           <signal driver="lpuart" instance="1" name="tx"/>
         </request>
-        <request position="14">
+        <request position="16">
           <signal driver="spi" instance="1" name="rx"/>
         </request>
-        <request position="15">
+        <request position="17">
           <signal driver="spi" instance="1" name="tx"/>
         </request>
-        <request position="16">
+        <request position="18">
           <signal driver="spi" instance="2" name="rx"/>
         </request>
-        <request position="17">
+        <request position="19">
           <signal driver="spi" instance="2" name="tx"/>
         </request>
-        <request position="18">
+        <request position="20">
           <signal driver="tim" instance="1" name="ch1"/>
         </request>
-        <request position="19">
+        <request position="21">
           <signal driver="tim" instance="1" name="ch2"/>
         </request>
-        <request position="20">
+        <request position="22">
           <signal driver="tim" instance="1" name="ch3"/>
         </request>
-        <request position="21">
+        <request position="23">
           <signal driver="tim" instance="1" name="ch4"/>
         </request>
-        <request position="22">
+        <request position="24">
           <signal driver="tim" instance="1" name="trig_com"/>
         </request>
-        <request position="23">
+        <request position="25">
           <signal driver="tim" instance="1" name="up"/>
         </request>
-        <request position="24">
+        <request position="26">
           <signal driver="tim" instance="2" name="ch1"/>
         </request>
-        <request position="25">
+        <request position="27">
           <signal driver="tim" instance="2" name="ch2"/>
         </request>
-        <request position="26">
+        <request position="28">
           <signal driver="tim" instance="2" name="ch3"/>
         </request>
-        <request position="27">
+        <request position="29">
           <signal driver="tim" instance="2" name="ch4"/>
         </request>
-        <request position="28">
+        <request position="30">
           <signal driver="tim" instance="2" name="trig"/>
         </request>
-        <request position="29">
+        <request position="31">
           <signal driver="tim" instance="2" name="up"/>
         </request>
-        <request position="30">
+        <request position="32">
           <signal driver="tim" instance="3" name="ch1"/>
         </request>
-        <request position="31">
+        <request position="33">
           <signal driver="tim" instance="3" name="ch2"/>
         </request>
-        <request position="32">
+        <request position="34">
           <signal driver="tim" instance="3" name="ch3"/>
         </request>
-        <request position="33">
+        <request position="35">
           <signal driver="tim" instance="3" name="ch4"/>
         </request>
-        <request position="34">
+        <request position="36">
           <signal driver="tim" instance="3" name="trig"/>
         </request>
-        <request position="35">
+        <request position="37">
           <signal driver="tim" instance="3" name="up"/>
         </request>
-        <request position="36">
+        <request position="44">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="37">
+        <request position="45">
           <signal driver="tim" instance="16" name="trig_com"/>
         </request>
-        <request position="38">
+        <request position="46">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="39">
+        <request position="47">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="40">
+        <request position="48">
           <signal driver="tim" instance="17" name="trig_com"/>
         </request>
-        <request position="41">
+        <request position="49">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="42">
+        <request position="50">
           <signal driver="usart" instance="1" name="rx"/>
         </request>
-        <request position="43">
+        <request position="51">
           <signal driver="usart" instance="1" name="tx"/>
         </request>
-        <request position="44">
+        <request position="52">
           <signal driver="usart" instance="2" name="rx"/>
         </request>
-        <request position="45">
+        <request position="53">
           <signal driver="usart" instance="2" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32h7-23_33.xml
+++ b/devices/stm32/stm32h7-23_33.xml
@@ -351,7 +351,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -628,110 +628,110 @@
         <request position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="107">
-          <signal driver="uart" instance="9" name="rx"/>
-        </request>
-        <request position="108">
-          <signal driver="uart" instance="9" name="tx"/>
-        </request>
-        <request position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request position="111">
+        <request position="115">
           <signal driver="adc" instance="3"/>
         </request>
-        <request position="112">
-          <signal driver="fmac" name="rd"/>
-        </request>
-        <request position="113">
-          <signal driver="fmac" name="wr"/>
-        </request>
-        <request position="114">
-          <signal driver="cordic" name="rd"/>
-        </request>
-        <request position="115">
-          <signal driver="cordic" name="wr"/>
-        </request>
         <request position="116">
-          <signal driver="i2c" instance="5" name="rx"/>
+          <signal driver="uart" instance="9" name="rx"/>
         </request>
         <request position="117">
-          <signal driver="i2c" instance="5" name="tx"/>
+          <signal driver="uart" instance="9" name="tx"/>
         </request>
         <request position="118">
-          <signal driver="tim" instance="23" name="ch1"/>
+          <signal driver="usart" instance="10" name="rx"/>
         </request>
         <request position="119">
-          <signal driver="tim" instance="23" name="ch2"/>
+          <signal driver="usart" instance="10" name="tx"/>
         </request>
         <request position="120">
-          <signal driver="tim" instance="23" name="ch3"/>
+          <signal driver="fmac" name="rd"/>
         </request>
         <request position="121">
-          <signal driver="tim" instance="23" name="ch4"/>
+          <signal driver="fmac" name="wr"/>
         </request>
         <request position="122">
-          <signal driver="tim" instance="23" name="trig"/>
+          <signal driver="cordic" name="rd"/>
         </request>
         <request position="123">
-          <signal driver="tim" instance="23" name="up"/>
+          <signal driver="cordic" name="wr"/>
         </request>
         <request position="124">
-          <signal driver="tim" instance="24" name="ch1"/>
+          <signal driver="i2c" instance="5" name="rx"/>
         </request>
         <request position="125">
-          <signal driver="tim" instance="24" name="ch2"/>
+          <signal driver="i2c" instance="5" name="tx"/>
         </request>
         <request position="126">
-          <signal driver="tim" instance="24" name="ch3"/>
+          <signal driver="tim" instance="23" name="ch1"/>
         </request>
         <request position="127">
-          <signal driver="tim" instance="24" name="ch4"/>
+          <signal driver="tim" instance="23" name="ch2"/>
         </request>
         <request position="128">
-          <signal driver="tim" instance="24" name="trig"/>
+          <signal driver="tim" instance="23" name="ch3"/>
         </request>
         <request position="129">
+          <signal driver="tim" instance="23" name="ch4"/>
+        </request>
+        <request position="130">
+          <signal driver="tim" instance="23" name="up"/>
+        </request>
+        <request position="131">
+          <signal driver="tim" instance="23" name="trig"/>
+        </request>
+        <request position="132">
+          <signal driver="tim" instance="24" name="ch1"/>
+        </request>
+        <request position="133">
+          <signal driver="tim" instance="24" name="ch2"/>
+        </request>
+        <request position="134">
+          <signal driver="tim" instance="24" name="ch3"/>
+        </request>
+        <request position="135">
+          <signal driver="tim" instance="24" name="ch4"/>
+        </request>
+        <request position="136">
           <signal driver="tim" instance="24" name="up"/>
+        </request>
+        <request position="137">
+          <signal driver="tim" instance="24" name="trig"/>
         </request>
       </requests>
       <mux-channels>
@@ -1336,7 +1336,7 @@
         <signal driver="adc" instance="2" name="inp4"/>
         <signal driver="comp" instance="1" name="inm"/>
         <signal driver="opamp" instance="1" name="vout"/>
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal af="1" driver="fmc" name="a22"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
@@ -1351,7 +1351,7 @@
         <signal driver="adc" instance="2" name="inn4"/>
         <signal driver="adc" instance="2" name="inp8"/>
         <signal driver="opamp" instance="1" name="vinm"/>
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal af="1" driver="sai" instance="4" name="d3"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
@@ -1551,7 +1551,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1562,7 +1562,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio port="d" pin="8">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
         <signal af="12" driver="fmc" name="d13"/>
@@ -1994,7 +1994,7 @@
         <signal af="14" driver="ltdc" name="clk"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="8">
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal af="3" driver="tim" instance="8" name="etr"/>
         <signal af="5" driver="i2s" instance="6" name="ws"/>
         <signal af="5" driver="spi" instance="6" name="nss"/>
@@ -2005,7 +2005,7 @@
         <signal af="14" driver="ltdc" name="g7"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="9">
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal af="2" driver="fdcan" instance="3" name="tx"/>
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
@@ -2032,7 +2032,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="11">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="1" driver="lptim" instance="1" name="in2"/>
         <signal af="4" driver="usart" instance="10" name="rx"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
@@ -2045,7 +2045,7 @@
         <signal af="14" driver="ltdc" name="b3"/>
       </gpio>
       <gpio device-pin="z" port="g" pin="12">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="1" driver="lptim" instance="1" name="in1"/>
         <signal af="3" driver="octospim" name="p2_ncs"/>
         <signal af="4" driver="usart" instance="10" name="tx"/>

--- a/devices/stm32/stm32h7-25_35.xml
+++ b/devices/stm32/stm32h7-25_35.xml
@@ -388,7 +388,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -683,128 +683,128 @@
         <request position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request device-pin="a|i|v|z" position="107">
-          <signal driver="uart" instance="9" name="rx"/>
-        </request>
-        <request device-pin="a|i|v|z" position="108">
-          <signal driver="uart" instance="9" name="tx"/>
-        </request>
-        <request device-pin="a" device-package="i" position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request device-pin="i" device-package="k|t" position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request device-pin="v" device-package="h" position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request device-pin="z" device-package="t" position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request device-pin="a" device-package="i" position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request device-pin="i" device-package="k|t" position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request device-pin="v" device-package="h" position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request device-pin="z" device-package="t" position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request position="111">
+        <request position="115">
           <signal driver="adc" instance="3"/>
         </request>
-        <request position="112">
-          <signal driver="fmac" name="rd"/>
-        </request>
-        <request position="113">
-          <signal driver="fmac" name="wr"/>
-        </request>
-        <request position="114">
-          <signal driver="cordic" name="rd"/>
-        </request>
-        <request position="115">
-          <signal driver="cordic" name="wr"/>
-        </request>
         <request device-pin="a|i|v|z" position="116">
-          <signal driver="i2c" instance="5" name="rx"/>
+          <signal driver="uart" instance="9" name="rx"/>
         </request>
         <request device-pin="a|i|v|z" position="117">
-          <signal driver="i2c" instance="5" name="tx"/>
+          <signal driver="uart" instance="9" name="tx"/>
         </request>
-        <request position="118">
-          <signal driver="tim" instance="23" name="ch1"/>
+        <request device-pin="a" device-package="i" position="118">
+          <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request position="119">
-          <signal driver="tim" instance="23" name="ch2"/>
+        <request device-pin="i" device-package="k|t" position="118">
+          <signal driver="usart" instance="10" name="rx"/>
+        </request>
+        <request device-pin="v" device-package="h" position="118">
+          <signal driver="usart" instance="10" name="rx"/>
+        </request>
+        <request device-pin="z" device-package="t" position="118">
+          <signal driver="usart" instance="10" name="rx"/>
+        </request>
+        <request device-pin="a" device-package="i" position="119">
+          <signal driver="usart" instance="10" name="tx"/>
+        </request>
+        <request device-pin="i" device-package="k|t" position="119">
+          <signal driver="usart" instance="10" name="tx"/>
+        </request>
+        <request device-pin="v" device-package="h" position="119">
+          <signal driver="usart" instance="10" name="tx"/>
+        </request>
+        <request device-pin="z" device-package="t" position="119">
+          <signal driver="usart" instance="10" name="tx"/>
         </request>
         <request position="120">
-          <signal driver="tim" instance="23" name="ch3"/>
+          <signal driver="fmac" name="rd"/>
         </request>
         <request position="121">
-          <signal driver="tim" instance="23" name="ch4"/>
+          <signal driver="fmac" name="wr"/>
         </request>
         <request position="122">
-          <signal driver="tim" instance="23" name="trig"/>
+          <signal driver="cordic" name="rd"/>
         </request>
         <request position="123">
-          <signal driver="tim" instance="23" name="up"/>
+          <signal driver="cordic" name="wr"/>
         </request>
-        <request position="124">
-          <signal driver="tim" instance="24" name="ch1"/>
+        <request device-pin="a|i|v|z" position="124">
+          <signal driver="i2c" instance="5" name="rx"/>
         </request>
-        <request position="125">
-          <signal driver="tim" instance="24" name="ch2"/>
+        <request device-pin="a|i|v|z" position="125">
+          <signal driver="i2c" instance="5" name="tx"/>
         </request>
         <request position="126">
-          <signal driver="tim" instance="24" name="ch3"/>
+          <signal driver="tim" instance="23" name="ch1"/>
         </request>
         <request position="127">
-          <signal driver="tim" instance="24" name="ch4"/>
+          <signal driver="tim" instance="23" name="ch2"/>
         </request>
         <request position="128">
-          <signal driver="tim" instance="24" name="trig"/>
+          <signal driver="tim" instance="23" name="ch3"/>
         </request>
         <request position="129">
+          <signal driver="tim" instance="23" name="ch4"/>
+        </request>
+        <request position="130">
+          <signal driver="tim" instance="23" name="up"/>
+        </request>
+        <request position="131">
+          <signal driver="tim" instance="23" name="trig"/>
+        </request>
+        <request position="132">
+          <signal driver="tim" instance="24" name="ch1"/>
+        </request>
+        <request position="133">
+          <signal driver="tim" instance="24" name="ch2"/>
+        </request>
+        <request position="134">
+          <signal driver="tim" instance="24" name="ch3"/>
+        </request>
+        <request position="135">
+          <signal driver="tim" instance="24" name="ch4"/>
+        </request>
+        <request position="136">
           <signal driver="tim" instance="24" name="up"/>
+        </request>
+        <request position="137">
+          <signal driver="tim" instance="24" name="trig"/>
         </request>
       </requests>
       <mux-channels>
@@ -1409,7 +1409,7 @@
         <signal driver="adc" instance="2" name="inp4"/>
         <signal driver="comp" instance="1" name="inm"/>
         <signal driver="opamp" instance="1" name="vout"/>
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal device-pin="a|i|v|z" af="1" driver="fmc" name="a22"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
@@ -1424,7 +1424,7 @@
         <signal driver="adc" instance="2" name="inn4"/>
         <signal driver="adc" instance="2" name="inp8"/>
         <signal driver="opamp" instance="1" name="vinm"/>
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal device-pin="a|i|v|z" af="1" driver="sai" instance="4" name="d3"/>
         <signal device-pin="a|i|v|z" af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
@@ -1675,7 +1675,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio device-pin="a" device-package="i" port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1686,7 +1686,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio device-pin="i" device-package="k|t" port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1697,7 +1697,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio device-pin="v" device-package="h" port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1708,7 +1708,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio device-pin="z" device-package="t" port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1719,7 +1719,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio device-pin="a|i|v|z" port="d" pin="8">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
         <signal af="12" driver="fmc" name="d13"/>
@@ -2367,7 +2367,7 @@
         <signal af="14" driver="ltdc" name="clk"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="8">
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal af="3" driver="tim" instance="8" name="etr"/>
         <signal af="5" driver="i2s" instance="6" name="ws"/>
         <signal af="5" driver="spi" instance="6" name="nss"/>
@@ -2378,7 +2378,7 @@
         <signal af="14" driver="ltdc" name="g7"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="9">
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal af="2" driver="fdcan" instance="3" name="tx"/>
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
@@ -2405,7 +2405,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="11">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="1" driver="lptim" instance="1" name="in2"/>
         <signal af="4" driver="usart" instance="10" name="rx"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
@@ -2418,7 +2418,7 @@
         <signal af="14" driver="ltdc" name="b3"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="12">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="1" driver="lptim" instance="1" name="in1"/>
         <signal af="3" driver="octospim" name="p2_ncs"/>
         <signal af="4" driver="usart" instance="10" name="tx"/>

--- a/devices/stm32/stm32h7-30.xml
+++ b/devices/stm32/stm32h7-30.xml
@@ -344,7 +344,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -621,110 +621,110 @@
         <request position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="107">
-          <signal driver="uart" instance="9" name="rx"/>
-        </request>
-        <request position="108">
-          <signal driver="uart" instance="9" name="tx"/>
-        </request>
-        <request position="109">
-          <signal driver="usart" instance="10" name="rx"/>
-        </request>
-        <request position="110">
-          <signal driver="usart" instance="10" name="tx"/>
-        </request>
-        <request position="111">
+        <request position="115">
           <signal driver="adc" instance="3"/>
         </request>
-        <request position="112">
-          <signal driver="fmac" name="rd"/>
-        </request>
-        <request position="113">
-          <signal driver="fmac" name="wr"/>
-        </request>
-        <request position="114">
-          <signal driver="cordic" name="rd"/>
-        </request>
-        <request position="115">
-          <signal driver="cordic" name="wr"/>
-        </request>
         <request position="116">
-          <signal driver="i2c" instance="5" name="rx"/>
+          <signal driver="uart" instance="9" name="rx"/>
         </request>
         <request position="117">
-          <signal driver="i2c" instance="5" name="tx"/>
+          <signal driver="uart" instance="9" name="tx"/>
         </request>
         <request position="118">
-          <signal driver="tim" instance="23" name="ch1"/>
+          <signal driver="usart" instance="10" name="rx"/>
         </request>
         <request position="119">
-          <signal driver="tim" instance="23" name="ch2"/>
+          <signal driver="usart" instance="10" name="tx"/>
         </request>
         <request position="120">
-          <signal driver="tim" instance="23" name="ch3"/>
+          <signal driver="fmac" name="rd"/>
         </request>
         <request position="121">
-          <signal driver="tim" instance="23" name="ch4"/>
+          <signal driver="fmac" name="wr"/>
         </request>
         <request position="122">
-          <signal driver="tim" instance="23" name="trig"/>
+          <signal driver="cordic" name="rd"/>
         </request>
         <request position="123">
-          <signal driver="tim" instance="23" name="up"/>
+          <signal driver="cordic" name="wr"/>
         </request>
         <request position="124">
-          <signal driver="tim" instance="24" name="ch1"/>
+          <signal driver="i2c" instance="5" name="rx"/>
         </request>
         <request position="125">
-          <signal driver="tim" instance="24" name="ch2"/>
+          <signal driver="i2c" instance="5" name="tx"/>
         </request>
         <request position="126">
-          <signal driver="tim" instance="24" name="ch3"/>
+          <signal driver="tim" instance="23" name="ch1"/>
         </request>
         <request position="127">
-          <signal driver="tim" instance="24" name="ch4"/>
+          <signal driver="tim" instance="23" name="ch2"/>
         </request>
         <request position="128">
-          <signal driver="tim" instance="24" name="trig"/>
+          <signal driver="tim" instance="23" name="ch3"/>
         </request>
         <request position="129">
+          <signal driver="tim" instance="23" name="ch4"/>
+        </request>
+        <request position="130">
+          <signal driver="tim" instance="23" name="up"/>
+        </request>
+        <request position="131">
+          <signal driver="tim" instance="23" name="trig"/>
+        </request>
+        <request position="132">
+          <signal driver="tim" instance="24" name="ch1"/>
+        </request>
+        <request position="133">
+          <signal driver="tim" instance="24" name="ch2"/>
+        </request>
+        <request position="134">
+          <signal driver="tim" instance="24" name="ch3"/>
+        </request>
+        <request position="135">
+          <signal driver="tim" instance="24" name="ch4"/>
+        </request>
+        <request position="136">
           <signal driver="tim" instance="24" name="up"/>
+        </request>
+        <request position="137">
+          <signal driver="tim" instance="24" name="trig"/>
         </request>
       </requests>
       <mux-channels>
@@ -1329,7 +1329,7 @@
         <signal driver="adc" instance="2" name="inp4"/>
         <signal driver="comp" instance="1" name="inm"/>
         <signal driver="opamp" instance="1" name="vout"/>
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal af="1" driver="fmc" name="a22"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
@@ -1344,7 +1344,7 @@
         <signal driver="adc" instance="2" name="inn4"/>
         <signal driver="adc" instance="2" name="inp8"/>
         <signal driver="opamp" instance="1" name="vinm"/>
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal af="1" driver="sai" instance="4" name="d3"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
@@ -1544,7 +1544,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio port="d" pin="7">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin4"/>
         <signal af="5" driver="i2s" instance="1" name="sdo"/>
         <signal af="5" driver="spi" instance="1" name="mosi"/>
@@ -1555,7 +1555,7 @@
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
       <gpio port="d" pin="8">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
         <signal af="12" driver="fmc" name="d13"/>
@@ -1987,7 +1987,7 @@
         <signal af="14" driver="ltdc" name="clk"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="8">
-        <signal driver="spdifrx" instance="1" name="in2"/>
+        <signal driver="spdifrx" name="in2"/>
         <signal af="3" driver="tim" instance="8" name="etr"/>
         <signal af="5" driver="i2s" instance="6" name="ws"/>
         <signal af="5" driver="spi" instance="6" name="nss"/>
@@ -1998,7 +1998,7 @@
         <signal af="14" driver="ltdc" name="g7"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="9">
-        <signal driver="spdifrx" instance="1" name="in3"/>
+        <signal driver="spdifrx" name="in3"/>
         <signal af="2" driver="fdcan" instance="3" name="tx"/>
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
@@ -2025,7 +2025,7 @@
         <signal af="14" driver="ltdc" name="b2"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="11">
-        <signal driver="spdifrx" instance="1" name="in0"/>
+        <signal driver="spdifrx" name="in0"/>
         <signal af="1" driver="lptim" instance="1" name="in2"/>
         <signal af="4" driver="usart" instance="10" name="rx"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
@@ -2038,7 +2038,7 @@
         <signal af="14" driver="ltdc" name="b3"/>
       </gpio>
       <gpio device-pin="a|i|z" port="g" pin="12">
-        <signal driver="spdifrx" instance="1" name="in1"/>
+        <signal driver="spdifrx" name="in1"/>
         <signal af="1" driver="lptim" instance="1" name="in1"/>
         <signal af="3" driver="octospim" name="p2_ncs"/>
         <signal af="4" driver="usart" instance="10" name="tx"/>

--- a/devices/stm32/stm32h7-42.xml
+++ b/devices/stm32/stm32h7-42.xml
@@ -333,7 +333,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -1168,7 +1168,7 @@
         <signal driver="opamp" instance="1" name="vout"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="9" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="rxd0"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
@@ -1181,7 +1181,7 @@
         <signal driver="opamp" instance="1" name="vinm0"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="9" driver="spdifrx" name="in3"/>
         <signal af="10" driver="sai" instance="4" name="d3"/>
         <signal af="11" driver="eth" name="rxd1"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
@@ -1351,7 +1351,7 @@
         <signal af="5" driver="spi" instance="1" name="mosi"/>
         <signal af="6" driver="dfsdm" instance="1" name="ckin1"/>
         <signal af="7" driver="usart" instance="2" name="ck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="9" driver="spdifrx" name="in0"/>
         <signal af="11" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
@@ -1359,7 +1359,7 @@
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="6" driver="sai" instance="3" name="sck_b"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="9" driver="spdifrx" name="in1"/>
         <signal af="12" driver="fmc" name="d13"/>
         <signal af="12" driver="fmc" name="da13"/>
       </gpio>
@@ -1733,7 +1733,7 @@
         <signal af="5" driver="spi" instance="6" name="nss"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="8" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="pps_out"/>
         <signal af="12" driver="fmc" name="sdclk"/>
       </gpio>
@@ -1741,7 +1741,7 @@
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="rx"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="8" driver="spdifrx" name="in3"/>
         <signal af="9" driver="quadspi" name="bk2_io2"/>
         <signal af="10" driver="sai" instance="2" name="fs_b"/>
         <signal af="12" driver="fmc" name="nce"/>
@@ -1761,7 +1761,7 @@
         <signal af="2" driver="hrtim" name="eev4"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
         <signal af="5" driver="spi" instance="1" name="sck"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="8" driver="spdifrx" name="in0"/>
         <signal af="10" driver="sdmmc" instance="2" name="d2"/>
         <signal af="11" driver="eth" name="tx_en"/>
         <signal af="13" driver="dcmi" name="d3"/>
@@ -1772,7 +1772,7 @@
         <signal af="5" driver="spi" instance="6" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="8" driver="spdifrx" name="in1"/>
         <signal af="11" driver="eth" name="txd1"/>
         <signal af="12" driver="fmc" name="ne4"/>
       </gpio>

--- a/devices/stm32/stm32h7-43_53.xml
+++ b/devices/stm32/stm32h7-43_53.xml
@@ -351,7 +351,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -1218,7 +1218,7 @@
         <signal driver="opamp" instance="1" name="vout"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="9" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="rxd0"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
@@ -1231,7 +1231,7 @@
         <signal driver="opamp" instance="1" name="vinm0"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="9" driver="spdifrx" name="in3"/>
         <signal af="10" driver="sai" instance="4" name="d3"/>
         <signal af="11" driver="eth" name="rxd1"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
@@ -1408,7 +1408,7 @@
         <signal af="5" driver="spi" instance="1" name="mosi"/>
         <signal af="6" driver="dfsdm" instance="1" name="ckin1"/>
         <signal af="7" driver="usart" instance="2" name="ck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="9" driver="spdifrx" name="in0"/>
         <signal af="11" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
@@ -1416,7 +1416,7 @@
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="6" driver="sai" instance="3" name="sck_b"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="9" driver="spdifrx" name="in1"/>
         <signal af="12" driver="fmc" name="d13"/>
         <signal af="12" driver="fmc" name="da13"/>
       </gpio>
@@ -1802,7 +1802,7 @@
         <signal af="5" driver="spi" instance="6" name="nss"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="8" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="pps_out"/>
         <signal af="12" driver="fmc" name="sdclk"/>
         <signal af="14" driver="ltdc" name="g7"/>
@@ -1811,7 +1811,7 @@
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="rx"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="8" driver="spdifrx" name="in3"/>
         <signal af="9" driver="quadspi" name="bk2_io2"/>
         <signal af="10" driver="sai" instance="2" name="fs_b"/>
         <signal af="12" driver="fmc" name="nce"/>
@@ -1833,7 +1833,7 @@
         <signal af="2" driver="hrtim" name="eev4"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
         <signal af="5" driver="spi" instance="1" name="sck"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="8" driver="spdifrx" name="in0"/>
         <signal af="10" driver="sdmmc" instance="2" name="d2"/>
         <signal af="11" driver="eth" name="tx_en"/>
         <signal af="13" driver="dcmi" name="d3"/>
@@ -1845,7 +1845,7 @@
         <signal af="5" driver="spi" instance="6" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="8" driver="spdifrx" name="in1"/>
         <signal af="9" driver="ltdc" name="b4"/>
         <signal af="11" driver="eth" name="txd1"/>
         <signal af="12" driver="fmc" name="ne4"/>

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -413,7 +413,7 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -1280,7 +1280,7 @@
         <signal driver="opamp" instance="1" name="vout"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="9" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="rxd0"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
@@ -1293,7 +1293,7 @@
         <signal driver="opamp" instance="1" name="vinm0"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="9" driver="spdifrx" name="in3"/>
         <signal af="10" driver="sai" instance="4" name="d3"/>
         <signal af="11" driver="eth" name="rxd1"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
@@ -1470,7 +1470,7 @@
         <signal af="5" driver="spi" instance="1" name="mosi"/>
         <signal af="6" driver="dfsdm" instance="1" name="ckin1"/>
         <signal af="7" driver="usart" instance="2" name="ck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="9" driver="spdifrx" name="in0"/>
         <signal af="11" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
@@ -1478,7 +1478,7 @@
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="6" driver="sai" instance="3" name="sck_b"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="9" driver="spdifrx" name="in1"/>
         <signal af="12" driver="fmc" name="d13"/>
         <signal af="12" driver="fmc" name="da13"/>
       </gpio>
@@ -1864,7 +1864,7 @@
         <signal af="5" driver="spi" instance="6" name="nss"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="8" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="pps_out"/>
         <signal af="12" driver="fmc" name="sdclk"/>
         <signal af="14" driver="ltdc" name="g7"/>
@@ -1873,7 +1873,7 @@
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="rx"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="8" driver="spdifrx" name="in3"/>
         <signal af="9" driver="quadspi" name="bk2_io2"/>
         <signal af="10" driver="sai" instance="2" name="fs_b"/>
         <signal af="12" driver="fmc" name="nce"/>
@@ -1895,7 +1895,7 @@
         <signal af="2" driver="hrtim" name="eev4"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
         <signal af="5" driver="spi" instance="1" name="sck"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="8" driver="spdifrx" name="in0"/>
         <signal af="10" driver="sdmmc" instance="2" name="d2"/>
         <signal af="11" driver="eth" name="tx_en"/>
         <signal af="13" driver="dcmi" name="d3"/>
@@ -1907,7 +1907,7 @@
         <signal af="5" driver="spi" instance="6" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="8" driver="spdifrx" name="in1"/>
         <signal af="9" driver="ltdc" name="b4"/>
         <signal af="11" driver="eth" name="txd1"/>
         <signal af="12" driver="fmc" name="ne4"/>

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -373,7 +373,7 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -1242,7 +1242,7 @@
         <signal driver="opamp" instance="1" name="vout"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="9" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="rxd0"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
@@ -1255,7 +1255,7 @@
         <signal driver="opamp" instance="1" name="vinm0"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="9" driver="spdifrx" name="in3"/>
         <signal af="10" driver="sai" instance="4" name="d3"/>
         <signal af="11" driver="eth" name="rxd1"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
@@ -1432,7 +1432,7 @@
         <signal af="5" driver="spi" instance="1" name="mosi"/>
         <signal af="6" driver="dfsdm" instance="1" name="ckin1"/>
         <signal af="7" driver="usart" instance="2" name="ck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="9" driver="spdifrx" name="in0"/>
         <signal af="11" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
@@ -1440,7 +1440,7 @@
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="6" driver="sai" instance="3" name="sck_b"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="9" driver="spdifrx" name="in1"/>
         <signal af="12" driver="fmc" name="d13"/>
         <signal af="12" driver="fmc" name="da13"/>
       </gpio>
@@ -1826,7 +1826,7 @@
         <signal af="5" driver="spi" instance="6" name="nss"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="8" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="pps_out"/>
         <signal af="12" driver="fmc" name="sdclk"/>
         <signal af="14" driver="ltdc" name="g7"/>
@@ -1835,7 +1835,7 @@
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="rx"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="8" driver="spdifrx" name="in3"/>
         <signal af="9" driver="quadspi" name="bk2_io2"/>
         <signal af="10" driver="sai" instance="2" name="fs_b"/>
         <signal af="12" driver="fmc" name="nce"/>
@@ -1857,7 +1857,7 @@
         <signal af="2" driver="hrtim" name="eev4"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
         <signal af="5" driver="spi" instance="1" name="sck"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="8" driver="spdifrx" name="in0"/>
         <signal af="10" driver="sdmmc" instance="2" name="d2"/>
         <signal af="11" driver="eth" name="tx_en"/>
         <signal af="13" driver="dcmi" name="d3"/>
@@ -1869,7 +1869,7 @@
         <signal af="5" driver="spi" instance="6" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="8" driver="spdifrx" name="in1"/>
         <signal af="9" driver="ltdc" name="b4"/>
         <signal af="11" driver="eth" name="txd1"/>
         <signal af="12" driver="fmc" name="ne4"/>

--- a/devices/stm32/stm32h7-50.xml
+++ b/devices/stm32/stm32h7-50.xml
@@ -330,7 +330,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -1197,7 +1197,7 @@
         <signal driver="opamp" instance="1" name="vout"/>
         <signal af="3" driver="dfsdm" instance="1" name="ckin2"/>
         <signal af="5" driver="i2s" instance="1" name="mck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="9" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="rxd0"/>
         <signal af="12" driver="fmc" name="sdne0"/>
       </gpio>
@@ -1210,7 +1210,7 @@
         <signal driver="opamp" instance="1" name="vinm0"/>
         <signal af="2" driver="sai" instance="1" name="d3"/>
         <signal af="3" driver="dfsdm" instance="1" name="datin2"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="9" driver="spdifrx" name="in3"/>
         <signal af="10" driver="sai" instance="4" name="d3"/>
         <signal af="11" driver="eth" name="rxd1"/>
         <signal af="12" driver="fmc" name="sdcke0"/>
@@ -1387,7 +1387,7 @@
         <signal af="5" driver="spi" instance="1" name="mosi"/>
         <signal af="6" driver="dfsdm" instance="1" name="ckin1"/>
         <signal af="7" driver="usart" instance="2" name="ck"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="9" driver="spdifrx" name="in0"/>
         <signal af="11" driver="sdmmc" instance="2" name="cmd"/>
         <signal af="12" driver="fmc" name="ne1"/>
       </gpio>
@@ -1395,7 +1395,7 @@
         <signal af="3" driver="dfsdm" instance="1" name="ckin3"/>
         <signal af="6" driver="sai" instance="3" name="sck_b"/>
         <signal af="7" driver="usart" instance="3" name="tx"/>
-        <signal af="9" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="9" driver="spdifrx" name="in1"/>
         <signal af="12" driver="fmc" name="d13"/>
         <signal af="12" driver="fmc" name="da13"/>
       </gpio>
@@ -1781,7 +1781,7 @@
         <signal af="5" driver="spi" instance="6" name="nss"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in2"/>
+        <signal af="8" driver="spdifrx" name="in2"/>
         <signal af="11" driver="eth" name="pps_out"/>
         <signal af="12" driver="fmc" name="sdclk"/>
         <signal af="14" driver="ltdc" name="g7"/>
@@ -1790,7 +1790,7 @@
         <signal af="5" driver="i2s" instance="1" name="sdi"/>
         <signal af="5" driver="spi" instance="1" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="rx"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in3"/>
+        <signal af="8" driver="spdifrx" name="in3"/>
         <signal af="9" driver="quadspi" name="bk2_io2"/>
         <signal af="10" driver="sai" instance="2" name="fs_b"/>
         <signal af="12" driver="fmc" name="nce"/>
@@ -1812,7 +1812,7 @@
         <signal af="2" driver="hrtim" name="eev4"/>
         <signal af="5" driver="i2s" instance="1" name="ck"/>
         <signal af="5" driver="spi" instance="1" name="sck"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in0"/>
+        <signal af="8" driver="spdifrx" name="in0"/>
         <signal af="10" driver="sdmmc" instance="2" name="d2"/>
         <signal af="11" driver="eth" name="tx_en"/>
         <signal af="13" driver="dcmi" name="d3"/>
@@ -1824,7 +1824,7 @@
         <signal af="5" driver="spi" instance="6" name="miso"/>
         <signal af="7" driver="usart" instance="6" name="de"/>
         <signal af="7" driver="usart" instance="6" name="rts"/>
-        <signal af="8" driver="spdifrx" instance="1" name="in1"/>
+        <signal af="8" driver="spdifrx" name="in1"/>
         <signal af="9" driver="ltdc" name="b4"/>
         <signal af="11" driver="eth" name="txd1"/>
         <signal af="12" driver="fmc" name="ne4"/>

--- a/devices/stm32/stm32h7-a3.xml
+++ b/devices/stm32/stm32h7-a3.xml
@@ -367,7 +367,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -677,88 +677,88 @@
         <request device-pin="z" device-package="t" device-variant="q" position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request device-pin="a|i|l|n|q|v|z" position="107">
+        <request device-pin="a|i|l|n|q|v|z" position="116">
           <signal driver="uart" instance="9" name="rx"/>
         </request>
-        <request device-pin="a|i|l|n|q|v|z" position="108">
+        <request device-pin="a|i|l|n|q|v|z" position="117">
           <signal driver="uart" instance="9" name="tx"/>
         </request>
-        <request device-pin="l|v" device-package="h" device-variant="q" position="109">
+        <request device-pin="l|v" device-package="h" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="n|v" device-package="h" device-variant="" position="109">
+        <request device-pin="n|v" device-package="h" device-variant="" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="v|z" device-package="t" device-variant="" position="109">
+        <request device-pin="v|z" device-package="t" device-variant="" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="a" device-package="i" device-variant="q" position="109">
+        <request device-pin="a" device-package="i" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="i" device-package="k|t" device-variant="|q" position="109">
+        <request device-pin="i" device-package="k|t" device-variant="|q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="q" device-package="y" device-variant="q" position="109">
+        <request device-pin="q" device-package="y" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="z" device-package="t" device-variant="q" position="109">
+        <request device-pin="z" device-package="t" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="l|v" device-package="h" device-variant="q" position="110">
+        <request device-pin="l|v" device-package="h" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="n|v" device-package="h" device-variant="" position="110">
+        <request device-pin="n|v" device-package="h" device-variant="" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="v|z" device-package="t" device-variant="" position="110">
+        <request device-pin="v|z" device-package="t" device-variant="" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="a" device-package="i" device-variant="q" position="110">
+        <request device-pin="a" device-package="i" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="i" device-package="k|t" device-variant="|q" position="110">
+        <request device-pin="i" device-package="k|t" device-variant="|q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="q" device-package="y" device-variant="q" position="110">
+        <request device-pin="q" device-package="y" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="z" device-package="t" device-variant="q" position="110">
+        <request device-pin="z" device-package="t" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32h7-b0.xml
+++ b/devices/stm32/stm32h7-b0.xml
@@ -340,7 +340,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -623,52 +623,52 @@
         <request position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request device-pin="a|i|v|z" position="107">
+        <request device-pin="a|i|v|z" position="116">
           <signal driver="uart" instance="9" name="rx"/>
         </request>
-        <request device-pin="a|i|v|z" position="108">
+        <request device-pin="a|i|v|z" position="117">
           <signal driver="uart" instance="9" name="tx"/>
         </request>
-        <request device-pin="a|i|v|z" position="109">
+        <request device-pin="a|i|v|z" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="a|i|v|z" position="110">
+        <request device-pin="a|i|v|z" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32h7-b3.xml
+++ b/devices/stm32/stm32h7-b3.xml
@@ -362,7 +362,7 @@
     <driver name="wwdg" type="stm32-v2.0">
       <instance value="1"/>
     </driver>
-    <driver name="dma" type="stm32-mux">
+    <driver name="dma" type="stm32-mux-stream">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -681,88 +681,88 @@
         <request device-pin="z" device-package="t" device-variant="q" position="94">
           <signal driver="spdifrx" name="cs"/>
         </request>
-        <request position="95">
+        <request position="101">
           <signal driver="dfsdm" instance="1" name="flt0"/>
         </request>
-        <request position="96">
+        <request position="102">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request position="97">
+        <request position="103">
           <signal driver="dfsdm" instance="1" name="flt2"/>
         </request>
-        <request position="98">
+        <request position="104">
           <signal driver="dfsdm" instance="1" name="flt3"/>
         </request>
-        <request position="99">
+        <request position="105">
           <signal driver="tim" instance="15" name="ch1"/>
         </request>
-        <request position="100">
+        <request position="106">
           <signal driver="tim" instance="15" name="up"/>
         </request>
-        <request position="101">
+        <request position="107">
           <signal driver="tim" instance="15" name="trig"/>
         </request>
-        <request position="102">
+        <request position="108">
           <signal driver="tim" instance="15" name="com"/>
         </request>
-        <request position="103">
+        <request position="109">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="104">
+        <request position="110">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="105">
+        <request position="111">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="106">
+        <request position="112">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request device-pin="a|i|l|n|q|v|z" position="107">
+        <request device-pin="a|i|l|n|q|v|z" position="116">
           <signal driver="uart" instance="9" name="rx"/>
         </request>
-        <request device-pin="a|i|l|n|q|v|z" position="108">
+        <request device-pin="a|i|l|n|q|v|z" position="117">
           <signal driver="uart" instance="9" name="tx"/>
         </request>
-        <request device-pin="l|v" device-package="h" device-variant="q" position="109">
+        <request device-pin="l|v" device-package="h" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="n|v" device-package="h" device-variant="" position="109">
+        <request device-pin="n|v" device-package="h" device-variant="" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="v|z" device-package="t" device-variant="" position="109">
+        <request device-pin="v|z" device-package="t" device-variant="" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="a" device-package="i" device-variant="q" position="109">
+        <request device-pin="a" device-package="i" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="i" device-package="k|t" device-variant="|q" position="109">
+        <request device-pin="i" device-package="k|t" device-variant="|q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="q" device-package="y" device-variant="q" position="109">
+        <request device-pin="q" device-package="y" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="z" device-package="t" device-variant="q" position="109">
+        <request device-pin="z" device-package="t" device-variant="q" position="118">
           <signal driver="usart" instance="10" name="rx"/>
         </request>
-        <request device-pin="l|v" device-package="h" device-variant="q" position="110">
+        <request device-pin="l|v" device-package="h" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="n|v" device-package="h" device-variant="" position="110">
+        <request device-pin="n|v" device-package="h" device-variant="" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="v|z" device-package="t" device-variant="" position="110">
+        <request device-pin="v|z" device-package="t" device-variant="" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="a" device-package="i" device-variant="q" position="110">
+        <request device-pin="a" device-package="i" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="i" device-package="k|t" device-variant="|q" position="110">
+        <request device-pin="i" device-package="k|t" device-variant="|q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="q" device-package="y" device-variant="q" position="110">
+        <request device-pin="q" device-package="y" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
-        <request device-pin="z" device-package="t" device-variant="q" position="110">
+        <request device-pin="z" device-package="t" device-variant="q" position="119">
           <signal driver="usart" instance="10" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32l4-p5.xml
+++ b/devices/stm32/stm32l4-p5.xml
@@ -511,13 +511,11 @@
         <request position="88">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request device-pin="a|q|r|v|z" position="89">
+        <request device-pin="a|q|r|v|z" position="91">
           <signal driver="dcmi"/>
-        </request>
-        <request device-pin="a|q|r|v|z" position="90">
           <signal driver="pssi"/>
         </request>
-        <request position="93">
+        <request position="94">
           <signal driver="hash" name="in"/>
         </request>
       </requests>

--- a/devices/stm32/stm32l4-q5.xml
+++ b/devices/stm32/stm32l4-q5.xml
@@ -508,19 +508,17 @@
         <request position="88">
           <signal driver="dfsdm" instance="1" name="flt1"/>
         </request>
-        <request device-pin="a|q|r|v|z" position="89">
+        <request device-pin="a|q|r|v|z" position="91">
           <signal driver="dcmi"/>
-        </request>
-        <request device-pin="a|q|r|v|z" position="90">
           <signal driver="pssi"/>
         </request>
-        <request position="91">
+        <request position="92">
           <signal driver="aes" name="in"/>
         </request>
-        <request position="92">
+        <request position="93">
           <signal driver="aes" name="out"/>
         </request>
-        <request position="93">
+        <request position="94">
           <signal driver="hash" name="in"/>
         </request>
       </requests>

--- a/devices/stm32/stm32wl-54_55.xml
+++ b/devices/stm32/stm32wl-54_55.xml
@@ -154,7 +154,7 @@
     </driver>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0"/>
-    <driver name="dma" type="stm32-channel">
+    <driver name="dma" type="stm32-mux">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -224,64 +224,64 @@
         <request position="22">
           <signal driver="lpuart" instance="1" name="tx"/>
         </request>
-        <request position="26">
+        <request position="23">
           <signal driver="tim" instance="1" name="ch1"/>
         </request>
-        <request position="27">
+        <request position="24">
           <signal driver="tim" instance="1" name="ch2"/>
         </request>
-        <request position="28">
+        <request position="25">
           <signal driver="tim" instance="1" name="ch3"/>
         </request>
-        <request position="29">
+        <request position="26">
           <signal driver="tim" instance="1" name="ch4"/>
         </request>
-        <request position="30">
+        <request position="27">
           <signal driver="tim" instance="1" name="up"/>
         </request>
-        <request position="31">
+        <request position="28">
           <signal driver="tim" instance="1" name="trig"/>
         </request>
-        <request position="32">
+        <request position="29">
           <signal driver="tim" instance="1" name="com"/>
         </request>
-        <request position="33">
+        <request position="30">
           <signal driver="tim" instance="2" name="ch1"/>
         </request>
-        <request position="34">
+        <request position="31">
           <signal driver="tim" instance="2" name="ch2"/>
         </request>
-        <request position="35">
+        <request position="32">
           <signal driver="tim" instance="2" name="ch3"/>
         </request>
-        <request position="36">
+        <request position="33">
           <signal driver="tim" instance="2" name="ch4"/>
         </request>
-        <request position="37">
+        <request position="34">
           <signal driver="tim" instance="2" name="up"/>
         </request>
-        <request position="38">
+        <request position="35">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="39">
+        <request position="36">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="40">
+        <request position="37">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="41">
+        <request position="38">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="42">
+        <request position="39">
           <signal driver="aes" name="in"/>
         </request>
-        <request position="43">
+        <request position="40">
           <signal driver="aes" name="out"/>
         </request>
-        <request position="44">
+        <request position="41">
           <signal driver="subghz" name="rx"/>
         </request>
-        <request position="45">
+        <request position="42">
           <signal driver="subghz" name="tx"/>
         </request>
       </requests>

--- a/devices/stm32/stm32wl-e4_e5.xml
+++ b/devices/stm32/stm32wl-e4_e5.xml
@@ -173,7 +173,7 @@
     </driver>
     <driver name="vrefbuf" type="stm32-v1.0"/>
     <driver name="wwdg" type="stm32-v2.0"/>
-    <driver name="dma" type="stm32-channel">
+    <driver name="dma" type="stm32-mux">
       <instance value="1"/>
       <instance value="2"/>
       <requests>
@@ -243,64 +243,64 @@
         <request position="22">
           <signal driver="lpuart" instance="1" name="tx"/>
         </request>
-        <request position="26">
+        <request position="23">
           <signal driver="tim" instance="1" name="ch1"/>
         </request>
-        <request position="27">
+        <request position="24">
           <signal driver="tim" instance="1" name="ch2"/>
         </request>
-        <request position="28">
+        <request position="25">
           <signal driver="tim" instance="1" name="ch3"/>
         </request>
-        <request position="29">
+        <request position="26">
           <signal driver="tim" instance="1" name="ch4"/>
         </request>
-        <request position="30">
+        <request position="27">
           <signal driver="tim" instance="1" name="up"/>
         </request>
-        <request position="31">
+        <request position="28">
           <signal driver="tim" instance="1" name="trig"/>
         </request>
-        <request position="32">
+        <request position="29">
           <signal driver="tim" instance="1" name="com"/>
         </request>
-        <request position="33">
+        <request position="30">
           <signal driver="tim" instance="2" name="ch1"/>
         </request>
-        <request position="34">
+        <request position="31">
           <signal driver="tim" instance="2" name="ch2"/>
         </request>
-        <request position="35">
+        <request position="32">
           <signal driver="tim" instance="2" name="ch3"/>
         </request>
-        <request position="36">
+        <request position="33">
           <signal driver="tim" instance="2" name="ch4"/>
         </request>
-        <request position="37">
+        <request position="34">
           <signal driver="tim" instance="2" name="up"/>
         </request>
-        <request position="38">
+        <request position="35">
           <signal driver="tim" instance="16" name="ch1"/>
         </request>
-        <request position="39">
+        <request position="36">
           <signal driver="tim" instance="16" name="up"/>
         </request>
-        <request position="40">
+        <request position="37">
           <signal driver="tim" instance="17" name="ch1"/>
         </request>
-        <request position="41">
+        <request position="38">
           <signal driver="tim" instance="17" name="up"/>
         </request>
-        <request position="42">
+        <request position="39">
           <signal driver="aes" name="in"/>
         </request>
-        <request position="43">
+        <request position="40">
           <signal driver="aes" name="out"/>
         </request>
-        <request position="44">
+        <request position="41">
           <signal driver="subghz" name="rx"/>
         </request>
-        <request position="45">
+        <request position="42">
           <signal driver="subghz" name="tx"/>
         </request>
       </requests>

--- a/modm_devices/__init__.py
+++ b/modm_devices/__init__.py
@@ -16,4 +16,4 @@ from .exception import ParserException
 
 __all__ = ['exception', 'device_file', 'device_identifier', 'device', 'parser', 'pkg']
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/tools/generator/Makefile
+++ b/tools/generator/Makefile
@@ -3,8 +3,11 @@
 ext/%:
 	@git clone https://github.com/modm-io/$(@:ext/%=%).git $@
 
+ext/stm32-cube-hal-drivers:
+	@git clone https://github.com/modm-ext/stm32-cube-hal-drivers.git $@
+
 .PHONY: init
-init: ext/cmsis-header-stm32 ext/cmsis-5-partial #ext/cmsis-header-sam
+init: ext/cmsis-header-stm32 ext/cmsis-5-partial ext/stm32-cube-hal-drivers #ext/cmsis-header-sam
 
 .PHONY: clean_init
 clean_init:
@@ -62,7 +65,7 @@ generate-nrf: generate-nrf52810 generate-nrf52811 generate-nrf52820 generate-nrf
 
 # STM32 device files
 .PHONY: generate-stm32%
-generate-stm32%: raw-device-data/stm32-devices ext/cmsis-5-partial ext/cmsis-header-stm32
+generate-stm32%: raw-device-data/stm32-devices ext/cmsis-5-partial ext/cmsis-header-stm32 ext/stm32-cube-hal-drivers
 	@rm -f ../../devices/stm32/$(@:generate-%=%)*
 	./stm_generator.py $(@:generate-%=%)
 

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -684,6 +684,10 @@ class STMDeviceTree:
                 # if driver.startswith("tc"): driver = "tc";
                 # if driver == "cpu": driver = "core"; instance = "core";
                 # add the af node
+                if driver == "spdifrx" and instance == "1":
+                    # Only one peripheral ever exists, but some H7 have instance "1"
+                    # Naming in manuals and headers is always without "1"
+                    instance = None
                 af = pin_driver.addChild("signal")
                 if afid == "": LOGGER.error("afid is not set: {}".format(s));
                 if afid:     af.setAttributes("af", afid);

--- a/tools/generator/dfg/stm32/stm_dmamux_requests.py
+++ b/tools/generator/dfg/stm32/stm_dmamux_requests.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Christopher Durand
+# All rights reserved.
+
+import re
+from pathlib import Path
+
+ROOT_PATH = Path(__file__).parents[2]
+CUBE_PATH = ROOT_PATH / "ext/stm32-cube-hal-drivers"
+DMAMUX_PATTERN = re.compile(r"^\s*#define\s+(?P<name>(LL_DMAMUX_REQ_\w+))\s+(?P<id>(0x[0-9A-Fa-f]+))U")
+REQUEST_PATTERN = re.compile(r"^\s*#define\s+(?P<name>(DMA_REQUEST_\w+))\s+(?P<id>([0-9]+))U")
+
+def read_request_map(did):
+    dma_header = _get_hal_dma_header_path(did.family)
+    dmamux_header = _get_ll_dmamux_header_path(did.family)
+    request_map = None
+    if did.family in ["g4", "h7", "l5"]:
+        request_map = _read_requests(dma_header)
+    elif did.family in ["g0", "wb", "wl"]:
+        request_map = _read_requests_from_ll_dmamux(dma_header, dmamux_header)
+    elif did.family == "l4" and did.name[0] in ["p", "q", "r", "s"]:
+        request_map = _read_requests_l4(did.name in ["p5", "q5"])
+    else:
+        raise RuntimeError("No DMAMUX request data available for {}".format(did))
+    _fix_request_data(request_map)
+    return request_map
+
+
+def _fix_request_data(request_map):
+    fix_requests = {}
+    dac_pattern = re.compile(r"(?P<dac>(DAC[0-9]))_CHANNEL(?P<ch>[0-9])")
+    for name, number in request_map.items():
+        if name.startswith("GENERATOR"):
+            fix_requests["DMA_" + name] = number
+        elif name == "FMAC_READ":
+            fix_requests["FMAC_RD"] = number
+        elif name == "FMAC_WRITE":
+            fix_requests["FMAC_WR"] = number
+        elif name == "CORDIC_READ":
+            fix_requests["CORDIC_RD"] = number
+        elif name == "CORDIC_WRITE":
+            fix_requests["CORDIC_WR"] = number
+        elif name == "DCMI_PSSI":
+            fix_requests["PSSI"] = number
+        elif name == "TIM16_COM":
+            fix_requests["TIM16_TRIG_COM"] = number
+        elif name == "TIM17_COM":
+            fix_requests["TIM17_TRIG_COM"] = number
+        elif name == "HRTIM_MASTER":
+            fix_requests["HRTIM1_M"] = number
+        elif name.startswith("HRTIM_TIMER_"):
+            fix_requests[name.replace("HRTIM_TIMER_", "HRTIM1_")] = number
+        elif name == "SUBGHZSPI_RX":
+            fix_requests["SUBGHZ_RX"] = number
+        elif name == "SUBGHZSPI_TX":
+            fix_requests["SUBGHZ_TX"] = number
+        else:
+            m = dac_pattern.match(name)
+            if m:
+                fix_requests["{}_CH{}".format(m.group("dac"), m.group("ch"))] = number
+
+    request_map.update(fix_requests)
+
+def _get_include_path(family):
+    return CUBE_PATH / Path("stm32{}xx/Inc".format(family))
+
+
+def _get_hal_dma_header_path(family):
+    return _get_include_path(family) / Path("stm32{}xx_hal_dma.h".format(family))
+
+
+def _get_ll_dmamux_header_path(family):
+    return _get_include_path(family) / Path("stm32{}xx_ll_dmamux.h".format(family))
+
+
+# For G4, H7 and L5
+def _read_requests(hal_dma_file):
+    requests_map = _read_map(hal_dma_file, REQUEST_PATTERN)
+    out_map = {}
+    for r in requests_map.keys():
+        out_map[r.replace("DMA_REQUEST_", "", 1)] = int(requests_map[r])
+    return out_map
+
+
+# For G0, WB and WL
+def _read_requests_from_ll_dmamux(hal_dma_file, ll_dmamux_file):
+    dmamux_map = _read_map(ll_dmamux_file, DMAMUX_PATTERN)
+    request_pattern = re.compile("^\s*#define\s+(?P<name>(DMA_REQUEST_\w+))\s+(?P<id>(LL_DMAMUX?_REQ_\w+))\s*")
+    requests_map = _read_map(hal_dma_file, request_pattern)
+    out_map = {}
+    for r in requests_map.keys():
+        out_map[r.replace("DMA_REQUEST_", "", 1)] = int(dmamux_map[requests_map[r]], 16)
+    return out_map
+
+
+# For L4+
+def _read_requests_l4(read_for_p5_q5):
+    out_map = {}
+    p5_q5_if = "#if defined (STM32L4P5xx) || defined (STM32L4Q5xx)"
+    if_pattern = re.compile(r"^\s*#\s*if\s+")
+    else_pattern = re.compile(r"^\s*#\s*else")
+    endif_pattern = re.compile(r"^\s*#\s*endif")
+    in_p5_q5_section = False
+    ignore = False
+    with open(_get_hal_dma_header_path("l4"), "r") as header_file:
+        if_counter = 0
+        for line in header_file.readlines():
+            if p5_q5_if in line:
+                in_p5_q5_section = True
+                ignore = not read_for_p5_q5
+            elif in_p5_q5_section:
+                if if_pattern.match(line):
+                    if_counter += 1
+                elif endif_pattern.match(line):
+                    if if_counter == 0:
+                        in_p5_q5_section = False
+                        ignore = False
+                    else:
+                        if_counter -= 1
+                elif else_pattern.match(line) and if_counter == 0:
+                    ignore = read_for_p5_q5
+            if not ignore:
+                m = REQUEST_PATTERN.match(line)
+                if m:
+                    name = m.group("name").replace("DMA_REQUEST_", "", 1)
+                    if name in out_map:
+                        raise RuntimeError("Duplicate entry {}".format(name))
+                    out_map[name] = int(m.group("id"))
+    return out_map
+
+
+def _read_map(filename, pattern):
+    out_map = {}
+    with open(filename, "r") as header_file:
+        for line in header_file.readlines():
+            m = pattern.match(line)
+            if m:
+                name = m.group("name")
+                if name in out_map:
+                    raise RuntimeError("Duplicate entry {}".format(name))
+                out_map[name] = m.group("id")
+    return out_map

--- a/tools/generator/dfg/stm32/stm_peripherals.py
+++ b/tools/generator/dfg/stm32/stm_peripherals.py
@@ -124,7 +124,13 @@ stm_peripherals = \
                 'hardware': 'stm32-mux',
                 'features': [],
                 'protocols': ['mem2mem', 'mem2per', 'per2per'],
-                'devices': [{'family': ['h7', 'g0', 'g4', 'wb']}, {'family': ['l4'], 'name': ['p5', 'p7', 'p9', 'q5', 'q7', 'q9', 'r5', 'r7', 'r9', 's5', 's7', 's9']}]
+                'devices': [{'family': ['g0', 'g4', 'l5', 'wb', 'wl']}, {'family': ['l4'], 'name': ['p5', 'p7', 'p9', 'q5', 'q7', 'q9', 'r5', 'r7', 'r9', 's5', 's7', 's9']}]
+            },
+            {
+                'hardware': 'stm32-mux-stream',
+                'features': [],
+                'protocols': ['mem2mem', 'mem2per', 'per2per'],
+                'devices': [{'family': ['h7']}]
             },
             {
                 'hardware': 'stm32-stream-channel',


### PR DESCRIPTION
The current DMAMUX request mapping data is wrong for many G0, H7, L4+ and WL devices. Ids were assumed to be sequential and to be listed in the correct order in the DMA IP CubeMX XML file. For G4 the assumptions were initially valid, but do not hold for various other device families.

The request mappings are now read from the CubeHAL driver header files with a regex-based parser. I double-checked the device file changes with the reference manuals and they seem correct.

Additionally, H7 controllers have a different DMA configuration compared to other controllers with a DMAMUX. They use the same DMA IP as F4 and F7 devices with DMA type "stm32-stream-channel", but multiplex requests with the DMAMUX. Therefore,  a new peripheral type "stm32-mux-stream" is defined.

This PR should be merged after the matching change in modm: https://github.com/modm-io/modm/pull/772