### PR TITLE
[dfg] Fix deprecated distutils

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install lxml jinja2 deepdiff CppHeaderParser
+          pip install lxml jinja2 deepdiff CppHeaderParser packaging
       - name: Run Unit Tests
         run: |
           make test

--- a/tools/generator/raw-data-extractor/extract-sam.py
+++ b/tools/generator/raw-data-extractor/extract-sam.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 from multiprocessing import Pool
 from collections import defaultdict
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 
 packurl = "http://packs.download.atmel.com/"
@@ -19,7 +19,7 @@ with urllib.request.urlopen(packurl) as response:
     html = response.read().decode("utf-8")
     family_links = defaultdict(list)
     for link, family, version in re.findall(r'data-link="(Atmel\.(SAM.*?)_DFP\.(.*?)\.atpack)"', html):
-        family_links[family].append((link, StrictVersion(version),))
+        family_links[family].append((link, Version(version),))
     # Choose only the latest version of the atpack
     family_links = [(family, sorted(data, key=lambda d: d[1])[-1][0])
                     for family, data in family_links.items()]


### PR DESCRIPTION
Python 3.12 removed the deprecated distutils, so this fails now.