### PR TITLE
Fix STM32H7 dual-core device files

### DIFF
--- a/devices/stm32/stm32h7-23_33.xml
+++ b/devices/stm32/stm32h7-23_33.xml
@@ -573,8 +573,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request device-name="33" position="76">
           <signal driver="cryp" name="in"/>

--- a/devices/stm32/stm32h7-25_35.xml
+++ b/devices/stm32/stm32h7-25_35.xml
@@ -614,8 +614,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request device-name="35" position="76">
           <signal driver="cryp" name="in"/>

--- a/devices/stm32/stm32h7-30.xml
+++ b/devices/stm32/stm32h7-30.xml
@@ -566,8 +566,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request position="76">
           <signal driver="cryp" name="in"/>

--- a/devices/stm32/stm32h7-42.xml
+++ b/devices/stm32/stm32h7-42.xml
@@ -2863,7 +2863,7 @@
         <pin position="E16" name="PA12"/>
         <pin position="E17" name="PA11"/>
         <pin position="F1" name="VSS" type="power"/>
-        <pin position="F2" name="VSS" type="power"/>
+        <pin position="F2" name="NC" type="nc"/>
         <pin position="F3" name="PI10"/>
         <pin position="F4" name="PI11"/>
         <pin position="F5" name="VDD" type="power"/>

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -330,10 +330,6 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="openamp" type="stm32-v1.0">
-      <instance value="cortex-m4"/>
-      <instance value="cortex-m7"/>
-    </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
     <driver name="ramecc" type="stm32-v1.0"/>
@@ -341,7 +337,6 @@
       <max-frequency device-core="m4" value="240000000"/>
       <max-frequency device-core="m7" value="480000000"/>
     </driver>
-    <driver name="resmgr_utility" type="stm32-stm32h7_cube"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">

--- a/devices/stm32/stm32h7-45_55.xml
+++ b/devices/stm32/stm32h7-45_55.xml
@@ -74,7 +74,7 @@
     <valid-device>stm32h755zit7@m4</valid-device>
     <valid-device>stm32h755zit7@m7</valid-device>
     <driver name="core">
-      <attribute-type device-core="m4" value="cortex-m4fd"/>
+      <attribute-type device-core="m4" value="cortex-m4f"/>
       <attribute-type device-core="m7" value="cortex-m7fd"/>
       <memory device-core="m7" name="itcm" access="rwx" start="0x00" size="65536"/>
       <memory device-size="g" name="flash" access="rx" start="0x8000000" size="1048576"/>

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -290,10 +290,6 @@
       <instance value="1"/>
       <instance value="2"/>
     </driver>
-    <driver name="openamp" type="stm32-v1.0">
-      <instance value="cortex-m4"/>
-      <instance value="cortex-m7"/>
-    </driver>
     <driver name="pwr" type="stm32-v1.0"/>
     <driver name="quadspi" type="stm32-v1.0"/>
     <driver name="ramecc" type="stm32-v1.0"/>
@@ -301,7 +297,6 @@
       <max-frequency device-core="m4" value="240000000"/>
       <max-frequency device-core="m7" value="480000000"/>
     </driver>
-    <driver name="resmgr_utility" type="stm32-stm32h7_cube"/>
     <driver name="rng" type="stm32"/>
     <driver name="rtc" type="stm32-v2.7"/>
     <driver name="sai" type="stm32-sai1_h7_cube">

--- a/devices/stm32/stm32h7-47_57.xml
+++ b/devices/stm32/stm32h7-47_57.xml
@@ -32,7 +32,7 @@
     <valid-device>stm32h757ziy6@m4</valid-device>
     <valid-device>stm32h757ziy6@m7</valid-device>
     <driver name="core">
-      <attribute-type device-core="m4" value="cortex-m4fd"/>
+      <attribute-type device-core="m4" value="cortex-m4f"/>
       <attribute-type device-core="m7" value="cortex-m7fd"/>
       <memory device-core="m7" name="itcm" access="rwx" start="0x00" size="65536"/>
       <memory device-size="g" name="flash" access="rx" start="0x8000000" size="1048576"/>

--- a/devices/stm32/stm32h7-a3.xml
+++ b/devices/stm32/stm32h7-a3.xml
@@ -591,8 +591,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request position="79">
           <signal driver="uart" instance="7" name="rx"/>

--- a/devices/stm32/stm32h7-b0.xml
+++ b/devices/stm32/stm32h7-b0.xml
@@ -564,8 +564,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request position="76">
           <signal driver="cryp" name="in"/>

--- a/devices/stm32/stm32h7-b3.xml
+++ b/devices/stm32/stm32h7-b3.xml
@@ -586,8 +586,7 @@
           <signal driver="i2c" instance="3" name="tx"/>
         </request>
         <request position="75">
-          <signal driver="dcmi"/>
-          <signal driver="pssi"/>
+          <signal driver="dcmi" name="pssi"/>
         </request>
         <request position="76">
           <signal driver="cryp" name="in"/>

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -150,7 +150,8 @@ class STMDeviceTree:
             software_ips = {"GFXSIMULATOR", "GRAPHICS", "FATFS", "TOUCHSENSING", "PDM2PCM",
                             "MBEDTLS", "FREERTOS", "CORTEX_M", "NVIC", "USB_DEVICE",
                             "USB_HOST", "LWIP", "LIBJPEG", "GUI_INTERFACE", "TRACER",
-                            "FILEX", "LEVELX", "THREADX", "USBX", "LINKEDLIST", "NETXDUO"}
+                            "FILEX", "LEVELX", "THREADX", "USBX", "LINKEDLIST", "NETXDUO",
+                            "OPENAMP", "RESMGR_UTILITY"}
             if any(ip.get("Name").upper().startswith(p) for p in software_ips):
                 continue
 

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -76,7 +76,7 @@ class STMDeviceTree:
     def _properties_from_id(comboDeviceName, device_file, did, core):
         if core.endswith("m4") or core.endswith("m7") or core.endswith("m33"):
             core += "f"
-        if did.family in ["h7"] or (did.family in ["f7"] and did.name not in ["45", "46", "56"]):
+        if (did.family in ["h7"] and "m7" in core) or (did.family in ["f7"] and did.name not in ["45", "46", "56"]):
             core += "d"
         if "@" in did.naming_schema:
             did.set("core", core[7:9])


### PR DESCRIPTION
- [x] Remove `OPENAMP` and `RESMGR_UTILITY` software IPs from device files for H7 dual core devices.
- [x] Fix Cortex-M4 core type (must be `cortex-m4f`, not `cortex-m4fd`)
- [ ] Fix memory layout for size `g` devices