### PR TITLE
Fix STM32G0B/C DMA channel count

### DIFF
--- a/devices/stm32/stm32g0-70_b0.xml
+++ b/devices/stm32/stm32g0-70_b0.xml
@@ -322,16 +322,11 @@
         <mux-channel position="4" dma-instance="1" dma-channel="5"/>
         <mux-channel position="5" dma-instance="1" dma-channel="6"/>
         <mux-channel position="6" dma-instance="1" dma-channel="7"/>
-        <mux-channel device-name="b0" position="7" dma-instance="1" dma-channel="8"/>
-        <mux-channel device-name="b0" position="8" dma-instance="1" dma-channel="9"/>
-        <mux-channel device-name="b0" position="9" dma-instance="1" dma-channel="10"/>
-        <mux-channel device-name="b0" position="10" dma-instance="1" dma-channel="11"/>
-        <mux-channel device-name="b0" position="11" dma-instance="1" dma-channel="12"/>
-        <mux-channel device-name="b0" position="12" dma-instance="2" dma-channel="1"/>
-        <mux-channel device-name="b0" position="13" dma-instance="2" dma-channel="2"/>
-        <mux-channel device-name="b0" position="14" dma-instance="2" dma-channel="3"/>
-        <mux-channel device-name="b0" position="15" dma-instance="2" dma-channel="4"/>
-        <mux-channel device-name="b0" position="16" dma-instance="2" dma-channel="5"/>
+        <mux-channel device-name="b0" position="7" dma-instance="2" dma-channel="1"/>
+        <mux-channel device-name="b0" position="8" dma-instance="2" dma-channel="2"/>
+        <mux-channel device-name="b0" position="9" dma-instance="2" dma-channel="3"/>
+        <mux-channel device-name="b0" position="10" dma-instance="2" dma-channel="4"/>
+        <mux-channel device-name="b0" position="11" dma-instance="2" dma-channel="5"/>
       </mux-channels>
     </driver>
     <driver name="gpio" type="stm32">

--- a/devices/stm32/stm32g0-b1_c1.xml
+++ b/devices/stm32/stm32g0-b1_c1.xml
@@ -497,16 +497,11 @@
         <mux-channel position="4" dma-instance="1" dma-channel="5"/>
         <mux-channel position="5" dma-instance="1" dma-channel="6"/>
         <mux-channel position="6" dma-instance="1" dma-channel="7"/>
-        <mux-channel position="7" dma-instance="1" dma-channel="8"/>
-        <mux-channel position="8" dma-instance="1" dma-channel="9"/>
-        <mux-channel position="9" dma-instance="1" dma-channel="10"/>
-        <mux-channel position="10" dma-instance="1" dma-channel="11"/>
-        <mux-channel position="11" dma-instance="1" dma-channel="12"/>
-        <mux-channel position="12" dma-instance="2" dma-channel="1"/>
-        <mux-channel position="13" dma-instance="2" dma-channel="2"/>
-        <mux-channel position="14" dma-instance="2" dma-channel="3"/>
-        <mux-channel position="15" dma-instance="2" dma-channel="4"/>
-        <mux-channel position="16" dma-instance="2" dma-channel="5"/>
+        <mux-channel position="7" dma-instance="2" dma-channel="1"/>
+        <mux-channel position="8" dma-instance="2" dma-channel="2"/>
+        <mux-channel position="9" dma-instance="2" dma-channel="3"/>
+        <mux-channel position="10" dma-instance="2" dma-channel="4"/>
+        <mux-channel position="11" dma-instance="2" dma-channel="5"/>
       </mux-channels>
     </driver>
     <driver name="gpio" type="stm32">

--- a/tools/generator/raw-data-extractor/patches/stm32.patch
+++ b/tools/generator/raw-data-extractor/patches/stm32.patch
@@ -1584,3 +1584,19 @@ index e8ffb555..9e46d578 100644
      <Ram>2514</Ram>
      <IONb>108</IONb>
      <Die>DIE481</Die>
+diff --git a/stm32-devices/mcu/IP/DMA-STM32G0B1_dma1_v1_3_Modes.xml b/stm32-devices/mcu/IP/DMA-STM32G0B1_dma1_v1_3_Modes.xml
+index 16f4362..9843602 100644
+--- a/stm32-devices/mcu/IP/DMA-STM32G0B1_dma1_v1_3_Modes.xml
++++ b/stm32-devices/mcu/IP/DMA-STM32G0B1_dma1_v1_3_Modes.xml
+@@ -9,11 +9,6 @@
+         <PossibleValue Comment="DMA1 Channel 5" Value="DMA1_Channel5"/>
+         <PossibleValue Comment="DMA1 Channel 6" Value="DMA1_Channel6"/>
+         <PossibleValue Comment="DMA1 Channel 7" Value="DMA1_Channel7"/>
+-        <PossibleValue Comment="DMA1 Channel 8" Value="DMA1_Channel8"/>
+-        <PossibleValue Comment="DMA1 Channel 9" Value="DMA1_Channel9"/>
+-        <PossibleValue Comment="DMA1 Channel 10" Value="DMA1_Channel10"/>
+-        <PossibleValue Comment="DMA1 Channel 11" Value="DMA1_Channel11"/>
+-        <PossibleValue Comment="DMA1 Channel 12" Value="DMA1_Channel12"/>
+         <PossibleValue Comment="DMA2 Channel 1" Value="DMA2_Channel1"/>
+         <PossibleValue Comment="DMA2 Channel 2" Value="DMA2_Channel2"/>
+         <PossibleValue Comment="DMA2 Channel 3" Value="DMA2_Channel3"/>


### PR DESCRIPTION
The device data incorrectly indicates up to 12 channels while the peripheral only supports up to 7.

![dma_g0](https://github.com/modm-io/modm-devices/assets/25187160/e7935e7b-b756-424e-9cf2-6d610161d61f)
 