### PR TITLE
Among stm32f7 family, only stm32f77x and stm32f76x have double precision FPU

### DIFF
--- a/devices/stm32/stm32f7-22_23_32_33.xml
+++ b/devices/stm32/stm32f7-22_23_32_33.xml
@@ -54,7 +54,7 @@
     <valid-device>stm32f733zei7</valid-device>
     <valid-device>stm32f733zet6</valid-device>
     <valid-device>stm32f733zet7</valid-device>
-    <driver name="core" type="cortex-m7fd">
+    <driver name="core" type="cortex-m7f">
       <memory name="itcm" access="rwx" start="0x00" size="16384"/>
       <memory device-size="c" name="flash" access="rx" start="0x200000" size="262144"/>
       <memory device-size="e" name="flash" access="rx" start="0x200000" size="524288"/>

--- a/devices/stm32/stm32f7-30_50.xml
+++ b/devices/stm32/stm32f7-30_50.xml
@@ -17,7 +17,7 @@
     <valid-device>stm32f750v8t7</valid-device>
     <valid-device>stm32f750z8t6</valid-device>
     <valid-device>stm32f750z8t7</valid-device>
-    <driver name="core" type="cortex-m7fd">
+    <driver name="core" type="cortex-m7f">
       <memory name="itcm" access="rwx" start="0x00" size="16384"/>
       <memory name="flash" access="rx" start="0x200000" size="65536"/>
       <memory name="dtcm" access="rwx" start="0x20000000" size="65536"/>

--- a/tools/generator/dfg/stm32/stm_device_tree.py
+++ b/tools/generator/dfg/stm32/stm_device_tree.py
@@ -77,7 +77,7 @@ class STMDeviceTree:
     def _properties_from_id(comboDeviceName, device_file, did, core):
         if core.endswith("m4") or core.endswith("m7") or core.endswith("m33"):
             core += "f"
-        if did.family in ["h7"] or (did.family in ["f7"] and did.name not in ["45", "46", "56"]):
+        if did.family in ["h7"] or (did.family in ["f7"] and (did.name[0] in ("6", "7"))):
             core += "d"
         if "@" in did.naming_schema:
             did.set("core", core[7:9])


### PR DESCRIPTION
Checked [here](https://www.st.com/content/st_com/en/stm32-mcu-developer-zone/mcu-portfolio.html) filtering the F7 family and sorting by FPU precision. 