### PR TITLE
fix: missing memory model for c0 and g0 series

### DIFF
--- a/tools/generator/dfg/stm32/stm.py
+++ b/tools/generator/dfg/stm32/stm.py
@@ -435,7 +435,20 @@ stm32_memory = \
             {
                 'name': ['11', '31', '71'],
                 'memories': {'flash': 0, 'sram1': 0}
+            },
+            {
+                'name': ['51'],
+                'memories': {'flash': 0, 'sram1': 12*1024}
+            },
+            {
+                'name': ['91'],
+                'memories': {'flash': 0, 'sram1': 36*1024}
+            },
+            {
+                'name': ['92'],
+                'memories': {'flash': 0, 'sram1': 30*1024}
             }
+
         ]
     },
     'g0': {
@@ -460,6 +473,10 @@ stm32_memory = \
             {
                 'name': ['31', '41'],
                 'memories': {'flash': 0, 'sram1': 0, 'sram2':  6*1024, 'ccm': 10*1024}
+            },
+            {
+                'name': ['11'],
+                'memories': {'flash': 0, 'sram1': 0, 'sram2':  22*1024, 'ccm': 10*1024}
             },
             {
                 'name': ['91', 'a1'],

--- a/tools/generator/dfg/stm32/stm_groups.py
+++ b/tools/generator/dfg/stm32/stm_groups.py
@@ -184,7 +184,7 @@ stm_groups = \
     # STM32C0 devices
     {
         'family': ['c0'],
-        'name': ['11', '31', '71']
+        'name': ['11', '31', '51', '71']
     },
 
     # STM32G0 devices


### PR DESCRIPTION
Slightly unsure about the stm_groups description