### PR TITLE
Fix Python syntax

### DIFF
--- a/tools/generator/dfg/stm32/stm_dmamux_requests.py
+++ b/tools/generator/dfg/stm32/stm_dmamux_requests.py
@@ -94,7 +94,7 @@ def _read_requests(hal_dma_file, request_pattern):
 # For G0, WB and WL
 def _read_requests_from_ll_dmamux(hal_dma_file, ll_dmamux_file):
     dmamux_map = _read_map(ll_dmamux_file, DMAMUX_PATTERN)
-    request_pattern = re.compile("^\s*#define\s+(?P<name>(DMA_REQUEST_\w+))\s+(?P<id>(LL_DMAMUX?_REQ_\w+))\s*")
+    request_pattern = re.compile(r"^\s*#define\s+(?P<name>(DMA_REQUEST_\w+))\s+(?P<id>(LL_DMAMUX?_REQ_\w+))\s*")
     requests_map = _read_map(hal_dma_file, request_pattern)
     out_map = {}
     for r in requests_map.keys():


### PR DESCRIPTION
Since Python 3.6 backslash-character pairs that are not valid escape sequences are [deprecated](https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior) and generate a `SyntaxWarning: invalid escape sequence` warning. This is fixed by using raw string.